### PR TITLE
Be more aggressive about canonicalizing types.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/AdapterMethodsFactory.java
+++ b/moshi/src/main/java/com/squareup/moshi/AdapterMethodsFactory.java
@@ -228,7 +228,7 @@ final class AdapterMethodsFactory implements JsonAdapter.Factory {
       List<AdapterMethod> adapterMethods, Type type, Set<? extends Annotation> annotations) {
     for (int i = 0, size = adapterMethods.size(); i < size; i++) {
       AdapterMethod adapterMethod = adapterMethods.get(i);
-      if (Types.equals(adapterMethod.type, type) && adapterMethod.annotations.equals(annotations)) {
+      if (adapterMethod.type.equals(type) && adapterMethod.annotations.equals(annotations)) {
         return adapterMethod;
       }
     }
@@ -244,7 +244,7 @@ final class AdapterMethodsFactory implements JsonAdapter.Factory {
 
     public AdapterMethod(Type type,
         Set<? extends Annotation> annotations, Object adapter, Method method, boolean nullable) {
-      this.type = type;
+      this.type = Types.canonicalize(type);
       this.annotations = annotations;
       this.adapter = adapter;
       this.method = method;

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -63,6 +62,8 @@ public final class Moshi {
 
   @SuppressWarnings("unchecked") // Factories are required to return only matching JsonAdapters.
   public <T> JsonAdapter<T> adapter(Type type, Set<? extends Annotation> annotations) {
+    type = Types.canonicalize(type);
+
     // If there's an equivalent adapter in the cache, we're done!
     Object cacheKey = cacheKey(type, annotations);
     synchronized (adapterCache) {
@@ -111,6 +112,8 @@ public final class Moshi {
   @SuppressWarnings("unchecked") // Factories are required to return only matching JsonAdapters.
   public <T> JsonAdapter<T> nextAdapter(JsonAdapter.Factory skipPast, Type type,
       Set<? extends Annotation> annotations) {
+    type = Types.canonicalize(type);
+
     int skipPastIndex = factories.indexOf(skipPast);
     if (skipPastIndex == -1) {
       throw new IllegalArgumentException("Unable to skip past unknown factory " + skipPast);

--- a/moshi/src/main/java/com/squareup/moshi/Types.java
+++ b/moshi/src/main/java/com/squareup/moshi/Types.java
@@ -76,15 +76,18 @@ public final class Types {
       return c.isArray() ? new GenericArrayTypeImpl(canonicalize(c.getComponentType())) : c;
 
     } else if (type instanceof ParameterizedType) {
+      if (type instanceof ParameterizedTypeImpl) return type;
       ParameterizedType p = (ParameterizedType) type;
       return new ParameterizedTypeImpl(p.getOwnerType(),
           p.getRawType(), p.getActualTypeArguments());
 
     } else if (type instanceof GenericArrayType) {
+      if (type instanceof GenericArrayTypeImpl) return type;
       GenericArrayType g = (GenericArrayType) type;
       return new GenericArrayTypeImpl(g.getGenericComponentType());
 
     } else if (type instanceof WildcardType) {
+      if (type instanceof WildcardTypeImpl) return type;
       WildcardType w = (WildcardType) type;
       return new WildcardTypeImpl(w.getUpperBounds(), w.getLowerBounds());
 
@@ -172,7 +175,7 @@ public final class Types {
           && va.getName().equals(vb.getName());
 
     } else {
-      // This isn't a supported type. Could be a generic array type, wildcard type, etc.
+      // This isn't a supported type.
       return false;
     }
   }


### PR DESCRIPTION
Unfortunately we shouldn't be relying on equals() and hashCode() of the
default implementations anywhere.