### PR TITLE
Fix isPlatformType

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -46,7 +46,7 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
         Type type, Set<? extends Annotation> annotations, Moshi moshi) {
       Class<?> rawType = Types.getRawType(type);
       if (rawType.isInterface() || rawType.isEnum()) return null;
-      if (isPlatformType(rawType)) {
+      if (isPlatformType(rawType) && !Types.isAllowedPlatformType(rawType)) {
         throw new IllegalArgumentException("Platform "
             + type
             + " annotated "
@@ -111,11 +111,11 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
      */
     private boolean isPlatformType(Class<?> rawType) {
       String name = rawType.getName();
-      return (name.startsWith("android.")
+      return name.startsWith("android.")
           || name.startsWith("java.")
           || name.startsWith("javax.")
           || name.startsWith("kotlin.")
-          || name.startsWith("scala.")) && !Types.isAllowedPlatformType(rawType);
+          || name.startsWith("scala.");
     }
 
     /** Returns true if fields with {@code modifiers} are included in the emitted JSON. */


### PR DESCRIPTION
createFieldBindings should not take the allowed platform types into
account.

Uh, so this isn't effectively a problem, and I'm nitpicking my change and improving readability. Figured I'd post here, anyway!

https://github.com/NightlyNexus/moshi/blob/e43252582ab74fe578a15591a683d5e5582d1a40/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java#L83 should not create bindings for private fields of these allowed platform types.
This isn't effectively a problem because the StandardJsonAdapters factory is installed first, and a lot of other things would break before this could ever be a problem.