### PR TITLE
Implement promoteValueToName() for ObjectJsonWriter.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/BufferedSinkJsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/BufferedSinkJsonWriter.java
@@ -62,8 +62,6 @@ final class BufferedSinkJsonWriter extends JsonWriter {
 
   private String deferredName;
 
-  private boolean promoteNameToValue;
-
   BufferedSinkJsonWriter(BufferedSink sink) {
     if (sink == null) {
       throw new NullPointerException("sink == null");
@@ -92,7 +90,7 @@ final class BufferedSinkJsonWriter extends JsonWriter {
   }
 
   @Override public JsonWriter endObject() throws IOException {
-    promoteNameToValue = false;
+    promoteValueToName = false;
     return close(EMPTY_OBJECT, NONEMPTY_OBJECT, "}");
   }
 
@@ -143,7 +141,7 @@ final class BufferedSinkJsonWriter extends JsonWriter {
     }
     deferredName = name;
     pathNames[stackSize - 1] = name;
-    promoteNameToValue = false;
+    promoteValueToName = false;
     return this;
   }
 
@@ -159,7 +157,7 @@ final class BufferedSinkJsonWriter extends JsonWriter {
     if (value == null) {
       return nullValue();
     }
-    if (promoteNameToValue) {
+    if (promoteValueToName) {
       return name(value);
     }
     writeDeferredName();
@@ -203,7 +201,7 @@ final class BufferedSinkJsonWriter extends JsonWriter {
     if (!lenient && (Double.isNaN(value) || Double.isInfinite(value))) {
       throw new IllegalArgumentException("Numeric values must be finite, but was " + value);
     }
-    if (promoteNameToValue) {
+    if (promoteValueToName) {
       return name(Double.toString(value));
     }
     writeDeferredName();
@@ -214,7 +212,7 @@ final class BufferedSinkJsonWriter extends JsonWriter {
   }
 
   @Override public JsonWriter value(long value) throws IOException {
-    if (promoteNameToValue) {
+    if (promoteValueToName) {
       return name(Long.toString(value));
     }
     writeDeferredName();
@@ -234,7 +232,7 @@ final class BufferedSinkJsonWriter extends JsonWriter {
         && (string.equals("-Infinity") || string.equals("Infinity") || string.equals("NaN"))) {
       throw new IllegalArgumentException("Numeric values must be finite, but was " + value);
     }
-    if (promoteNameToValue) {
+    if (promoteValueToName) {
       return name(string);
     }
     writeDeferredName();
@@ -368,13 +366,5 @@ final class BufferedSinkJsonWriter extends JsonWriter {
       default:
         throw new IllegalStateException("Nesting problem.");
     }
-  }
-
-  @Override void promoteNameToValue() throws IOException {
-    int context = peekScope();
-    if (context != NONEMPTY_OBJECT && context != EMPTY_OBJECT) {
-      throw new IllegalStateException("Nesting problem.");
-    }
-    promoteNameToValue = true;
   }
 }

--- a/moshi/src/main/java/com/squareup/moshi/MapJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/MapJsonAdapter.java
@@ -52,7 +52,7 @@ final class MapJsonAdapter<K, V> extends JsonAdapter<Map<K, V>> {
       if (entry.getKey() == null) {
         throw new JsonDataException("Map key is null at " + writer.getPath());
       }
-      writer.promoteNameToValue();
+      writer.promoteValueToName();
       keyAdapter.toJson(writer, entry.getKey());
       valueAdapter.toJson(writer, entry.getValue());
     }

--- a/moshi/src/main/java/com/squareup/moshi/ObjectJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/ObjectJsonReader.java
@@ -273,10 +273,10 @@ final class ObjectJsonReader extends JsonReader {
   }
 
   @Override void promoteNameToValue() throws IOException {
-    Map.Entry<?, ?> peeked = require(Map.Entry.class, Token.NAME);
-
-    push(peeked.getKey());
-    stack[stackSize - 2] = peeked.getValue();
+    if (hasNext()) {
+      String name = nextName();
+      push(name);
+    }
   }
 
   @Override public void close() throws IOException {

--- a/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
@@ -125,6 +125,22 @@ public final class MapJsonAdapterTest {
         MapEntry.entry(5, true), MapEntry.entry(6, false), MapEntry.entry(7, null));
   }
 
+  @Test public void mapWithNonStringKeysToJsonObject() throws Exception {
+    Map<Integer, Boolean> map = new LinkedHashMap<>();
+    map.put(5, true);
+    map.put(6, false);
+    map.put(7, null);
+
+    Map<String, Boolean> jsonObject = new LinkedHashMap<>();
+    jsonObject.put("5", true);
+    jsonObject.put("6", false);
+    jsonObject.put("7", null);
+
+    JsonAdapter<Map<Integer, Boolean>> jsonAdapter = mapAdapter(Integer.class, Boolean.class);
+    assertThat(jsonAdapter.serializeNulls().toJsonObject(map)).isEqualTo(jsonObject);
+    assertThat(jsonAdapter.fromJsonObject(jsonObject)).isEqualTo(map);
+  }
+
   private <K, V> String toJson(Type keyType, Type valueType, Map<K, V> value) throws IOException {
     JsonAdapter<Map<K, V>> jsonAdapter = mapAdapter(keyType, valueType);
     Buffer buffer = new Buffer();


### PR DESCRIPTION
This was renamed from promoteNameToValue(). Also run the test on both types of
codecs and fix some implementation issues that uncovered.