### PR TITLE
Adapter caching, plus other ergonomic features.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/AdapterMethodsFactory.java
+++ b/moshi/src/main/java/com/squareup/moshi/AdapterMethodsFactory.java
@@ -34,7 +34,7 @@ final class AdapterMethodsFactory implements JsonAdapter.Factory {
   }
 
   @Override public JsonAdapter<?> create(
-      Type type, Set<? extends Annotation> annotations, final Moshi moshi) {
+      final Type type, final Set<? extends Annotation> annotations, final Moshi moshi) {
     final AdapterMethod toAdapter = get(toAdapters, type, annotations);
     final AdapterMethod fromAdapter = get(fromAdapters, type, annotations);
     if (toAdapter == null && fromAdapter == null) return null;
@@ -86,6 +86,10 @@ final class AdapterMethodsFactory implements JsonAdapter.Factory {
             throw new JsonDataException(e.getCause() + " at " + reader.getPath());
           }
         }
+      }
+
+      @Override public String toString() {
+        return "JsonAdapter" + annotations + "(" + type + ")";
       }
     };
   }

--- a/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
@@ -44,6 +44,9 @@ abstract class ClassFactory<T> {
           Object[] args = null;
           return (T) constructor.newInstance(args);
         }
+        @Override public String toString() {
+          return rawType.getName();
+        }
       };
     } catch (NoSuchMethodException ignored) {
       // No no-args constructor. Fall back to something more magical...
@@ -63,6 +66,9 @@ abstract class ClassFactory<T> {
         @SuppressWarnings("unchecked")
         @Override public T newInstance() throws InvocationTargetException, IllegalAccessException {
           return (T) allocateInstance.invoke(unsafe, rawType);
+        }
+        @Override public String toString() {
+          return rawType.getName();
         }
       };
     } catch (IllegalAccessException e) {
@@ -88,6 +94,9 @@ abstract class ClassFactory<T> {
         @SuppressWarnings("unchecked")
         @Override public T newInstance() throws InvocationTargetException, IllegalAccessException {
           return (T) newInstance.invoke(null, rawType, constructorId);
+        }
+        @Override public String toString() {
+          return rawType.getName();
         }
       };
     } catch (IllegalAccessException e) {

--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -166,6 +166,10 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
     }
   }
 
+  @Override public String toString() {
+    return "JsonAdapter(" + classFactory + ")";
+  }
+
   static class FieldBinding<T> {
     private final Field field;
     private final JsonAdapter<T> adapter;

--- a/moshi/src/main/java/com/squareup/moshi/CollectionJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/CollectionJsonAdapter.java
@@ -85,4 +85,8 @@ abstract class CollectionJsonAdapter<C extends Collection<T>, T> extends JsonAda
     }
     writer.endArray();
   }
+
+  @Override public String toString() {
+    return elementAdapter + ".collection()";
+  }
 }

--- a/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
@@ -75,6 +75,9 @@ public abstract class JsonAdapter<T> {
           delegate.toJson(writer, value);
         }
       }
+      @Override public String toString() {
+        return delegate + ".nullSafe()";
+      }
     };
   }
 
@@ -100,6 +103,9 @@ public abstract class JsonAdapter<T> {
           writer.setLenient(lenient);
         }
       }
+      @Override public String toString() {
+        return delegate + ".lenient()";
+      }
     };
   }
 
@@ -123,6 +129,9 @@ public abstract class JsonAdapter<T> {
       }
       @Override public void toJson(JsonWriter writer, T value) throws IOException {
         delegate.toJson(writer, value);
+      }
+      @Override public String toString() {
+        return delegate + ".failOnUnknown()";
       }
     };
   }

--- a/moshi/src/main/java/com/squareup/moshi/MapJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/MapJsonAdapter.java
@@ -75,4 +75,8 @@ final class MapJsonAdapter<K, V> extends JsonAdapter<Map<K, V>> {
     reader.endObject();
     return result;
   }
+
+  @Override public String toString() {
+    return "JsonAdapter(" + keyAdapter + "=" + valueAdapter + ")";
+  }
 }

