### PR TITLE
Add JsonAdapter.defaultIfDataException(T)

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
@@ -224,6 +224,32 @@ public abstract class JsonAdapter<T> {
     };
   }
 
+  /**
+   * Return a JSON adapter equal to this, but using {@code defaultValue} instead of throwing a
+   * {@linkplain JsonDataException} on data type mismatches.
+   *
+   * @param defaultValue the default value to use as a fallback.
+   */
+  public JsonAdapter<T> defaultIfDataException(final T defaultValue) {
+    final JsonAdapter<T> delegate = this;
+    return new JsonAdapter<T>() {
+      @Override public T fromJson(JsonReader reader) throws IOException {
+        try {
+          Object value = reader.readJsonValue();
+          return delegate.fromJsonValue(value);
+        } catch (JsonDataException e) {
+          return defaultValue;
+        }
+      }
+      @Override public void toJson(JsonWriter writer, T value) throws IOException {
+        delegate.toJson(writer, value);
+      }
+      @Override public String toString() {
+        return delegate + ".defaultIfDataException(\"" + defaultValue + "\")";
+      }
+    };
+  }
+
   public interface Factory {
     /**
      * Attempts to create an adapter for {@code type} annotated with {@code annotations}. This

--- a/moshi/src/test/java/com/squareup/moshi/JsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonAdapterTest.java
@@ -16,11 +16,14 @@
 package com.squareup.moshi;
 
 import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -163,5 +166,72 @@ public final class JsonAdapterTest {
     JsonWriter writer = factory.newWriter();
     serializeNulls.toJson(writer, Collections.<String, String>singletonMap("a", null));
     assertThat(factory.json()).isEqualTo("{\"a\":null}");
+  }
+
+  @Test public void defaultIfDataExceptionInt() throws Exception {
+    Moshi moshi = new Moshi.Builder().build();
+    String json = "\"ZERO\"";
+    JsonAdapter<Integer> adapter = moshi.adapter(int.class).defaultIfDataException(0);
+    assertThat(adapter.fromJson(json)).isEqualTo(0);
+  }
+
+  @Test public void defaultIfDataExceptionCustomType() throws Exception {
+    Moshi moshi = new Moshi.Builder().build();
+    String json = "{\"price\":\"eighty\"}";
+    JsonAdapter<Pizza> adapter = moshi.adapter(Pizza.class).defaultIfDataException(new Pizza(-1));
+    assertThat(adapter.fromJson(json)).isEqualTo(new Pizza(-1));
+  }
+
+  @Test public void defaultIfDataExceptionInNested() throws Exception {
+    JsonAdapter.Factory pizzaFactory = new JsonAdapter.Factory() {
+      @Override
+      public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {
+        if (type != Pizza.class) {
+          return null;
+        }
+        JsonAdapter<Pizza> pizzaAdapter = moshi.nextAdapter(this, type, annotations);
+        return pizzaAdapter.defaultIfDataException(new Pizza(-1));
+      }
+    };
+    Moshi moshi = new Moshi.Builder().add(pizzaFactory).build();
+    String json = "{\"pizza\":{\"price\":\"eighty\"}, \"drink\":\"coke\"}";
+    JsonAdapter<MealDeal> adapter = moshi.adapter(MealDeal.class);
+    assertThat(adapter.fromJson(json)).isEqualTo(new MealDeal(new Pizza(-1), "coke"));
+  }
+
+  private static final class Pizza {
+    final long price;
+
+    Pizza(long price) {
+      this.price = price;
+    }
+
+    @Override public boolean equals(Object o) {
+      return o instanceof Pizza && ((Pizza) o).price == price;
+    }
+
+    @Override public int hashCode() {
+      return (int) (price ^ (price >>> 32));
+    }
+  }
+
+  private static final class MealDeal {
+    final Pizza pizza;
+    final String drink;
+
+    MealDeal(Pizza pizza, String drink) {
+      this.pizza = pizza;
+      this.drink = drink;
+    }
+
+    @Override public boolean equals(Object o) {
+      return o instanceof MealDeal
+          && ((MealDeal) o).pizza.equals(pizza)
+          && ((MealDeal) o).drink.equals(drink);
+    }
+
+    @Override public int hashCode() {
+      return pizza.hashCode() + (31 * drink.hashCode());
+    }
   }
 }


### PR DESCRIPTION
https://github.com/square/moshi/issues/218
Enums are a good use case. Other cases are unfortunate workarounds, and I'm not yet confident this is great to generalize.