### PR TITLE
Fix conversion to JSON for lists

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/CollectionJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/CollectionJsonAdapter.java
@@ -31,10 +31,10 @@ abstract class CollectionJsonAdapter<C extends Collection<T>, T> extends JsonAda
         Type type, Set<? extends Annotation> annotations, Moshi moshi) {
       Class<?> rawType = Types.getRawType(type);
       if (!annotations.isEmpty()) return null;
-      if (rawType == List.class || rawType == Collection.class) {
-        return newArrayListAdapter(type, moshi).nullSafe();
-      } else if (rawType == Set.class) {
+      if (Set.class.isAssignableFrom(rawType)) {
         return newLinkedHashSetAdapter(type, moshi).nullSafe();
+      } else if (Collection.class.isAssignableFrom(rawType)) {
+        return newArrayListAdapter(type, moshi).nullSafe();
       }
       return null;
     }


### PR DESCRIPTION
The `CollectionJsonAdapter` does not work when the request body is a list that should be converted to a JSON array because the adapter does check the raw type for equality with `Set`, `List`, and `Collection`. However, when an `ArrayList` is passed as request body, this is what the raw type will be.

```
java.lang.IllegalArgumentException: No JsonAdapter for class java.util.ArrayList annotated []
	at com.squareup.moshi.Moshi.createAdapter(Moshi.java:93)
	at com.squareup.moshi.Moshi.adapter(Moshi.java:55)
	at com.squareup.moshi.Moshi.adapter(Moshi.java:46)
	at retrofit.MoshiConverter.toBody(MoshiConverter.java:59)
	at retrofit.RequestBuilder.setArguments(RequestBuilder.java:323)
	at retrofit.OkHttpCall.createRawCall(OkHttpCall.java:115)
	at retrofit.OkHttpCall.execute(OkHttpCall.java:106)
	at retrofit.DefaultCallAdapterFactory$ExecutorCallbackCall.execute(DefaultCallAdapterFactory.java:76)
```

Here's the code I'm running:

```Java
public interface MyService {
	@POST("/api")
	Call<List<MyResult>> post(@Body List<MyRequest> body);
}

@Test
public void test() throws IOException {
	Retrofit retrofit = new Retrofit.Builder()
			.endpoint("http://localhost:8778/")
			.converter(new MoshiConverter())
			.build();

	List<MyRequest> body = new ArrayList<>();
	body.add(new MyRequest("foo"));
	body.add(new MyRequest("bar"));

	Call<List<MyResult>> call = retrofit.create(MyService.class).post(body);
	Response<List<MyResult>> response = call.execute();
}
```

I managed to fix it with the provided change. Thanks for considering it.