--- a/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.java
+++ b/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.java
@@ -78,15 +78,23 @@ final class StandardJsonAdapters {
     @Override public void toJson(JsonWriter writer, Boolean value) throws IOException {
       writer.value(value);
     }
+
+    @Override public String toString() {
+      return "JsonAdapter(Boolean)";
+    }
   };
 
   static final JsonAdapter<Byte> BYTE_JSON_ADAPTER = new JsonAdapter<Byte>() {
     @Override public Byte fromJson(JsonReader reader) throws IOException {
-      return (byte) rangeCheckNextInt(reader, "a byte", Byte.MIN_VALUE, 0xFF);
+      return (byte) rangeCheckNextInt(reader, "a byte", Byte.MIN_VALUE, 0xff);
     }
 
     @Override public void toJson(JsonWriter writer, Byte value) throws IOException {
-      writer.value(value.intValue() & 0xFF);
+      writer.value(value.intValue() & 0xff);
+    }
+
+    @Override public String toString() {
+      return "JsonAdapter(Byte)";
     }
   };
 
@@ -103,6 +111,10 @@ final class StandardJsonAdapters {
     @Override public void toJson(JsonWriter writer, Character value) throws IOException {
       writer.value(value.toString());
     }
+
+    @Override public String toString() {
+      return "JsonAdapter(Character)";
+    }
   };
 
   static final JsonAdapter<Double> DOUBLE_JSON_ADAPTER = new JsonAdapter<Double>() {
@@ -112,6 +124,10 @@ final class StandardJsonAdapters {
 
     @Override public void toJson(JsonWriter writer, Double value) throws IOException {
       writer.value(value.doubleValue());
+    }
+
+    @Override public String toString() {
+      return "JsonAdapter(Double)";
     }
   };
 
@@ -134,6 +150,10 @@ final class StandardJsonAdapters {
       // Use the Number overload so we write out float precision instead of double precision.
       writer.value(value);
     }
+
+    @Override public String toString() {
+      return "JsonAdapter(Float)";
+    }
   };
 
   static final JsonAdapter<Integer> INTEGER_JSON_ADAPTER = new JsonAdapter<Integer>() {
@@ -143,6 +163,10 @@ final class StandardJsonAdapters {
 
     @Override public void toJson(JsonWriter writer, Integer value) throws IOException {
       writer.value(value.intValue());
+    }
+
+    @Override public String toString() {
+      return "JsonAdapter(Integer)";
     }
   };
 
@@ -154,6 +178,10 @@ final class StandardJsonAdapters {
     @Override public void toJson(JsonWriter writer, Long value) throws IOException {
       writer.value(value.longValue());
     }
+
+    @Override public String toString() {
+      return "JsonAdapter(Long)";
+    }
   };
 
   static final JsonAdapter<Short> SHORT_JSON_ADAPTER = new JsonAdapter<Short>() {
@@ -164,6 +192,10 @@ final class StandardJsonAdapters {
     @Override public void toJson(JsonWriter writer, Short value) throws IOException {
       writer.value(value.intValue());
     }
+
+    @Override public String toString() {
+      return "JsonAdapter(Short)";
+    }
   };
 
   static final JsonAdapter<String> STRING_JSON_ADAPTER = new JsonAdapter<String>() {
@@ -173,6 +205,10 @@ final class StandardJsonAdapters {
 
     @Override public void toJson(JsonWriter writer, String value) throws IOException {
       writer.value(value);
+    }
+
+    @Override public String toString() {
+      return "JsonAdapter(String)";
     }
   };
 
@@ -191,6 +227,10 @@ final class StandardJsonAdapters {
 
       @Override public void toJson(JsonWriter writer, T value) throws IOException {
         writer.value(value.name());
+      }
+
+      @Override public String toString() {
+        return "JsonAdapter(" + enumType.getName() + ")";
       }
     };
   }
@@ -270,6 +310,10 @@ final class StandardJsonAdapters {
       if (Map.class.isAssignableFrom(valueClass)) return Map.class;
       if (Collection.class.isAssignableFrom(valueClass)) return Collection.class;
       return valueClass;
+    }
+
+    @Override public String toString() {
+      return "JsonAdapter(Object)";
     }
   }
 }


### PR DESCRIPTION
This adds a toString() to most adapters. The format isn't perfect, but
it should make step-debugging easier.

Define the precedence order of adapter factories.

Forbid registering adapters with annotation literals if those annotations
need values to be provided.