### PR TITLE
Add Types.nextAnnotations

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/Types.java
+++ b/moshi/src/main/java/com/squareup/moshi/Types.java
@@ -28,15 +28,41 @@ import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
+import java.util.Set;
 
 /** Factory methods for types. */
 public final class Types {
   static final Type[] EMPTY_TYPE_ARRAY = new Type[] {};
 
   private Types() {
+  }
+
+  /**
+   * Checks if {@code annotations} contains {@code jsonQualifier}.
+   * Returns the subset of {@code annotations} without {@code jsonQualifier}, or null if {@code
+   * annotations} does not contain {@code jsonQualifier}.
+   */
+  public static Set<? extends Annotation> nextAnnotations(Set<? extends Annotation> annotations,
+      Class<? extends Annotation> jsonQualifier) {
+    if (!jsonQualifier.isAnnotationPresent(JsonQualifier.class)) {
+      throw new IllegalArgumentException(jsonQualifier + " is not a JsonQualifier.");
+    }
+    if (annotations.isEmpty()) {
+      return null;
+    }
+    for (Annotation annotation : annotations) {
+      if (jsonQualifier.equals(annotation.annotationType())) {
+        Set<Annotation> delegateAnnotations = new LinkedHashSet<>(annotations);
+        delegateAnnotations.remove(annotation);
+        return Collections.unmodifiableSet(delegateAnnotations);
+      }
+    }
+    return null;
   }
 
   /**

--- a/moshi/src/test/java/com/squareup/moshi/TypesTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/TypesTest.java
@@ -15,13 +15,17 @@
  */
 package com.squareup.moshi;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import org.junit.Test;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -29,6 +33,44 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 public final class TypesTest {
+  @Retention(RUNTIME) @JsonQualifier @interface TestQualifier {
+  }
+
+  @Retention(RUNTIME) @JsonQualifier @interface AnotherTestQualifier {
+  }
+
+  @Retention(RUNTIME) @interface TestAnnotation {
+  }
+
+  @TestQualifier private Object hasTestQualifier;
+
+  @Test public void nextAnnotationsRequiresJsonAnnotation() throws Exception {
+    try {
+      Types.nextAnnotations(Collections.<Annotation>emptySet(), TestAnnotation.class);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessage(
+          "interface com.squareup.moshi.TypesTest$TestAnnotation is not a JsonQualifier.");
+    }
+  }
+
+  @Test public void nextAnnotationsDoesNotContainReturnsNull() throws Exception {
+    Set<? extends Annotation> annotations =
+        Collections.singleton(Types.createJsonQualifierImplementation(AnotherTestQualifier.class));
+    assertThat(Types.nextAnnotations(annotations, TestQualifier.class)).isNull();
+    assertThat(
+        Types.nextAnnotations(Collections.<Annotation>emptySet(), TestQualifier.class)).isNull();
+  }
+
+  @Test public void nextAnnotationsReturnsDelegateAnnotations() throws Exception {
+    Set<Annotation> annotations = new LinkedHashSet<>(2);
+    annotations.add(Types.createJsonQualifierImplementation(TestQualifier.class));
+    annotations.add(Types.createJsonQualifierImplementation(AnotherTestQualifier.class));
+    Set<AnotherTestQualifier> expected =
+        Collections.singleton(Types.createJsonQualifierImplementation(AnotherTestQualifier.class));
+    assertThat(Types.nextAnnotations(Collections.unmodifiableSet(annotations), TestQualifier.class))
+        .isEqualTo(expected);
+  }
 
   @Test public void newParameterizedType() throws Exception {
     // List<A>. List is a top-level class.
@@ -149,16 +191,11 @@ public final class TypesTest {
   @Test public void createJsonQualifierImplementation() throws Exception {
     TestQualifier actual = Types.createJsonQualifierImplementation(TestQualifier.class);
     TestQualifier expected =
-        (TestQualifier) TypesTest.class.getDeclaredField("unused").getAnnotations()[0];
+        (TestQualifier) TypesTest.class.getDeclaredField("hasTestQualifier").getAnnotations()[0];
     assertThat(actual.annotationType()).isEqualTo(TestQualifier.class);
     assertThat(actual).isEqualTo(expected);
     assertThat(actual).isNotEqualTo(null);
     assertThat(actual.hashCode()).isEqualTo(expected.hashCode());
     assertThat(actual.getClass()).isNotEqualTo(TestQualifier.class);
-  }
-
-  @TestQualifier private static Object unused;
-
-  @Retention(RUNTIME) @JsonQualifier @interface TestQualifier {
   }
 }


### PR DESCRIPTION
This is useful for JsonAdapter factories.
From https://github.com/square/moshi/pull/236/files#r98377813

The method is a little weird because it is both `hasJsonQualifier` (null means false) and `nextAnnotations`.

~~Maybe this method should not also be `hasJsonQualifier`, though. Maybe this method should just throw an IllegalArgumentException instead of returning null?
The combination of these two methods is not a real performance (`annotations.contains(jsonQualifier)` is O(1)) or simplicity gain.~~
Edit: wasn't thinking, forgetting that we don't have the jsonQualifier instance.