### PR TITLE
Make two methods on Types public.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/Types.java
+++ b/moshi/src/main/java/com/squareup/moshi/Types.java
@@ -93,7 +93,7 @@ public final class Types {
     }
   }
 
-  static Class<?> getRawType(Type type) {
+  public static Class<?> getRawType(Type type) {
     if (type instanceof Class<?>) {
       // type is a normal class.
       return (Class<?>) type;
@@ -260,7 +260,7 @@ public final class Types {
    * Returns the element type of this collection type.
    * @throws IllegalArgumentException if this type is not a collection.
    */
-  static Type collectionElementType(Type context, Class<?> contextRawType) {
+  public static Type collectionElementType(Type context, Class<?> contextRawType) {
     Type collectionType = getSupertype(context, contextRawType, Collection.class);
 
     if (collectionType instanceof WildcardType) {


### PR DESCRIPTION
To facilitate custom JsonAdapter.Factory implementations.

When I closed #84 I was fooled by my Android Studio which was using a cached version of moshi, or something.

Like @JakeWharton said in that issue `getRawType` and `collectionElementType` were indeed non-public before.

This commit makes them public.
