### PR TITLE
JsonAdapter.indent(String indent)

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
@@ -136,6 +136,31 @@ public abstract class JsonAdapter<T> {
     };
   }
 
+  /**
+   * Return a JSON adapter equal to this, but with pretty printing instead of the default compact form.
+   */
+  public JsonAdapter<T> indent(final String indent) {
+    final JsonAdapter<T> delegate = this;
+    return new JsonAdapter<T>() {
+
+      @Override
+      public T fromJson(JsonReader reader) throws IOException {
+        return delegate.fromJson(reader);
+      }
+
+      @Override
+      public void toJson(JsonWriter writer, T value) throws IOException {
+        writer.setIndent(indent);
+        delegate.toJson(writer, value);
+      }
+
+      @Override
+      public String toString() {
+        return delegate + ".indent(" + indent + ")";
+      }
+    };
+  }
+
   public interface Factory {
     /**
      * Attempts to create an adapter for {@code type} annotated with {@code annotations}. This

--- a/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
@@ -68,7 +68,7 @@ import okio.BufferedSink;
  * This code encodes the above structure: <pre>   {@code
  *   public void writeJsonStream(BufferedSink sink, List<Message> messages) throws IOException {
  *     JsonWriter writer = JsonWriter.of(sink);
- *     writer.setIndentSpaces(4);
+ *     writer.setIndent("    ");
  *     writeMessagesArray(writer, messages);
  *     writer.close();
  *   }

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -190,6 +190,8 @@ public final class Moshi {
       return add(AdapterMethodsFactory.get(adapter));
     }
 
+    public Builder setPrettyPrinting() { return this; }
+
     Builder addAll(List<JsonAdapter.Factory> factories) {
       this.factories.addAll(factories);
       return this;

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -190,8 +190,6 @@ public final class Moshi {
       return add(AdapterMethodsFactory.get(adapter));
     }
 
-    public Builder setPrettyPrinting() { return this; }
-
     Builder addAll(List<JsonAdapter.Factory> factories) {
       this.factories.addAll(factories);
       return this;

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -33,6 +33,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import javax.crypto.KeyGenerator;
+
+import okio.Buffer;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -548,17 +550,24 @@ public final class MoshiTest {
 
   @Test public void setPrettyPrinting() throws Exception {
     Moshi moshi = new Moshi.Builder()
-            .setPrettyPrinting() 
             .add(Pizza.class, new PizzaAdapter())
             .build();
+    JsonAdapter<Pizza> jsonAdapter = moshi.adapter(Pizza.class).indent("  ");
 
+    Pizza pizza = new Pizza(15, true);
     String expectedJson = "{\n" +
             "  \"size\": 15,\n" +
             "  \"extra cheese\": true\n" +
             "}";
-    JsonAdapter<Pizza> jsonAdapter = moshi.adapter(Pizza.class);
-    assertThat(jsonAdapter.toJson(new Pizza(15, true)))
-            .isEqualTo(expectedJson);
+
+    assertThat(jsonAdapter.toJson(pizza)).isEqualTo(expectedJson);
+
+    Buffer buffer = new Buffer();
+    jsonAdapter.toJson(buffer, pizza);
+    assertThat(buffer.readUtf8()).isEqualTo(expectedJson);
+
+
+
   }
 
   @Test public void composingJsonAdapterFactory() throws Exception {

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -546,6 +546,21 @@ public final class MoshiTest {
         .isEqualTo(new Pizza(18, true));
   }
 
+  @Test public void setPrettyPrinting() throws Exception {
+    Moshi moshi = new Moshi.Builder()
+            .setPrettyPrinting() 
+            .add(Pizza.class, new PizzaAdapter())
+            .build();
+
+    String expectedJson = "{\n" +
+            "  \"size\": 15,\n" +
+            "  \"extra cheese\": true\n" +
+            "}";
+    JsonAdapter<Pizza> jsonAdapter = moshi.adapter(Pizza.class);
+    assertThat(jsonAdapter.toJson(new Pizza(15, true)))
+            .isEqualTo(expectedJson);
+  }
+
   @Test public void composingJsonAdapterFactory() throws Exception {
     Moshi moshi = new Moshi.Builder()
         .add(new MealDealAdapterFactory())


### PR DESCRIPTION
Hello, 

Researching how to output human readable (prettyprinted) json turns to more longer as expected, which I don't regret because okio, okio.Buffer and JsonWriter are super interesting 👍 

My code now contains

```kotlin
fun  <T> JsonAdapter<T>.toPrettyJson(value: T, indent: String = "  ") : String {
    val buffer = Buffer()
    val writer = JsonWriter.of(buffer).apply { setIndent(indent) }
    toJson(writer, value)
    return buffer.readUtf8()
}
```

Still it's such a common use case, could a configuration option be added?

I implemented a failing test to explain myself in code, borrowing from `gson` 

[Gson: Compact Vs. Pretty Printing for JSON Output Format](https://github.com/google/gson/blob/master/UserGuide.md#TOC-Compact-Vs.-Pretty-Printing-for-JSON-Output-Format)

