### PR TITLE
Look up a map's key/value adapters using raw types. Add a test for ma…

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/MapJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/MapJsonAdapter.java
@@ -34,8 +34,7 @@ final class MapJsonAdapter<K, V> extends JsonAdapter<Map<K, V>> {
       Class<?> rawType = Types.getRawType(type);
       if (rawType != Map.class) return null;
       Type[] keyAndValue = Types.mapKeyAndValueTypes(type, rawType);
-      return new MapJsonAdapter<>(moshi, Types.getRawType(keyAndValue[0]),
-              Types.getRawType(keyAndValue[1])).nullSafe();
+      return new MapJsonAdapter<>(moshi, keyAndValue[0], keyAndValue[1]).nullSafe();
     }
   };
 

--- a/moshi/src/main/java/com/squareup/moshi/MapJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/MapJsonAdapter.java
@@ -34,7 +34,8 @@ final class MapJsonAdapter<K, V> extends JsonAdapter<Map<K, V>> {
       Class<?> rawType = Types.getRawType(type);
       if (rawType != Map.class) return null;
       Type[] keyAndValue = Types.mapKeyAndValueTypes(type, rawType);
-      return new MapJsonAdapter<>(moshi, keyAndValue[0], keyAndValue[1]).nullSafe();
+      return new MapJsonAdapter<>(moshi, Types.getRawType(keyAndValue[0]),
+              Types.getRawType(keyAndValue[1])).nullSafe();
     }
   };
 

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -87,9 +86,10 @@ public final class Moshi {
     // Prepare for re-entrant calls, then ask each factory to create a type adapter.
     DeferredAdapter<T> deferredAdapter = new DeferredAdapter<>(cacheKey);
     deferredAdapters.add(deferredAdapter);
+    Type canonicalType = Types.canonicalizePlatformTypes(type);
     try {
       for (int i = 0, size = factories.size(); i < size; i++) {
-        JsonAdapter<T> result = (JsonAdapter<T>) factories.get(i).create(type, annotations, this);
+        JsonAdapter<T> result = (JsonAdapter<T>) factories.get(i).create(canonicalType, annotations, this);
         if (result != null) {
           deferredAdapter.ready(result);
           synchronized (adapterCache) {

--- a/moshi/src/main/java/com/squareup/moshi/Types.java
+++ b/moshi/src/main/java/com/squareup/moshi/Types.java
@@ -93,6 +93,30 @@ public final class Types {
     }
   }
 
+  static Type canonicalizePlatformTypes(Type type) {
+    if (type instanceof GenericArrayType) {
+      Type c = ((GenericArrayType) type).getGenericComponentType();
+      if (c.equals(Byte.TYPE)) {
+        return byte[].class;
+      } else if (c.equals(Long.TYPE)) {
+        return long[].class;
+      } else if (c.equals(Integer.TYPE)) {
+        return int[].class;
+      } else if (c.equals(Short.TYPE)) {
+        return short[].class;
+      } else if (c.equals(Character.TYPE)) {
+        return char[].class;
+      } else if (c.equals(Boolean.TYPE)) {
+        return boolean[].class;
+      } else if (c.equals(Float.TYPE)) {
+        return float[].class;
+      } else if (c.equals(Double.TYPE)) {
+        return double[].class;
+      }
+    }
+    return type;
+  }
+
   public static Class<?> getRawType(Type type) {
     if (type instanceof Class<?>) {
       // type is a normal class.

--- a/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
@@ -17,6 +17,7 @@ package com.squareup.moshi;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -32,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 public final class MapJsonAdapterTest {
-  private final Moshi moshi = new Moshi.Builder().build();
+  private final Moshi moshi = new Moshi.Builder().add(byte[].class, new Base32Adapter()).build();
 
   @Test public void map() throws Exception {
     Map<String, Boolean> map = new LinkedHashMap<>();
@@ -123,7 +124,34 @@ public final class MapJsonAdapterTest {
     Map<String, Boolean> fromJson = fromJson(
         Integer.class, Boolean.class, "{\"5\":true,\"6\":false,\"7\":null}");
     assertThat(fromJson).containsExactly(
-        MapEntry.entry(5, true), MapEntry.entry(6, false), MapEntry.entry(7, null));
+            MapEntry.entry(5, true), MapEntry.entry(6, false), MapEntry.entry(7, null));
+  }
+
+  class Base32Adapter extends JsonAdapter<byte[]>  {
+    @Override
+    public byte[] fromJson(JsonReader reader) throws IOException {
+      String string = reader.nextString();
+      return new BigInteger(string, 32).toByteArray();
+    }
+
+    @Override
+    public void toJson(JsonWriter writer, byte[] bytes) throws IOException {
+      String string = new BigInteger(bytes).toString(32);
+      writer.value(string);
+    }
+  }
+
+  static class DevBytes {
+    public Map<String, byte[]> bytes;
+  }
+
+  @Test public void byteArrayMapAdapter() throws Exception {
+    String jsonString = "{\"bytes\":{\"jesse\":\"a\",\"jake\":\"1\"}}";
+    DevBytes dev = moshi.adapter(DevBytes.class).fromJson(jsonString);
+
+    assertThat(dev.bytes).containsOnlyKeys("jesse", "jake");
+    assertThat(dev.bytes.get("jesse")).isEqualTo(new byte[] { 0xa });
+    assertThat(dev.bytes.get("jake")).isEqualTo(new byte[] { 0x1 });
   }
 
   private <K, V> String toJson(Type keyType, Type valueType, Map<K, V> value) throws IOException {

--- a/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
@@ -124,7 +124,7 @@ public final class MapJsonAdapterTest {
     Map<String, Boolean> fromJson = fromJson(
         Integer.class, Boolean.class, "{\"5\":true,\"6\":false,\"7\":null}");
     assertThat(fromJson).containsExactly(
-            MapEntry.entry(5, true), MapEntry.entry(6, false), MapEntry.entry(7, null));
+        MapEntry.entry(5, true), MapEntry.entry(6, false), MapEntry.entry(7, null));
   }
 
   class Base32Adapter extends JsonAdapter<byte[]>  {


### PR DESCRIPTION
…ps with byte[] values. fixes #128 

Types.canonicalize() didn't work in either JVM or Android, fetching the raw type passes on both.
