### PR TITLE
Ignore BOM

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/BufferedSourceJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/BufferedSourceJsonReader.java
@@ -240,8 +240,7 @@ final class BufferedSourceJsonReader extends JsonReader {
     int peekStack = stack[stackSize - 1];
 
     if (peekStack == JsonScope.EMPTY_DOCUMENT
-            && source.request(BYTE_ORDER_MARK.size())
-            && buffer.indexOf(BYTE_ORDER_MARK) == 0) {
+            && source.rangeEquals(0, BYTE_ORDER_MARK)) {
       buffer.skip(BYTE_ORDER_MARK.size());
     }
 

--- a/moshi/src/main/java/com/squareup/moshi/BufferedSourceJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/BufferedSourceJsonReader.java
@@ -29,6 +29,7 @@ final class BufferedSourceJsonReader extends JsonReader {
   private static final ByteString UNQUOTED_STRING_TERMINALS
       = ByteString.encodeUtf8("{}[]:, \n\t\r\f/\\;#=");
   private static final ByteString LINEFEED_OR_CARRIAGE_RETURN = ByteString.encodeUtf8("\n\r");
+  private static final ByteString BYTE_ORDER_MARK = ByteString.encodeUtf8("\ufeff");
 
   private static final int PEEKED_NONE = 0;
   private static final int PEEKED_BEGIN_OBJECT = 1;
@@ -236,6 +237,9 @@ final class BufferedSourceJsonReader extends JsonReader {
   }
 
   private int doPeek() throws IOException {
+    if (stackSize == 1 && buffer.indexOf(BYTE_ORDER_MARK) == 0) {
+      this.buffer.skip(BYTE_ORDER_MARK.size());
+    }
     int peekStack = stack[stackSize - 1];
     if (peekStack == JsonScope.EMPTY_ARRAY) {
       stack[stackSize - 1] = JsonScope.NONEMPTY_ARRAY;

--- a/moshi/src/main/java/com/squareup/moshi/BufferedSourceJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/BufferedSourceJsonReader.java
@@ -238,7 +238,7 @@ final class BufferedSourceJsonReader extends JsonReader {
 
   private int doPeek() throws IOException {
     if (stackSize == 1
-            && buffer.request(BYTE_ORDER_MARK.size())
+            && source.request(BYTE_ORDER_MARK.size())
             && buffer.indexOf(BYTE_ORDER_MARK) == 0) {
       buffer.skip(BYTE_ORDER_MARK.size());
     }

--- a/moshi/src/main/java/com/squareup/moshi/BufferedSourceJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/BufferedSourceJsonReader.java
@@ -237,12 +237,14 @@ final class BufferedSourceJsonReader extends JsonReader {
   }
 
   private int doPeek() throws IOException {
-    if (stackSize == 1
+    int peekStack = stack[stackSize - 1];
+
+    if (peekStack == JsonScope.EMPTY_DOCUMENT
             && source.request(BYTE_ORDER_MARK.size())
             && buffer.indexOf(BYTE_ORDER_MARK) == 0) {
       buffer.skip(BYTE_ORDER_MARK.size());
     }
-    int peekStack = stack[stackSize - 1];
+
     if (peekStack == JsonScope.EMPTY_ARRAY) {
       stack[stackSize - 1] = JsonScope.NONEMPTY_ARRAY;
     } else if (peekStack == JsonScope.NONEMPTY_ARRAY) {

--- a/moshi/src/main/java/com/squareup/moshi/BufferedSourceJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/BufferedSourceJsonReader.java
@@ -237,7 +237,9 @@ final class BufferedSourceJsonReader extends JsonReader {
   }
 
   private int doPeek() throws IOException {
-    if (stackSize == 1 && buffer.indexOf(BYTE_ORDER_MARK) == 0) {
+    if (stackSize == 1
+            && buffer.request(BYTE_ORDER_MARK.size())
+            && buffer.indexOf(BYTE_ORDER_MARK) == 0) {
       buffer.skip(BYTE_ORDER_MARK.size());
     }
     int peekStack = stack[stackSize - 1];

--- a/moshi/src/main/java/com/squareup/moshi/BufferedSourceJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/BufferedSourceJsonReader.java
@@ -238,7 +238,7 @@ final class BufferedSourceJsonReader extends JsonReader {
 
   private int doPeek() throws IOException {
     if (stackSize == 1 && buffer.indexOf(BYTE_ORDER_MARK) == 0) {
-      this.buffer.skip(BYTE_ORDER_MARK.size());
+      buffer.skip(BYTE_ORDER_MARK.size());
     }
     int peekStack = stack[stackSize - 1];
     if (peekStack == JsonScope.EMPTY_ARRAY) {

--- a/moshi/src/test/java/com/squareup/moshi/BufferedSourceJsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/BufferedSourceJsonReaderTest.java
@@ -1366,7 +1366,7 @@ public final class BufferedSourceJsonReaderTest {
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
   }
 
-  @Test @Ignore public void bomIgnoredAsFirstCharacterOfDocument() throws IOException {
+  @Test public void bomIgnoredAsFirstCharacterOfDocument() throws IOException {
     JsonReader reader = newReader("\ufeff[]");
     reader.beginArray();
     reader.endArray();

--- a/moshi/src/test/java/com/squareup/moshi/BufferedSourceJsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/BufferedSourceJsonReaderTest.java
@@ -1421,7 +1421,7 @@ public final class BufferedSourceJsonReaderTest {
     testFailWithPosition("Expected value at path $[1]", "[\n\n\"\\\n\n\",}");
   }
 
-  @Test @Ignore public void failWithPositionIsOffsetByBom() throws IOException {
+  @Test public void failWithPositionIsOffsetByBom() throws IOException {
     testFailWithPosition("Expected value at path $[1]", "\ufeff[\"a\",}]");
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <java.version>1.7</java.version>
 
     <!-- Dependencies -->
-    <okio.version>1.8.0</okio.version>
+    <okio.version>1.9.0</okio.version>
 
     <!-- Test Dependencies -->
     <junit.version>4.12</junit.version>


### PR DESCRIPTION
Ignore byte order mark when doing first peek. Fixes #169 