### PR TITLE
Cache json adapters in memory

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/Util.java
@@ -63,4 +63,15 @@ final class Util {
     }
     return false;
   }
+
+  /** Calculates an unique hash code for the type and annotations set pair */
+  public static int hashCodeOf(Type type, Set<? extends Annotation> annotations) {
+    int result = type != null ? type.hashCode() : 0;
+    if (annotations != null) {
+      for (Annotation annotation : annotations) {
+        result = 31 * result + (annotation != null ? annotation.getClass().hashCode() : 0);
+      }
+    }
+    return result;
+  }
 }

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -735,6 +735,19 @@ public final class MoshiTest {
     }
   }
 
+  @Test public void adaptersAreNotCreatedTwice() throws Exception {
+    Moshi moshi = new Moshi.Builder().add(new UppercaseAdapterFactory()).build();
+
+    assertThat(moshi.adapter(String.class)).isEqualTo(moshi.adapter(String.class));
+    assertThat(moshi.adapter(Object.class)).isEqualTo(moshi.adapter(Object.class));
+    assertThat(moshi.adapter(Boolean.class)).isEqualTo(moshi.adapter(Boolean.class));
+
+    Field uppercaseString = MoshiTest.class.getDeclaredField("uppercaseString");
+    Set<? extends Annotation> annotations = Util.jsonAnnotations(uppercaseString);
+    JsonAdapter<String> jsonAdapter2 = moshi.adapter(String.class, annotations);
+    assertThat(jsonAdapter2).isNotEqualTo(moshi.adapter(String.class));
+  }
+
   static class Pizza {
     final int diameter;
     final boolean extraCheese;


### PR DESCRIPTION
Implement simple in memory caching for `JsonAdapter` classes. Not sure if this is the right way to do this, and if this is the most efficient solution. Will be glad to rework this if necessary.