### PR TITLE
Fix bugs in getPath() with arrays of objects and arrays of arrays.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -350,6 +350,7 @@ public class JsonReader implements Closeable {
     }
     if (p == PEEKED_END_ARRAY) {
       stackSize--;
+      pathIndices[stackSize - 1]++;
       peeked = PEEKED_NONE;
     } else {
       throw new IllegalStateException("Expected END_ARRAY but was " + peek()
@@ -387,6 +388,7 @@ public class JsonReader implements Closeable {
     if (p == PEEKED_END_OBJECT) {
       stackSize--;
       pathNames[stackSize] = null; // Free the last path name so that it can be garbage collected!
+      pathIndices[stackSize - 1]++;
       peeked = PEEKED_NONE;
     } else {
       throw new IllegalStateException("Expected END_OBJECT but was " + peek()

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderPathTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderPathTest.java
@@ -47,16 +47,56 @@ public class JsonReaderPathTest {
     reader.nextString();
     assertEquals("$.a[5].c", reader.getPath());
     reader.endObject();
-    assertEquals("$.a[5]", reader.getPath());
+    assertEquals("$.a[6]", reader.getPath());
     reader.beginArray();
-    assertEquals("$.a[5][0]", reader.getPath());
+    assertEquals("$.a[6][0]", reader.getPath());
     reader.nextInt();
-    assertEquals("$.a[5][1]", reader.getPath());
+    assertEquals("$.a[6][1]", reader.getPath());
     reader.endArray();
-    assertEquals("$.a[5]", reader.getPath());
+    assertEquals("$.a[7]", reader.getPath());
     reader.endArray();
     assertEquals("$.a", reader.getPath());
     reader.endObject();
+    assertEquals("$", reader.getPath());
+  }
+
+  @Test public void arrayOfObjects() throws IOException {
+    JsonReader reader = new JsonReader("[{},{},{}]");
+    reader.beginArray();
+    assertEquals("$[0]", reader.getPath());
+    reader.beginObject();
+    assertEquals("$[0].", reader.getPath());
+    reader.endObject();
+    assertEquals("$[1]", reader.getPath());
+    reader.beginObject();
+    assertEquals("$[1].", reader.getPath());
+    reader.endObject();
+    assertEquals("$[2]", reader.getPath());
+    reader.beginObject();
+    assertEquals("$[2].", reader.getPath());
+    reader.endObject();
+    assertEquals("$[3]", reader.getPath());
+    reader.endArray();
+    assertEquals("$", reader.getPath());
+  }
+
+  @Test public void arrayOfArrays() throws IOException {
+    JsonReader reader = new JsonReader("[[],[],[]]");
+    reader.beginArray();
+    assertEquals("$[0]", reader.getPath());
+    reader.beginArray();
+    assertEquals("$[0][0]", reader.getPath());
+    reader.endArray();
+    assertEquals("$[1]", reader.getPath());
+    reader.beginArray();
+    assertEquals("$[1][0]", reader.getPath());
+    reader.endArray();
+    assertEquals("$[2]", reader.getPath());
+    reader.beginArray();
+    assertEquals("$[2][0]", reader.getPath());
+    reader.endArray();
+    assertEquals("$[3]", reader.getPath());
+    reader.endArray();
     assertEquals("$", reader.getPath());
   }
 


### PR DESCRIPTION
Original commit: Gson r1303 by Jesse Wilson.
