### PR TITLE
Fix Long parsing for large values.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/BufferedSourceJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/BufferedSourceJsonReader.java
@@ -17,6 +17,7 @@ package com.squareup.moshi;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.math.BigDecimal;
 import okio.Buffer;
 import okio.BufferedSource;
 import okio.ByteString;
@@ -718,15 +719,15 @@ final class BufferedSourceJsonReader extends JsonReader {
     }
 
     peeked = PEEKED_BUFFERED;
-    double asDouble;
+    BigDecimal asDecimal;
     try {
-      asDouble = Double.parseDouble(peekedString);
+      asDecimal = new BigDecimal(peekedString);
     } catch (NumberFormatException e) {
       throw new JsonDataException("Expected a long but was " + peekedString
           + " at path " + getPath());
     }
-    long result = (long) asDouble;
-    if (result != asDouble) { // Make sure no precision was lost casting to 'long'.
+    long result = asDecimal.longValue();
+    if (result != asDecimal.doubleValue()) { // Make sure no precision was lost casting to 'long'.
       throw new JsonDataException("Expected a long but was " + peekedString
           + " at path " + getPath());
     }

--- a/moshi/src/test/java/com/squareup/moshi/BufferedSourceJsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/BufferedSourceJsonReaderTest.java
@@ -621,7 +621,7 @@ public final class BufferedSourceJsonReaderTest {
    * This test fails because there's no double for 9223372036854775808, and our
    * long parsing uses Double.parseDouble() for fractional values.
    */
-  @Test @Ignore public void peekLargerThanLongMaxValue() throws IOException {
+  @Test public void peekLargerThanLongMaxValue() throws IOException {
     JsonReader reader = newReader("[9223372036854775808]");
     reader.setLenient(true);
     reader.beginArray();

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -433,21 +433,19 @@ public final class MoshiTest {
     assertThat(adapter.fromJson("9223372036854775807")).isEqualTo(Long.MAX_VALUE);
     assertThat(adapter.toJson(Long.MAX_VALUE)).isEqualTo("9223372036854775807");
 
-    // TODO: This is a bug?
-    assertThat(adapter.fromJson("9223372036854775808")).isEqualTo(Long.MAX_VALUE); // wtf?
-    //try {
-    //  adapter.fromJson("9223372036854775808");
-    //  fail();
-    //} catch (NumberFormatException expected) {
-    //  assertThat(expected).hasMessage("Expected a long but was 9223372036854775808 at path $");
-    //}
-    //
-    //try {
-    //  adapter.fromJson("-9223372036854775809");
-    //  fail();
-    //} catch (NumberFormatException expected) {
-    //  assertThat(expected).hasMessage("Expected a long but was -9223372036854775809 at path $");
-    //}
+    try {
+      adapter.fromJson("9223372036854775808");
+      fail();
+    } catch (JsonDataException expected) {
+      assertThat(expected).hasMessage("Expected a long but was 9223372036854775808 at path $");
+    }
+
+    try {
+      adapter.fromJson("-9223372036854775809");
+      fail();
+    } catch (JsonDataException expected) {
+      assertThat(expected).hasMessage("Expected a long but was -9223372036854775809 at path $");
+    }
 
     // Nulls not allowed for long.class
     try {


### PR DESCRIPTION
Made `BufferedSourceJsonReader#nextLong()` to rely on `BigDecemal` instead of `Double`. 