### PR TITLE
Limit to 31 levels of nested structure.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/BufferedSourceJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/BufferedSourceJsonReader.java
@@ -92,17 +92,17 @@ final class BufferedSourceJsonReader extends JsonReader {
    */
   private String peekedString;
 
-  /*
-   * The nesting stack. Using a manual array rather than an ArrayList saves 20%.
-   */
-  private int[] stack = new int[32];
+  // The nesting stack. Using a manual array rather than an ArrayList saves 20%. This stack permits
+  // up to 32 levels of nesting including the top-level document. Deeper nesting is prone to trigger
+  // StackOverflowErrors.
+  private final int[] stack = new int[32];
   private int stackSize = 0;
   {
     stack[stackSize++] = JsonScope.EMPTY_DOCUMENT;
   }
 
-  private String[] pathNames = new String[32];
-  private int[] pathIndices = new int[32];
+  private final String[] pathNames = new String[32];
+  private final int[] pathIndices = new int[32];
 
   BufferedSourceJsonReader(BufferedSource source) {
     if (source == null) {
@@ -901,15 +901,7 @@ final class BufferedSourceJsonReader extends JsonReader {
 
   private void push(int newTop) {
     if (stackSize == stack.length) {
-      int[] newStack = new int[stackSize * 2];
-      int[] newPathIndices = new int[stackSize * 2];
-      String[] newPathNames = new String[stackSize * 2];
-      System.arraycopy(stack, 0, newStack, 0, stackSize);
-      System.arraycopy(pathIndices, 0, newPathIndices, 0, stackSize);
-      System.arraycopy(pathNames, 0, newPathNames, 0, stackSize);
-      stack = newStack;
-      pathIndices = newPathIndices;
-      pathNames = newPathNames;
+      throw new JsonDataException("Nesting too deep at " + getPath());
     }
     stack[stackSize++] = newTop;
   }

--- a/moshi/src/main/java/com/squareup/moshi/JsonDataException.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonDataException.java
@@ -22,6 +22,10 @@ package com.squareup.moshi;
  *
  * <p>Exceptions of this type should be fixed by either changing the application code to accept
  * the unexpected JSON, or by changing the JSON to conform to the application's expectations.
+ *
+ * <p>This exception may also be triggered if a document's nesting exceeds 31 levels. This depth is
+ * sufficient for all practical applications, but shallow enough to avoid uglier failures like
+ * {@link StackOverflowError}.
  */
 public final class JsonDataException extends RuntimeException {
   public JsonDataException() {

--- a/moshi/src/main/java/com/squareup/moshi/MapJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/MapJsonAdapter.java
@@ -50,7 +50,7 @@ final class MapJsonAdapter<K, V> extends JsonAdapter<Map<K, V>> {
     writer.beginObject();
     for (Map.Entry<K, V> entry : map.entrySet()) {
       if (entry.getKey() == null) {
-        throw new JsonDataException("Map key is null at path " + writer.getPath());
+        throw new JsonDataException("Map key is null at " + writer.getPath());
       }
       writer.promoteNameToValue();
       keyAdapter.toJson(writer, entry.getKey());

--- a/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
@@ -23,7 +23,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import okio.Buffer;
 import org.assertj.core.data.MapEntry;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static com.squareup.moshi.TestUtil.newReader;
@@ -57,7 +56,7 @@ public final class MapJsonAdapterTest {
       toJson(String.class, Boolean.class, map);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Map key is null at path $.");
+      assertThat(expected).hasMessage("Map key is null at $.");
     }
   }
 


### PR DESCRIPTION
With the implicit enclosing document this is 32 levels total. The limit
is arbitrary but sufficient - deeper limits yield code that fails with
StackOverflowExceptions during the depth-first traversal.

We were previously broken in JsonWriter on this - the code we added to
support path building was accessing the top of the stack before the
stack had been resized, causing a crash. Because this crash has existed
forever without much outcry we know the limit is likely sufficient for
our existing users.

Closes: https://github.com/square/moshi/issues/189