### PR TITLE
Update doc with how to parse JSONArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,31 @@ JsonAdapter<Event> jsonAdapter = moshi.adapter(Event.class);
 Event event = jsonAdapter.fromJson(json);
 ```
 
+### Parse JSON Arrays
+Say we have a JSON string of this structure:
+
+```java
+[
+	 {
+	   "rank": "4",
+	   "suit": "CLUBS"
+	 },
+	 {
+	   "rank": "A",
+	   "suit": "HEARTS"
+	 }
+]
+```
+
+We can now use Moshi to parse the JSON string into a `List<Card>`.
+
+```java
+final String cardsJsonResponse = ...;
+Type type = Types.newParameterizedType(List.class, Card.class);
+JsonAdapter<List<Card>> adapter = moshi.adapter(type);
+List<Card> cards = adapter.fromJson(cardsJsonResponse);
+```
+
 ### Fails Gracefully
 
 Automatic databinding almost feels like magic. But unlike the black magic that typically accompanies


### PR DESCRIPTION
Adds an example to the README file on how to parse the sample JSON string below.

```
[
  {
    "title": "Split",
    "casts": ["James McAvoy","Anya Taylor-Joy"],
    "year": "2016"
  },
  {
    "title": "Rings",
    "casts": ["Matilda Anna Ingrid Lutz","Alex Roe"],
    "year": "2017"
  }
]
```

Personally I had to search for this as I couldn't figure out how to do that with Moshi. See #78  and the [comment](https://github.com/square/moshi/issues/78#issuecomment-249983288)

Ping @swankjesse 