### PR TITLE
Improve error message for qualified platform types

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -111,11 +111,11 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
      */
     private boolean isPlatformType(Class<?> rawType) {
       String name = rawType.getName();
-      return name.startsWith("android.")
+      return (name.startsWith("android.")
           || name.startsWith("java.")
           || name.startsWith("javax.")
           || name.startsWith("kotlin.")
-          || name.startsWith("scala.");
+          || name.startsWith("scala.")) && !Types.isAllowedPlatformType(rawType);
     }
 
     /** Returns true if fields with {@code modifiers} are included in the emitted JSON. */

--- a/moshi/src/main/java/com/squareup/moshi/Types.java
+++ b/moshi/src/main/java/com/squareup/moshi/Types.java
@@ -386,6 +386,22 @@ public final class Types {
     return unknown;
   }
 
+  /**
+   * Returns true if this is a Type supported by {@link StandardJsonAdapters#FACTORY}.
+   */
+  static boolean isAllowedPlatformType(Type type) {
+    return type == Boolean.class
+        || type == Byte.class
+        || type == Character.class
+        || type == Double.class
+        || type == Float.class
+        || type == Integer.class
+        || type == Long.class
+        || type == Short.class
+        || type == String.class
+        || type == Object.class;
+  }
+
   private static int indexOf(Object[] array, Object toFind) {
     for (int i = 0; i < array.length; i++) {
       if (toFind.equals(array[i])) return i;

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -776,6 +776,19 @@ public final class MoshiTest {
     }
   }
 
+  @Test public void noTypeAdapterForQualifiedPlatformType() throws Exception {
+    Moshi moshi = new Moshi.Builder().build();
+    Field uppercaseStringField = MoshiTest.class.getDeclaredField("uppercaseString");
+    try {
+      moshi.adapter(uppercaseStringField.getGenericType(),
+          Util.jsonAnnotations(uppercaseStringField));
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessage("No JsonAdapter for class java.lang.String "
+          + "annotated [@com.squareup.moshi.MoshiTest$Uppercase()]");
+    }
+  }
+
   @Test public void objectArray() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<String[]> adapter = moshi.adapter(String[].class);


### PR DESCRIPTION
Previously, the ClassJsonAdapter saw the platform type and gave its `IllegalArgumentException: Platform {type} annotated {annotations} requires explicit JsonAdapter to be registered`.
If the platform types are allowed but are just not caught by an adapter because they are qualified, they should fall through to the "no adapter found" Moshi error.