### PR TITLE
expecting EncodingException with beginArray() when malformed json

### DIFF
--- a/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
@@ -1227,6 +1227,17 @@ public final class JsonUtf8ReaderTest {
     assertThat(reader.nextString()).isEqualTo("string");
   }
 
+  @Test
+  public void expectEncodingExceptionWhenMalFormedJSON() throws IOException {
+    JsonReader reader = newReader("A");
+    try {
+      reader.beginArray();
+      fail();
+    } catch (JsonEncodingException expected) {
+      assertThat(expected).hasMessage("Use JsonReader.setLenient(true) to accept malformed JSON at path $");
+    }
+  }
+
   private void assertDocument(String document, Object... expectations) throws IOException {
     JsonReader reader = newReader(document);
     reader.setLenient(true);


### PR DESCRIPTION
Hi,

I propose to had the following changes to expect a `JsonEncodingException` while the flag lenient is false.