### PR TITLE
Implement UUID adapter

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.java
+++ b/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 final class StandardJsonAdapters {
   public static final JsonAdapter.Factory FACTORY = new JsonAdapter.Factory() {
@@ -47,6 +48,7 @@ final class StandardJsonAdapters {
       if (type == Long.class) return LONG_JSON_ADAPTER.nullSafe();
       if (type == Short.class) return SHORT_JSON_ADAPTER.nullSafe();
       if (type == String.class) return STRING_JSON_ADAPTER.nullSafe();
+      if (type == UUID.class) return UUID_JSON_ADAPTER.nullSafe();
       if (type == Object.class) return new ObjectJsonAdapter(moshi).nullSafe();
 
       Class<?> rawType = Types.getRawType(type);
@@ -173,6 +175,16 @@ final class StandardJsonAdapters {
 
     @Override public void toJson(JsonWriter writer, String value) throws IOException {
       writer.value(value);
+    }
+  };
+
+  static final JsonAdapter<UUID> UUID_JSON_ADAPTER = new JsonAdapter<UUID>() {
+    @Override public UUID fromJson(JsonReader reader) throws IOException {
+      return UUID.fromString(STRING_JSON_ADAPTER.fromJson(reader));
+    }
+
+    @Override public void toJson(JsonWriter writer, UUID value) throws IOException {
+      STRING_JSON_ADAPTER.toJson(writer, value.toString());
     }
   };
 

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.UUID;
 import javax.crypto.KeyGenerator;
 import org.junit.Test;
 
@@ -526,6 +527,17 @@ public final class MoshiTest {
     JsonAdapter<String> adapter = moshi.adapter(String.class).lenient();
     assertThat(adapter.fromJson("\"a\"")).isEqualTo("a");
     assertThat(adapter.toJson("b")).isEqualTo("\"b\"");
+    assertThat(adapter.fromJson("null")).isEqualTo(null);
+    assertThat(adapter.toJson(null)).isEqualTo("null");
+  }
+
+  @Test public void uuidAdapter() throws Exception {
+    UUID uuid = UUID.randomUUID();
+
+    Moshi moshi = new Moshi.Builder().build();
+    JsonAdapter<UUID> adapter = moshi.adapter(UUID.class).lenient();
+    assertThat(adapter.fromJson("\"" + uuid + "\"")).isEqualTo(uuid);
+    assertThat(adapter.toJson(uuid)).isEqualTo("\"" + uuid + "\"");
     assertThat(adapter.fromJson("null")).isEqualTo(null);
     assertThat(adapter.toJson(null)).isEqualTo("null");
   }


### PR DESCRIPTION
This PR adds an UUID adapter to the `StandardJsonAdapters` class that converts between the `java.util.UUID` class and JSON strings.