### PR TITLE
JsonReader.of() and JsonWriter.of() instead of constructors.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
@@ -30,7 +30,7 @@ public abstract class JsonAdapter<T> {
   public abstract T fromJson(JsonReader reader) throws IOException;
 
   public final T fromJson(BufferedSource source) throws IOException {
-    return fromJson(new JsonReader(source));
+    return fromJson(JsonReader.of(source));
   }
 
   public final T fromJson(String string) throws IOException {
@@ -40,7 +40,7 @@ public abstract class JsonAdapter<T> {
   public abstract void toJson(JsonWriter writer, T value) throws IOException;
 
   public final void toJson(BufferedSink sink, T value) throws IOException {
-    JsonWriter writer = new JsonWriter(sink);
+    JsonWriter writer = JsonWriter.of(sink);
     toJson(writer, value);
   }
 

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -84,7 +84,7 @@ import okio.ByteString;
  * This code implements the parser for the above structure: <pre>   {@code
  *
  *   public List<Message> readJsonStream(BufferedSource source) throws IOException {
- *     JsonReader reader = new JsonReader(source);
+ *     JsonReader reader = JsonReader.of(source);
  *     try {
  *       return readMessagesArray(reader);
  *     } finally {
@@ -171,7 +171,7 @@ import okio.ByteString;
  * <p>Each {@code JsonReader} may be used to read a single JSON stream. Instances
  * of this class are not thread safe.
  */
-public final class JsonReader implements Closeable {
+public class JsonReader implements Closeable {
   private static final long MIN_INCOMPLETE_INTEGER = Long.MIN_VALUE / 10;
 
   private static final ByteString SINGLE_QUOTE_OR_SLASH = ByteString.encodeUtf8("'\\");
@@ -254,15 +254,19 @@ public final class JsonReader implements Closeable {
   private String[] pathNames = new String[32];
   private int[] pathIndices = new int[32];
 
-  /**
-   * Creates a new instance that reads a JSON-encoded stream from {@code source}.
-   */
-  public JsonReader(BufferedSource source) {
+  private JsonReader(BufferedSource source) {
     if (source == null) {
       throw new NullPointerException("source == null");
     }
     this.source = source;
     this.buffer = source.buffer();
+  }
+
+  /**
+   * Returns a new instance that reads a JSON-encoded stream from {@code source}.
+   */
+  public static JsonReader of(BufferedSource source) {
+    return new JsonReader(source);
   }
 
   /**

--- a/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
@@ -76,7 +76,7 @@ import static com.squareup.moshi.JsonScope.NONEMPTY_OBJECT;
  * ]}</pre>
  * This code encodes the above structure: <pre>   {@code
  *   public void writeJsonStream(BufferedSink sink, List<Message> messages) throws IOException {
- *     JsonWriter writer = new JsonWriter(sink);
+ *     JsonWriter writer = JsonWriter.of(sink);
  *     writer.setIndentSpaces(4);
  *     writeMessagesArray(writer, messages);
  *     writer.close();
@@ -124,7 +124,7 @@ import static com.squareup.moshi.JsonScope.NONEMPTY_OBJECT;
  * Instances of this class are not thread safe. Calls that would result in a
  * malformed JSON string will fail with an {@link IllegalStateException}.
  */
-public final class JsonWriter implements Closeable, Flushable {
+public class JsonWriter implements Closeable, Flushable {
 
   /*
    * From RFC 4627, "All Unicode characters may be placed within the
@@ -182,14 +182,18 @@ public final class JsonWriter implements Closeable, Flushable {
 
   private boolean promoteNameToValue;
 
-  /**
-   * Creates a new instance that writes a JSON-encoded stream to {@code sink}.
-   */
-  public JsonWriter(BufferedSink sink) {
+  private JsonWriter(BufferedSink sink) {
     if (sink == null) {
       throw new NullPointerException("sink == null");
     }
     this.sink = sink;
+  }
+
+  /**
+   * Returns a new instance that writes a JSON-encoded stream to {@code sink}.
+   */
+  public static JsonWriter of(BufferedSink sink) {
+    return new JsonWriter(sink);
   }
 
   /**

--- a/moshi/src/test/java/com/squareup/moshi/ClassJsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/ClassJsonAdapterTest.java
@@ -436,7 +436,7 @@ public final class ClassJsonAdapterTest {
 
     // Wrap in an array to avoid top-level object warnings without going completely lenient.
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.setSerializeNulls(true);
     jsonWriter.beginArray();
     jsonAdapter.toJson(jsonWriter, value);

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
@@ -39,12 +39,12 @@ public final class JsonReaderTest {
   @Test public void readingDoesNotBuffer() throws IOException {
     Buffer buffer = new Buffer().writeUtf8("{}{}");
 
-    JsonReader reader1 = new JsonReader(buffer);
+    JsonReader reader1 = JsonReader.of(buffer);
     reader1.beginObject();
     reader1.endObject();
     assertThat(buffer.size()).isEqualTo(2);
 
-    JsonReader reader2 = new JsonReader(buffer);
+    JsonReader reader2 = JsonReader.of(buffer);
     reader2.beginObject();
     reader2.endObject();
     assertThat(buffer.size()).isEqualTo(0);
@@ -80,7 +80,7 @@ public final class JsonReaderTest {
 
   @Test public void readObjectBuffer() throws IOException {
     Buffer buffer = new Buffer().writeUtf8("{\"a\": \"android\", \"b\": \"banana\"}");
-    JsonReader reader = new JsonReader(buffer);
+    JsonReader reader = JsonReader.of(buffer);
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("a");
     assertThat(reader.nextString()).isEqualTo("android");
@@ -92,7 +92,7 @@ public final class JsonReaderTest {
 
   @Test public void readObjectSource() throws IOException {
     Buffer buffer = new Buffer().writeUtf8("{\"a\": \"android\", \"b\": \"banana\"}");
-    JsonReader reader = new JsonReader(buffer);
+    JsonReader reader = JsonReader.of(buffer);
     reader.beginObject();
     assertThat(reader.nextName()).isEqualTo("a");
     assertThat(reader.nextString()).isEqualTo("android");
@@ -245,7 +245,7 @@ public final class JsonReaderTest {
 
   @Test public void nullSource() {
     try {
-      new JsonReader(null);
+      JsonReader.of(null);
       fail();
     } catch (NullPointerException expected) {
     }

--- a/moshi/src/test/java/com/squareup/moshi/JsonWriterPathTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonWriterPathTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public final class JsonWriterPathTest {
   @Test public void path() throws IOException {
-    JsonWriter writer = new JsonWriter(new Buffer());
+    JsonWriter writer = JsonWriter.of(new Buffer());
     assertThat(writer.getPath()).isEqualTo("$");
     writer.beginObject();
     assertThat(writer.getPath()).isEqualTo("$.");
@@ -63,7 +63,7 @@ public final class JsonWriterPathTest {
   }
 
   @Test public void arrayOfObjects() throws IOException {
-    JsonWriter writer = new JsonWriter(new Buffer());
+    JsonWriter writer = JsonWriter.of(new Buffer());
     writer.beginArray();
     assertThat(writer.getPath()).isEqualTo("$[0]");
     writer.beginObject();
@@ -83,7 +83,7 @@ public final class JsonWriterPathTest {
   }
 
   @Test public void arrayOfArrays() throws IOException {
-    JsonWriter writer = new JsonWriter(new Buffer());
+    JsonWriter writer = JsonWriter.of(new Buffer());
     writer.beginArray();
     assertThat(writer.getPath()).isEqualTo("$[0]");
     writer.beginArray();
@@ -103,7 +103,7 @@ public final class JsonWriterPathTest {
   }
 
   @Test public void objectPath() throws IOException {
-    JsonWriter writer = new JsonWriter(new Buffer());
+    JsonWriter writer = JsonWriter.of(new Buffer());
     assertThat(writer.getPath()).isEqualTo("$");
     writer.beginObject();
     assertThat(writer.getPath()).isEqualTo("$.");
@@ -122,7 +122,7 @@ public final class JsonWriterPathTest {
   }
 
   @Test public void nestedObjects() throws IOException {
-    JsonWriter writer = new JsonWriter(new Buffer());
+    JsonWriter writer = JsonWriter.of(new Buffer());
     assertThat(writer.getPath()).isEqualTo("$");
     writer.beginObject();
     assertThat(writer.getPath()).isEqualTo("$.");
@@ -147,7 +147,7 @@ public final class JsonWriterPathTest {
   }
 
   @Test public void arrayPath() throws IOException {
-    JsonWriter writer = new JsonWriter(new Buffer());
+    JsonWriter writer = JsonWriter.of(new Buffer());
     assertThat(writer.getPath()).isEqualTo("$");
     writer.beginArray();
     assertThat(writer.getPath()).isEqualTo("$[0]");
@@ -168,7 +168,7 @@ public final class JsonWriterPathTest {
   }
 
   @Test public void nestedArrays() throws IOException {
-    JsonWriter writer = new JsonWriter(new Buffer());
+    JsonWriter writer = JsonWriter.of(new Buffer());
     assertThat(writer.getPath()).isEqualTo("$");
     writer.beginArray();
     assertThat(writer.getPath()).isEqualTo("$[0]");
@@ -189,7 +189,7 @@ public final class JsonWriterPathTest {
   }
 
   @Test public void multipleTopLevelValuesInOneDocument() throws IOException {
-    JsonWriter writer = new JsonWriter(new Buffer());
+    JsonWriter writer = JsonWriter.of(new Buffer());
     writer.setLenient(true);
     writer.beginArray();
     writer.endArray();
@@ -200,7 +200,7 @@ public final class JsonWriterPathTest {
   }
 
   @Test public void skipNulls() throws IOException {
-    JsonWriter writer = new JsonWriter(new Buffer());
+    JsonWriter writer = JsonWriter.of(new Buffer());
     writer.setSerializeNulls(false);
     assertThat(writer.getPath()).isEqualTo("$");
     writer.beginObject();

--- a/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.fail;
 public final class JsonWriterTest {
   @Test public void nullsValuesNotSerializedByDefault() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginObject();
     jsonWriter.name("a");
     jsonWriter.nullValue();
@@ -38,7 +38,7 @@ public final class JsonWriterTest {
 
   @Test public void nullsValuesSerializedWhenConfigured() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.setSerializeNulls(true);
     jsonWriter.beginObject();
     jsonWriter.name("a");
@@ -50,7 +50,7 @@ public final class JsonWriterTest {
 
   @Test public void wrongTopLevelType() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     try {
       jsonWriter.value("a");
       fail();
@@ -60,7 +60,7 @@ public final class JsonWriterTest {
 
   @Test public void twoNames() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginObject();
     jsonWriter.name("a");
     try {
@@ -72,7 +72,7 @@ public final class JsonWriterTest {
 
   @Test public void nameWithoutValue() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginObject();
     jsonWriter.name("a");
     try {
@@ -84,7 +84,7 @@ public final class JsonWriterTest {
 
   @Test public void valueWithoutName() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginObject();
     try {
       jsonWriter.value(true);
@@ -95,7 +95,7 @@ public final class JsonWriterTest {
 
   @Test public void multipleTopLevelValues() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginArray().endArray();
     try {
       jsonWriter.beginArray();
@@ -106,7 +106,7 @@ public final class JsonWriterTest {
 
   @Test public void badNestingObject() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginArray();
     jsonWriter.beginObject();
     try {
@@ -118,7 +118,7 @@ public final class JsonWriterTest {
 
   @Test public void badNestingArray() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginArray();
     jsonWriter.beginArray();
     try {
@@ -130,7 +130,7 @@ public final class JsonWriterTest {
 
   @Test public void nullName() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginObject();
     try {
       jsonWriter.name(null);
@@ -141,7 +141,7 @@ public final class JsonWriterTest {
 
   @Test public void nullStringValue() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.setSerializeNulls(true);
     jsonWriter.beginObject();
     jsonWriter.name("a");
@@ -152,7 +152,7 @@ public final class JsonWriterTest {
 
   @Test public void nonFiniteDoubles() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginArray();
     try {
       jsonWriter.value(Double.NaN);
@@ -173,7 +173,7 @@ public final class JsonWriterTest {
 
   @Test public void nonFiniteBoxedDoubles() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginArray();
     try {
       jsonWriter.value(new Double(Double.NaN));
@@ -194,7 +194,7 @@ public final class JsonWriterTest {
 
   @Test public void doubles() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginArray();
     jsonWriter.value(-0.0);
     jsonWriter.value(1.0);
@@ -220,7 +220,7 @@ public final class JsonWriterTest {
 
   @Test public void longs() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginArray();
     jsonWriter.value(0);
     jsonWriter.value(1);
@@ -238,7 +238,7 @@ public final class JsonWriterTest {
 
   @Test public void numbers() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginArray();
     jsonWriter.value(new BigInteger("0"));
     jsonWriter.value(new BigInteger("9223372036854775808"));
@@ -254,7 +254,7 @@ public final class JsonWriterTest {
 
   @Test public void booleans() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginArray();
     jsonWriter.value(true);
     jsonWriter.value(false);
@@ -264,7 +264,7 @@ public final class JsonWriterTest {
 
   @Test public void nulls() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginArray();
     jsonWriter.nullValue();
     jsonWriter.endArray();
@@ -273,7 +273,7 @@ public final class JsonWriterTest {
 
   @Test public void strings() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginArray();
     jsonWriter.value("a");
     jsonWriter.value("a\"");
@@ -316,7 +316,7 @@ public final class JsonWriterTest {
 
   @Test public void unicodeLineBreaksEscaped() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginArray();
     jsonWriter.value("\u2028 \u2029");
     jsonWriter.endArray();
@@ -325,7 +325,7 @@ public final class JsonWriterTest {
 
   @Test public void emptyArray() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginArray();
     jsonWriter.endArray();
     assertThat(buffer.readUtf8()).isEqualTo("[]");
@@ -333,7 +333,7 @@ public final class JsonWriterTest {
 
   @Test public void emptyObject() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginObject();
     jsonWriter.endObject();
     assertThat(buffer.readUtf8()).isEqualTo("{}");
@@ -341,7 +341,7 @@ public final class JsonWriterTest {
 
   @Test public void objectsInArrays() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginArray();
     jsonWriter.beginObject();
     jsonWriter.name("a").value(5);
@@ -358,7 +358,7 @@ public final class JsonWriterTest {
 
   @Test public void arraysInObjects() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginObject();
     jsonWriter.name("a");
     jsonWriter.beginArray();
@@ -377,7 +377,7 @@ public final class JsonWriterTest {
 
   @Test public void deepNestingArrays() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     for (int i = 0; i < 20; i++) {
       jsonWriter.beginArray();
     }
@@ -389,7 +389,7 @@ public final class JsonWriterTest {
 
   @Test public void deepNestingObjects() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginObject();
     for (int i = 0; i < 20; i++) {
       jsonWriter.name("a");
@@ -407,7 +407,7 @@ public final class JsonWriterTest {
 
   @Test public void repeatedName() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.beginObject();
     jsonWriter.name("a").value(true);
     jsonWriter.name("a").value(false);
@@ -418,7 +418,7 @@ public final class JsonWriterTest {
 
   @Test public void prettyPrintObject() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.setSerializeNulls(true);
     jsonWriter.setIndent("   ");
 
@@ -456,7 +456,7 @@ public final class JsonWriterTest {
 
   @Test public void prettyPrintArray() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.setIndent("   ");
 
     jsonWriter.beginArray();
@@ -493,7 +493,7 @@ public final class JsonWriterTest {
 
   @Test public void lenientWriterPermitsMultipleTopLevelValues() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter writer = new JsonWriter(buffer);
+    JsonWriter writer = JsonWriter.of(buffer);
     writer.setLenient(true);
     writer.beginArray();
     writer.endArray();
@@ -505,7 +505,7 @@ public final class JsonWriterTest {
 
   @Test public void strictWriterDoesNotPermitMultipleTopLevelValues() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter writer = new JsonWriter(buffer);
+    JsonWriter writer = JsonWriter.of(buffer);
     writer.beginArray();
     writer.endArray();
     try {
@@ -517,7 +517,7 @@ public final class JsonWriterTest {
 
   @Test public void closedWriterThrowsOnStructure() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter writer = new JsonWriter(buffer);
+    JsonWriter writer = JsonWriter.of(buffer);
     writer.beginArray();
     writer.endArray();
     writer.close();
@@ -545,7 +545,7 @@ public final class JsonWriterTest {
 
   @Test public void closedWriterThrowsOnName() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter writer = new JsonWriter(buffer);
+    JsonWriter writer = JsonWriter.of(buffer);
     writer.beginArray();
     writer.endArray();
     writer.close();
@@ -558,7 +558,7 @@ public final class JsonWriterTest {
 
   @Test public void closedWriterThrowsOnValue() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter writer = new JsonWriter(buffer);
+    JsonWriter writer = JsonWriter.of(buffer);
     writer.beginArray();
     writer.endArray();
     writer.close();
@@ -571,7 +571,7 @@ public final class JsonWriterTest {
 
   @Test public void closedWriterThrowsOnFlush() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter writer = new JsonWriter(buffer);
+    JsonWriter writer = JsonWriter.of(buffer);
     writer.beginArray();
     writer.endArray();
     writer.close();
@@ -584,7 +584,7 @@ public final class JsonWriterTest {
 
   @Test public void writerCloseIsIdempotent() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter writer = new JsonWriter(buffer);
+    JsonWriter writer = JsonWriter.of(buffer);
     writer.beginArray();
     writer.endArray();
     writer.close();

--- a/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
@@ -75,7 +75,7 @@ public final class MapJsonAdapterTest {
     JsonAdapter<?> jsonAdapter = mapAdapter(String.class, Boolean.class);
 
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.setLenient(true);
     jsonAdapter.toJson(jsonWriter, null);
     assertThat(buffer.readUtf8()).isEqualTo("null");
@@ -129,7 +129,7 @@ public final class MapJsonAdapterTest {
   private <K, V> String toJson(Type keyType, Type valueType, Map<K, V> value) throws IOException {
     JsonAdapter<Map<K, V>> jsonAdapter = mapAdapter(keyType, valueType);
     Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = new JsonWriter(buffer);
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.setSerializeNulls(true);
     jsonAdapter.toJson(jsonWriter, value);
     return buffer.readUtf8();

--- a/moshi/src/test/java/com/squareup/moshi/PromoteNameToValueTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/PromoteNameToValueTest.java
@@ -160,12 +160,12 @@ public final class PromoteNameToValueTest {
   }
 
   private JsonReader newReader(String s) {
-    return new JsonReader(new Buffer().writeUtf8(s));
+    return JsonReader.of(new Buffer().writeUtf8(s));
   }
 
   @Test public void writerStringValue() throws Exception {
     Buffer buffer = new Buffer();
-    JsonWriter writer = new JsonWriter(buffer);
+    JsonWriter writer = JsonWriter.of(buffer);
     writer.beginObject();
     writer.promoteNameToValue();
     writer.value("a");
@@ -179,7 +179,7 @@ public final class PromoteNameToValueTest {
 
   @Test public void writerIntegerValue() throws Exception {
     Buffer buffer = new Buffer();
-    JsonWriter writer = new JsonWriter(buffer);
+    JsonWriter writer = JsonWriter.of(buffer);
     writer.beginObject();
     writer.promoteNameToValue();
     writer.value(5);
@@ -193,7 +193,7 @@ public final class PromoteNameToValueTest {
 
   @Test public void writerDoubleValue() throws Exception {
     Buffer buffer = new Buffer();
-    JsonWriter writer = new JsonWriter(buffer);
+    JsonWriter writer = JsonWriter.of(buffer);
     writer.beginObject();
     writer.promoteNameToValue();
     writer.value(5.5d);
@@ -207,7 +207,7 @@ public final class PromoteNameToValueTest {
 
   @Test public void writerBooleanValue() throws Exception {
     Buffer buffer = new Buffer();
-    JsonWriter writer = new JsonWriter(buffer);
+    JsonWriter writer = JsonWriter.of(buffer);
     writer.beginObject();
     writer.promoteNameToValue();
     try {
@@ -226,7 +226,7 @@ public final class PromoteNameToValueTest {
 
   @Test public void writerLongValue() throws Exception {
     Buffer buffer = new Buffer();
-    JsonWriter writer = new JsonWriter(buffer);
+    JsonWriter writer = JsonWriter.of(buffer);
     writer.beginObject();
     writer.promoteNameToValue();
     writer.value(5L);
@@ -240,7 +240,7 @@ public final class PromoteNameToValueTest {
 
   @Test public void writerNullValue() throws Exception {
     Buffer buffer = new Buffer();
-    JsonWriter writer = new JsonWriter(buffer);
+    JsonWriter writer = JsonWriter.of(buffer);
     writer.beginObject();
     writer.promoteNameToValue();
     try {
@@ -260,7 +260,7 @@ public final class PromoteNameToValueTest {
 
   @Test public void writerMultipleValueObject() throws Exception {
     Buffer buffer = new Buffer();
-    JsonWriter writer = new JsonWriter(buffer);
+    JsonWriter writer = JsonWriter.of(buffer);
     writer.beginObject();
     writer.name("a");
     writer.value(1);
@@ -276,7 +276,7 @@ public final class PromoteNameToValueTest {
 
   @Test public void writerEmptyValueObject() throws Exception {
     Buffer buffer = new Buffer();
-    JsonWriter writer = new JsonWriter(buffer);
+    JsonWriter writer = JsonWriter.of(buffer);
     writer.beginObject();
     writer.promoteNameToValue();
     assertThat(writer.getPath()).isEqualTo("$.");
@@ -287,7 +287,7 @@ public final class PromoteNameToValueTest {
 
   @Test public void writerUnusedPromotionDoesntPersist() throws Exception {
     Buffer buffer = new Buffer();
-    JsonWriter writer = new JsonWriter(buffer);
+    JsonWriter writer = JsonWriter.of(buffer);
     writer.beginArray();
     writer.beginObject();
     writer.promoteNameToValue();

--- a/moshi/src/test/java/com/squareup/moshi/TestUtil.java
+++ b/moshi/src/test/java/com/squareup/moshi/TestUtil.java
@@ -20,7 +20,7 @@ import okio.Buffer;
 final class TestUtil {
   static JsonReader newReader(String json) {
     Buffer buffer = new Buffer().writeUtf8(json);
-    return new JsonReader(buffer);
+    return JsonReader.of(buffer);
   }
 
   private TestUtil() {


### PR DESCRIPTION
This opens the door to later implementations of these types that write
to something other than a stream. In particular, we could have a
JsonReader that reads from a DOM-like object, or a JsonWriter that
creates such an object.