### PR TITLE
Possibility to create new `Moshi.Builder` from `Moshi` instance.

### DIFF
--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -799,6 +799,16 @@ public final class MoshiTest {
     assertThat(adapter1).isSameAs(adapter2);
   }
 
+  @Test public void newBuilder() throws Exception {
+    Moshi moshi = new Moshi.Builder()
+        .add(Pizza.class, new PizzaAdapter())
+        .build();
+    Moshi.Builder newBuilder = moshi.newBuilder();
+    for (JsonAdapter.Factory factory : Moshi.BUILT_IN_FACTORIES) {
+      assertThat(factory).isNotIn(newBuilder.factories);
+    }
+  }
+
   static class Pizza {
     final int diameter;
     final boolean extraCheese;


### PR DESCRIPTION
Added `Moshi#newBuilder` method, which creates a `Moshi.Builder` with all custom factories.

Discused in #101 