### PR TITLE
Add writer value overload for boxed booleans.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/BufferedSinkJsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/BufferedSinkJsonWriter.java
@@ -260,6 +260,13 @@ final class BufferedSinkJsonWriter extends JsonWriter {
     return this;
   }
 
+  @Override public JsonWriter value(Boolean value) throws IOException {
+    if (value == null) {
+      return nullValue();
+    }
+    return value(value.booleanValue());
+  }
+
   @Override public JsonWriter value(double value) throws IOException {
     if (Double.isNaN(value) || Double.isInfinite(value)) {
       throw new IllegalArgumentException("Numeric values must be finite, but was " + value);

--- a/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
@@ -231,6 +231,13 @@ public abstract class JsonWriter implements Closeable, Flushable {
   /**
    * Encodes {@code value}.
    *
+   * @return this writer.
+   */
+  public abstract JsonWriter value(Boolean value) throws IOException;
+
+  /**
+   * Encodes {@code value}.
+   *
    * @param value a finite value. May not be {@linkplain Double#isNaN() NaNs} or
    *     {@linkplain Double#isInfinite() infinities}.
    * @return this writer.

--- a/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.java
+++ b/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.java
@@ -76,7 +76,7 @@ final class StandardJsonAdapters {
     }
 
     @Override public void toJson(JsonWriter writer, Boolean value) throws IOException {
-      writer.value(value);
+      writer.value(value.booleanValue());
     }
 
     @Override public String toString() {

--- a/moshi/src/test/java/com/squareup/moshi/BufferedSinkJsonWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/BufferedSinkJsonWriterTest.java
@@ -292,6 +292,17 @@ public final class BufferedSinkJsonWriterTest {
     assertThat(buffer.readUtf8()).isEqualTo("[true,false]");
   }
 
+  @Test public void boxedBooleans() throws IOException {
+    Buffer buffer = new Buffer();
+    JsonWriter jsonWriter = JsonWriter.of(buffer);
+    jsonWriter.beginArray();
+    jsonWriter.value((Boolean) true);
+    jsonWriter.value((Boolean) false);
+    jsonWriter.value((Boolean) null);
+    jsonWriter.endArray();
+    assertThat(buffer.readUtf8()).isEqualTo("[true,false,null]");
+  }
+
   @Test public void nulls() throws IOException {
     Buffer buffer = new Buffer();
     JsonWriter jsonWriter = JsonWriter.of(buffer);


### PR DESCRIPTION
Autoboxing resolves boxed longs and doubles to `value(Number)`, but a boxed boolean would otherwise resolve to `value(boolean)` with an implicit call to `booleanValue()` which has the potential to throw NPEs.

Same change as https://github.com/google/gson/pull/836