### PR TITLE
Support @Nullable in Adapter Methods.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/Util.java
@@ -53,4 +53,14 @@ final class Util {
     }
     return false;
   }
+
+  /** Returns true if {@code annotations} has any annotation whose simple name is Nullable. */
+  public static boolean hasNullable(Annotation[] annotations) {
+    for (Annotation annotation : annotations) {
+      if (annotation.annotationType().getSimpleName().equals("Nullable")) {
+        return true;
+      }
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
When the annotation is present, the adapter method is used. When
it isn't, it isn't.