### PR TITLE
Throw JsonDataException consistently.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonDataException.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonDataException.java
@@ -15,7 +15,14 @@
  */
 package com.squareup.moshi;
 
-/** Thrown when a JSON document doesn't match the expected format. */
+/**
+ * Thrown when the data in a JSON document doesn't match the data expected by the caller. For
+ * example, suppose the application expects a boolean but the JSON document contains a string. When
+ * the call to {@link JsonReader#nextBoolean} is made, a {@code JsonDataException} is thrown.
+ *
+ * <p>Exceptions of this type should be fixed by either changing the application code to accept
+ * the unexpected JSON, or by changing the JSON to conform to the application's expectations.
+ */
 public final class JsonDataException extends RuntimeException {
   public JsonDataException() {
   }

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -311,8 +311,8 @@ public final class JsonReader implements Closeable {
   }
 
   /**
-   * Consumes the next token from the JSON stream and asserts that it is the
-   * beginning of a new array.
+   * Consumes the next token from the JSON stream and asserts that it is the beginning of a new
+   * array.
    */
   public void beginArray() throws IOException {
     int p = peeked;
@@ -324,7 +324,7 @@ public final class JsonReader implements Closeable {
       pathIndices[stackSize - 1] = 0;
       peeked = PEEKED_NONE;
     } else {
-      throw new IllegalStateException("Expected BEGIN_ARRAY but was " + peek()
+      throw new JsonDataException("Expected BEGIN_ARRAY but was " + peek()
           + " at path " + getPath());
     }
   }
@@ -343,14 +343,14 @@ public final class JsonReader implements Closeable {
       pathIndices[stackSize - 1]++;
       peeked = PEEKED_NONE;
     } else {
-      throw new IllegalStateException("Expected END_ARRAY but was " + peek()
+      throw new JsonDataException("Expected END_ARRAY but was " + peek()
           + " at path " + getPath());
     }
   }
 
   /**
-   * Consumes the next token from the JSON stream and asserts that it is the
-   * beginning of a new object.
+   * Consumes the next token from the JSON stream and asserts that it is the beginning of a new
+   * object.
    */
   public void beginObject() throws IOException {
     int p = peeked;
@@ -361,14 +361,14 @@ public final class JsonReader implements Closeable {
       push(JsonScope.EMPTY_OBJECT);
       peeked = PEEKED_NONE;
     } else {
-      throw new IllegalStateException("Expected BEGIN_OBJECT but was " + peek()
+      throw new JsonDataException("Expected BEGIN_OBJECT but was " + peek()
           + " at path " + getPath());
     }
   }
 
   /**
-   * Consumes the next token from the JSON stream and asserts that it is the
-   * end of the current object.
+   * Consumes the next token from the JSON stream and asserts that it is the end of the current
+   * object.
    */
   public void endObject() throws IOException {
     int p = peeked;
@@ -381,7 +381,7 @@ public final class JsonReader implements Closeable {
       pathIndices[stackSize - 1]++;
       peeked = PEEKED_NONE;
     } else {
-      throw new IllegalStateException("Expected END_OBJECT but was " + peek()
+      throw new JsonDataException("Expected END_OBJECT but was " + peek()
           + " at path " + getPath());
     }
   }
@@ -744,11 +744,9 @@ public final class JsonReader implements Closeable {
   }
 
   /**
-   * Returns the next token, a {@link Token#NAME property name}, and
-   * consumes it.
+   * Returns the next token, a {@link Token#NAME property name}, and consumes it.
    *
-   * @throws java.io.IOException if the next token in the stream is not a property
-   *     name.
+   * @throws JsonDataException if the next token in the stream is not a property name.
    */
   public String nextName() throws IOException {
     int p = peeked;
@@ -763,8 +761,7 @@ public final class JsonReader implements Closeable {
     } else if (p == PEEKED_SINGLE_QUOTED_NAME) {
       result = nextQuotedValue(SINGLE_QUOTE_OR_SLASH);
     } else {
-      throw new IllegalStateException("Expected a name but was " + peek()
-          + " at path " + getPath());
+      throw new JsonDataException("Expected a name but was " + peek() + " at path " + getPath());
     }
     peeked = PEEKED_NONE;
     pathNames[stackSize - 1] = result;
@@ -772,12 +769,10 @@ public final class JsonReader implements Closeable {
   }
 
   /**
-   * Returns the {@link Token#STRING string} value of the next token,
-   * consuming it. If the next token is a number, this method will return its
-   * string form.
+   * Returns the {@link Token#STRING string} value of the next token, consuming it. If the next
+   * token is a number, this method will return its string form.
    *
-   * @throws IllegalStateException if the next token is not a string or if
-   *     this reader is closed.
+   * @throws JsonDataException if the next token is not a string or if this reader is closed.
    */
   public String nextString() throws IOException {
     int p = peeked;
@@ -799,8 +794,7 @@ public final class JsonReader implements Closeable {
     } else if (p == PEEKED_NUMBER) {
       result = buffer.readUtf8(peekedNumberLength);
     } else {
-      throw new IllegalStateException("Expected a string but was " + peek()
-          + " at path " + getPath());
+      throw new JsonDataException("Expected a string but was " + peek() + " at path " + getPath());
     }
     peeked = PEEKED_NONE;
     pathIndices[stackSize - 1]++;
@@ -808,11 +802,9 @@ public final class JsonReader implements Closeable {
   }
 
   /**
-   * Returns the {@link Token#BOOLEAN boolean} value of the next token,
-   * consuming it.
+   * Returns the {@link Token#BOOLEAN boolean} value of the next token, consuming it.
    *
-   * @throws IllegalStateException if the next token is not a boolean or if
-   *     this reader is closed.
+   * @throws JsonDataException if the next token is not a boolean or if this reader is closed.
    */
   public boolean nextBoolean() throws IOException {
     int p = peeked;
@@ -828,16 +820,14 @@ public final class JsonReader implements Closeable {
       pathIndices[stackSize - 1]++;
       return false;
     }
-    throw new IllegalStateException("Expected a boolean but was " + peek()
-        + " at path " + getPath());
+    throw new JsonDataException("Expected a boolean but was " + peek() + " at path " + getPath());
   }
 
   /**
-   * Consumes the next token from the JSON stream and asserts that it is a
-   * literal null. Returns null.
+   * Consumes the next token from the JSON stream and asserts that it is a literal null. Returns
+   * null.
    *
-   * @throws IllegalStateException if the next token is not null or if this
-   *     reader is closed.
+   * @throws JsonDataException if the next token is not null or if this reader is closed.
    */
   public <T> T nextNull() throws IOException {
     int p = peeked;
@@ -849,19 +839,17 @@ public final class JsonReader implements Closeable {
       pathIndices[stackSize - 1]++;
       return null;
     } else {
-      throw new IllegalStateException("Expected null but was " + peek()
-          + " at path " + getPath());
+      throw new JsonDataException("Expected null but was " + peek() + " at path " + getPath());
     }
   }
 
   /**
-   * Returns the {@link Token#NUMBER double} value of the next token,
-   * consuming it. If the next token is a string, this method will attempt to
-   * parse it as a double using {@link Double#parseDouble(String)}.
+   * Returns the {@link Token#NUMBER double} value of the next token, consuming it. If the next
+   * token is a string, this method will attempt to parse it as a double using {@link
+   * Double#parseDouble(String)}.
    *
-   * @throws IllegalStateException if the next token is not a literal value.
-   * @throws NumberFormatException if the next literal value cannot be parsed
-   *     as a double, or is non-finite.
+   * @throws JsonDataException if the next token is not a literal value, or if the next literal
+   *     value cannot be parsed as a double, or is non-finite.
    */
   public double nextDouble() throws IOException {
     int p = peeked;
@@ -884,14 +872,19 @@ public final class JsonReader implements Closeable {
     } else if (p == PEEKED_UNQUOTED) {
       peekedString = nextUnquotedValue();
     } else if (p != PEEKED_BUFFERED) {
-      throw new IllegalStateException("Expected a double but was " + peek()
-          + " at path " + getPath());
+      throw new JsonDataException("Expected a double but was " + peek() + " at path " + getPath());
     }
 
     peeked = PEEKED_BUFFERED;
-    double result = Double.parseDouble(peekedString); // don't catch this NumberFormatException.
+    double result;
+    try {
+      result = Double.parseDouble(peekedString);
+    } catch (NumberFormatException e) {
+      throw new JsonDataException("Expected a double but was " + peekedString
+          + " at path " + getPath());
+    }
     if (!lenient && (Double.isNaN(result) || Double.isInfinite(result))) {
-      throw new NumberFormatException("JSON forbids NaN and infinities: " + result
+      throw new IOException("JSON forbids NaN and infinities: " + result
           + " at path " + getPath());
     }
     peekedString = null;
@@ -901,14 +894,12 @@ public final class JsonReader implements Closeable {
   }
 
   /**
-   * Returns the {@link Token#NUMBER long} value of the next token,
-   * consuming it. If the next token is a string, this method will attempt to
-   * parse it as a long. If the next token's numeric value cannot be exactly
-   * represented by a Java {@code long}, this method throws.
+   * Returns the {@link Token#NUMBER long} value of the next token, consuming it. If the next token
+   * is a string, this method will attempt to parse it as a long. If the next token's numeric value
+   * cannot be exactly represented by a Java {@code long}, this method throws.
    *
-   * @throws IllegalStateException if the next token is not a literal value.
-   * @throws NumberFormatException if the next literal value cannot be parsed
-   *     as a number, or exactly represented as a long.
+   * @throws JsonDataException if the next token is not a literal value, if the next literal value
+   *     cannot be parsed as a number, or exactly represented as a long.
    */
   public long nextLong() throws IOException {
     int p = peeked;
@@ -937,15 +928,21 @@ public final class JsonReader implements Closeable {
         // Fall back to parse as a double below.
       }
     } else {
-      throw new IllegalStateException("Expected a long but was " + peek()
+      throw new JsonDataException("Expected a long but was " + peek()
           + " at path " + getPath());
     }
 
     peeked = PEEKED_BUFFERED;
-    double asDouble = Double.parseDouble(peekedString); // don't catch this NumberFormatException.
+    double asDouble;
+    try {
+      asDouble = Double.parseDouble(peekedString);
+    } catch (NumberFormatException e) {
+      throw new JsonDataException("Expected a long but was " + peekedString
+          + " at path " + getPath());
+    }
     long result = (long) asDouble;
     if (result != asDouble) { // Make sure no precision was lost casting to 'long'.
-      throw new NumberFormatException("Expected a long but was " + peekedString
+      throw new JsonDataException("Expected a long but was " + peekedString
           + " at path " + getPath());
     }
     peekedString = null;
@@ -955,13 +952,11 @@ public final class JsonReader implements Closeable {
   }
 
   /**
-   * Returns the string up to but not including {@code quote}, unescaping any
-   * character escape sequences encountered along the way. The opening quote
-   * should have already been read. This consumes the closing quote, but does
-   * not include it in the returned string.
+   * Returns the string up to but not including {@code quote}, unescaping any character escape
+   * sequences encountered along the way. The opening quote should have already been read. This
+   * consumes the closing quote, but does not include it in the returned string.
    *
-   * @throws NumberFormatException if any unicode escape sequences are
-   *     malformed.
+   * @throws IOException if any unicode escape sequences are malformed.
    */
   private String nextQuotedValue(ByteString runTerminator) throws IOException {
     StringBuilder builder = null;
@@ -1018,14 +1013,12 @@ public final class JsonReader implements Closeable {
   }
 
   /**
-   * Returns the {@link Token#NUMBER int} value of the next token,
-   * consuming it. If the next token is a string, this method will attempt to
-   * parse it as an int. If the next token's numeric value cannot be exactly
-   * represented by a Java {@code int}, this method throws.
+   * Returns the {@link Token#NUMBER int} value of the next token, consuming it. If the next token
+   * is a string, this method will attempt to parse it as an int. If the next token's numeric value
+   * cannot be exactly represented by a Java {@code int}, this method throws.
    *
-   * @throws IllegalStateException if the next token is not a literal value.
-   * @throws NumberFormatException if the next literal value cannot be parsed
-   *     as a number, or exactly represented as an int.
+   * @throws JsonDataException if the next token is not a literal value, if the next literal value
+   *     cannot be parsed as a number, or exactly represented as an int.
    */
   public int nextInt() throws IOException {
     int p = peeked;
@@ -1037,7 +1030,7 @@ public final class JsonReader implements Closeable {
     if (p == PEEKED_LONG) {
       result = (int) peekedLong;
       if (peekedLong != result) { // Make sure no precision was lost casting to 'int'.
-        throw new NumberFormatException("Expected an int but was " + peekedLong
+        throw new JsonDataException("Expected an int but was " + peekedLong
             + " at path " + getPath());
       }
       peeked = PEEKED_NONE;
@@ -1060,15 +1053,20 @@ public final class JsonReader implements Closeable {
         // Fall back to parse as a double below.
       }
     } else {
-      throw new IllegalStateException("Expected an int but was " + peek()
-          + " at path " + getPath());
+      throw new JsonDataException("Expected an int but was " + peek() + " at path " + getPath());
     }
 
     peeked = PEEKED_BUFFERED;
-    double asDouble = Double.parseDouble(peekedString); // don't catch this NumberFormatException.
+    double asDouble;
+    try {
+      asDouble = Double.parseDouble(peekedString);
+    } catch (NumberFormatException e) {
+      throw new JsonDataException("Expected an int but was " + peekedString
+          + " at path " + getPath());
+    }
     result = (int) asDouble;
     if (result != asDouble) { // Make sure no precision was lost casting to 'int'.
-      throw new NumberFormatException("Expected an int but was " + peekedString
+      throw new JsonDataException("Expected an int but was " + peekedString
           + " at path " + getPath());
     }
     peekedString = null;
@@ -1089,9 +1087,9 @@ public final class JsonReader implements Closeable {
   }
 
   /**
-   * Skips the next value recursively. If it is an object or array, all nested
-   * elements are skipped. This method is intended for use when the JSON token
-   * stream contains unrecognized or unhandled values.
+   * Skips the next value recursively. If it is an object or array, all nested elements are skipped.
+   * This method is intended for use when the JSON token stream contains unrecognized or unhandled
+   * values.
    */
   public void skipValue() throws IOException {
     int count = 0;
@@ -1296,13 +1294,11 @@ public final class JsonReader implements Closeable {
   }
 
   /**
-   * Unescapes the character identified by the character or characters that
-   * immediately follow a backslash. The backslash '\' should have already
-   * been read. This supports both unicode escapes "u000A" and two-character
-   * escapes "\n".
+   * Unescapes the character identified by the character or characters that immediately follow a
+   * backslash. The backslash '\' should have already been read. This supports both unicode escapes
+   * "u000A" and two-character escapes "\n".
    *
-   * @throws NumberFormatException if any unicode escape sequences are
-   *     malformed.
+   * @throws IOException if any unicode escape sequences are malformed.
    */
   private char readEscapeCharacter() throws IOException {
     if (!fillBuffer(1)) {
@@ -1313,7 +1309,7 @@ public final class JsonReader implements Closeable {
     switch (escaped) {
       case 'u':
         if (!fillBuffer(4)) {
-          throw syntaxError("Unterminated escape sequence");
+          throw new EOFException("Unterminated escape sequence at path " + getPath());
         }
         // Equivalent to Integer.parseInt(stringPool.get(buffer, pos, 4), 16);
         char result = 0;
@@ -1327,7 +1323,7 @@ public final class JsonReader implements Closeable {
           } else if (c >= 'A' && c <= 'F') {
             result += (c - 'A' + 10);
           } else {
-            throw new NumberFormatException("\\u" + buffer.readUtf8(4));
+            throw syntaxError("\\u" + buffer.readUtf8(4));
           }
         }
         buffer.skip(4);

--- a/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
@@ -353,11 +353,11 @@ public final class JsonWriter implements Closeable, Flushable {
     if (name == null) {
       throw new NullPointerException("name == null");
     }
-    if (deferredName != null) {
-      throw new IllegalStateException();
-    }
     if (stackSize == 0) {
       throw new IllegalStateException("JsonWriter is closed.");
+    }
+    if (deferredName != null) {
+      throw new IllegalStateException();
     }
     deferredName = name;
     return this;
@@ -484,7 +484,7 @@ public final class JsonWriter implements Closeable, Flushable {
   /**
    * Flushes and closes this writer and the underlying {@link Sink}.
    *
-   * @throws IOException if the JSON document is incomplete.
+   * @throws JsonDataException if the JSON document is incomplete.
    */
   public void close() throws IOException {
     sink.close();

--- a/moshi/src/main/java/com/squareup/moshi/MapJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/MapJsonAdapter.java
@@ -63,7 +63,7 @@ final class MapJsonAdapter<K, V> extends JsonAdapter<Map<K, V>> {
       V value = valueAdapter.fromJson(reader);
       V replaced = result.put(name, value);
       if (replaced != null) {
-        throw new IllegalArgumentException("object property '" + name + "' has multiple values");
+        throw new JsonDataException("object property '" + name + "' has multiple values");
       }
     }
     reader.endObject();

--- a/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.java
+++ b/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.java
@@ -59,7 +59,7 @@ final class StandardJsonAdapters {
       throws IOException {
     int value = reader.nextInt();
     if (value < min || value > max) {
-      throw new NumberFormatException(
+      throw new JsonDataException(
           String.format(ERROR_FORMAT, typeMessage, value, reader.getPath()));
     }
     return value;
@@ -89,7 +89,7 @@ final class StandardJsonAdapters {
     @Override public Character fromJson(JsonReader reader) throws IOException {
       String value = reader.nextString();
       if (value.length() > 1) {
-        throw new IllegalStateException(
+        throw new JsonDataException(
             String.format(ERROR_FORMAT, "a char", '"' + value + '"', reader.getPath()));
       }
       return value.charAt(0);
@@ -115,7 +115,7 @@ final class StandardJsonAdapters {
       float value = (float) reader.nextDouble();
       // Double check for infinity after float conversion; many doubles > Float.MAX
       if (!reader.isLenient() && Float.isInfinite(value)) {
-        throw new NumberFormatException("JSON forbids NaN and infinities: " + value
+        throw new JsonDataException("JSON forbids NaN and infinities: " + value
             + " at path " + reader.getPath());
       }
       return value;
@@ -178,7 +178,7 @@ final class StandardJsonAdapters {
         try {
           return Enum.valueOf(enumType, name);
         } catch (IllegalArgumentException e) {
-          throw new IllegalStateException("Expected one of "
+          throw new JsonDataException("Expected one of "
               + Arrays.toString(enumType.getEnumConstants()) + " but was " + name + " at path "
               + reader.getPath());
         }

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
@@ -216,16 +216,16 @@ public final class JsonReaderTest {
     }
   }
 
-  @Test public void emptyString() {
+  @Test public void emptyString() throws Exception {
     try {
       newReader("").beginArray();
       fail();
-    } catch (IOException expected) {
+    } catch (EOFException expected) {
     }
     try {
       newReader("").beginObject();
       fail();
-    } catch (IOException expected) {
+    } catch (EOFException expected) {
     }
   }
 
@@ -290,7 +290,7 @@ public final class JsonReaderTest {
     try {
       reader.nextString();
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (IOException expected) {
     }
   }
 
@@ -301,7 +301,7 @@ public final class JsonReaderTest {
     try {
       reader.nextString();
       fail();
-    } catch (IOException expected) {
+    } catch (EOFException expected) {
     }
   }
 
@@ -367,7 +367,7 @@ public final class JsonReaderTest {
     try {
       reader.nextDouble();
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (IOException expected) {
       assertThat(expected).hasMessageContaining("NaN");
     }
   }
@@ -425,13 +425,13 @@ public final class JsonReaderTest {
     try {
       reader.nextInt();
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (JsonDataException expected) {
     }
     assertThat(reader.nextLong()).isEqualTo(Long.MIN_VALUE);
     try {
       reader.nextInt();
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (JsonDataException expected) {
     }
     assertThat(reader.nextLong()).isEqualTo(Long.MAX_VALUE);
     reader.endArray();
@@ -484,7 +484,7 @@ public final class JsonReaderTest {
     try {
       reader.nextBoolean();
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
     }
     assertThat(reader.nextString()).isEqualTo("truey");
     reader.endArray();
@@ -544,7 +544,7 @@ public final class JsonReaderTest {
     try {
       reader.nextInt();
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
     }
     assertThat(reader.nextString()).isEqualTo("12.34e5x");
   }
@@ -573,7 +573,7 @@ public final class JsonReaderTest {
     try {
       reader.nextLong();
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (JsonDataException expected) {
     }
   }
 
@@ -585,7 +585,7 @@ public final class JsonReaderTest {
     try {
       reader.nextLong();
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (JsonDataException expected) {
     }
   }
 
@@ -601,7 +601,7 @@ public final class JsonReaderTest {
     try {
       reader.nextLong();
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (JsonDataException expected) {
     }
   }
 
@@ -617,7 +617,7 @@ public final class JsonReaderTest {
     try {
       reader.nextLong();
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (JsonDataException expected) {
     }
     assertThat(reader.nextDouble()).isEqualTo(-9223372036854775809d);
   }
@@ -642,7 +642,7 @@ public final class JsonReaderTest {
     try {
       reader.nextLong();
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (JsonDataException expected) {
     }
     assertThat(reader.nextDouble()).isEqualTo(-92233720368547758080d);
   }
@@ -687,7 +687,7 @@ public final class JsonReaderTest {
     try {
       reader.nextName();
       fail();
-    } catch (IOException expected) {
+    } catch (EOFException expected) {
     }
   }
 
@@ -727,54 +727,54 @@ public final class JsonReaderTest {
     try {
       reader.nextString();
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
     }
     assertThat(reader.nextName()).isEqualTo("a");
     try {
       reader.nextName();
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
     }
     try {
       reader.beginArray();
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
     }
     try {
       reader.endArray();
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
     }
     try {
       reader.beginObject();
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
     }
     try {
       reader.endObject();
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
     }
     assertThat(reader.nextBoolean()).isTrue();
     try {
       reader.nextString();
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
     }
     try {
       reader.nextName();
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
     }
     try {
       reader.beginArray();
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
     }
     try {
       reader.endArray();
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
     }
     reader.endObject();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
@@ -787,7 +787,7 @@ public final class JsonReaderTest {
     try {
       reader.nextInt();
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (JsonDataException expected) {
     }
     assertThat(reader.nextDouble()).isEqualTo(1.5d);
     reader.endArray();
@@ -799,7 +799,7 @@ public final class JsonReaderTest {
     try {
       reader.nextNull();
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
     }
   }
 
@@ -809,7 +809,7 @@ public final class JsonReaderTest {
     try {
       reader.nextString();
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
@@ -103,7 +103,7 @@ public final class MapJsonAdapterTest {
     try {
       fromJson(String.class, Integer.class, "{\"c\":1,\"c\":2}");
       fail();
-    } catch (IllegalArgumentException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("object property 'c' has multiple values");
     }
   }

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -50,7 +50,7 @@ public final class MoshiTest {
     try {
       adapter.fromJson("null");
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Expected a boolean but was NULL at path $");
     }
 
@@ -93,14 +93,14 @@ public final class MoshiTest {
     try {
       adapter.fromJson("256");
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Expected a byte but was 256 at path $");
     }
 
     try {
       adapter.fromJson("-129");
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Expected a byte but was -129 at path $");
     }
 
@@ -108,7 +108,7 @@ public final class MoshiTest {
     try {
       adapter.fromJson("null");
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Expected an int but was NULL at path $");
     }
 
@@ -189,7 +189,7 @@ public final class MoshiTest {
       // Only a single character is allowed.
       adapter.fromJson("'ab'");
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Expected a char but was \"ab\" at path $");
     }
 
@@ -197,7 +197,7 @@ public final class MoshiTest {
     try {
       adapter.fromJson("null");
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Expected a string but was NULL at path $");
     }
 
@@ -219,7 +219,7 @@ public final class MoshiTest {
       // Only a single character is allowed.
       adapter.fromJson("'ab'");
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Expected a char but was \"ab\" at path $");
     }
 
@@ -253,7 +253,7 @@ public final class MoshiTest {
     try {
       adapter.fromJson("null");
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Expected a double but was NULL at path $");
     }
 
@@ -270,7 +270,7 @@ public final class MoshiTest {
     try {
       adapter.fromJson(reader);
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (IOException expected) {
       assertThat(expected).hasMessage("JSON forbids NaN and infinities: Infinity at path $[0]");
     }
 
@@ -279,7 +279,7 @@ public final class MoshiTest {
     try {
       adapter.fromJson(reader);
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (IOException expected) {
       assertThat(expected).hasMessage("JSON forbids NaN and infinities: -Infinity at path $[0]");
     }
   }
@@ -321,7 +321,7 @@ public final class MoshiTest {
     try {
       adapter.fromJson("null");
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Expected a double but was NULL at path $");
     }
 
@@ -338,7 +338,7 @@ public final class MoshiTest {
     try {
       adapter.fromJson(reader);
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("JSON forbids NaN and infinities: Infinity at path $[1]");
     }
 
@@ -347,7 +347,7 @@ public final class MoshiTest {
     try {
       adapter.fromJson(reader);
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("JSON forbids NaN and infinities: -Infinity at path $[1]");
     }
   }
@@ -379,14 +379,14 @@ public final class MoshiTest {
     try {
       adapter.fromJson("2147483648");
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Expected an int but was 2147483648 at path $");
     }
 
     try {
       adapter.fromJson("-2147483649");
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Expected an int but was -2147483649 at path $");
     }
 
@@ -394,7 +394,7 @@ public final class MoshiTest {
     try {
       adapter.fromJson("null");
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Expected an int but was NULL at path $");
     }
 
@@ -447,7 +447,7 @@ public final class MoshiTest {
     try {
       adapter.fromJson("null");
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Expected a long but was NULL at path $");
     }
 
@@ -483,14 +483,14 @@ public final class MoshiTest {
     try {
       adapter.fromJson("32768");
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Expected a short but was 32768 at path $");
     }
 
     try {
       adapter.fromJson("-32769");
       fail();
-    } catch (NumberFormatException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Expected a short but was -32769 at path $");
     }
 
@@ -498,7 +498,7 @@ public final class MoshiTest {
     try {
       adapter.fromJson("null");
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Expected an int but was NULL at path $");
     }
 
@@ -676,7 +676,7 @@ public final class MoshiTest {
     try {
       adapter.fromJson("\"SPOCK\"");
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (JsonDataException expected) {
       assertThat(expected).hasMessage(
           "Expected one of [ROCK, PAPER, SCISSORS] but was SPOCK at path $");
     }


### PR DESCRIPTION
We throw IllegalStateException when the application code is
internally inconsistent, such as when it closes and then writes
or similar.

We throw an IOException when the source JSON is structurally
invalid, such as when strings are unquoted in strict mode.

And we throw JsonDataException when the application code is
correct, and the JSON is well-formed, but the application code
and JSON disagree with one another.