### PR TITLE
Add support for forcing Moshi to construct instances using a specified constructor

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
@@ -46,8 +46,8 @@ abstract class ClassFactory<T> {
         }
 
         // Try to find a constructor with the JsonConstructor annotation
-        for (int i = 0; i < rawType.getConstructors().length; i++) {
-            final Constructor<?> constructor = rawType.getConstructors()[i];
+        for (int i = 0; i < rawType.getDeclaredConstructors().length; i++) {
+            final Constructor<?> constructor = rawType.getDeclaredConstructors()[i];
             boolean hasAnnotation = constructor.isAnnotationPresent(JsonConstructor.class);
 
             if (hasAnnotation) {

--- a/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
@@ -94,7 +94,6 @@ abstract class ClassFactory<T> {
                             } else {
                                 args[j] = ClassFactory.get(parameterType).newInstance();
                             }
-                            System.out.println("Constructed " + j + "/" + parameterTypes.length);
                         }
 
                         return (T) constructor.newInstance(args);

--- a/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
@@ -30,200 +30,200 @@ import java.util.Map;
  */
 abstract class ClassFactory<T> {
 
-    /**
-     * This can't be a {@link LinkedHashTreeMap} since {@link Class}
-     * does not implement {@link Comparable}.
-     */
-    private static Map<Class<?>, ClassFactory<?>> unsafeFactories = new HashMap<>();
+  /**
+   * This can't be a {@link LinkedHashTreeMap} since {@link Class}
+   * does not implement {@link Comparable}.
+   */
+  private static Map<Class<?>, ClassFactory<?>> unsafeFactories = new HashMap<>();
 
-    abstract T newInstance() throws
-            InvocationTargetException, IllegalAccessException, InstantiationException;
+  abstract T newInstance() throws
+      InvocationTargetException, IllegalAccessException, InstantiationException;
 
-    public static <T> ClassFactory<T> get(final Class<?> rawType) {
-        if (unsafeFactories.containsKey(rawType)) {
-            //noinspection unchecked
-            return (ClassFactory<T>) unsafeFactories.get(rawType);
-        }
-
-        // Try to find a constructor with the JsonConstructor annotation
-        for (int i = 0; i < rawType.getDeclaredConstructors().length; i++) {
-            final Constructor<?> constructor = rawType.getDeclaredConstructors()[i];
-            boolean hasAnnotation = constructor.isAnnotationPresent(JsonConstructor.class);
-
-            if (hasAnnotation) {
-                constructor.setAccessible(true);
-                ClassFactory<T> factory = new ClassFactory<T>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    T newInstance() throws InvocationTargetException, IllegalAccessException, InstantiationException {
-                        Class<?>[] parameterTypes = constructor.getParameterTypes();
-                        Object[] args = new Object[parameterTypes.length];
-                        for (int j = 0; j < parameterTypes.length; j++) {
-                            Class<?> parameterType = parameterTypes[j];
-                            // Default values according to
-                            // https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html
-                            if (parameterType == byte.class || parameterType == Byte.class) {
-                                args[j] = (byte) 0;
-                            } else if (parameterType == short.class || parameterType == Short.class) {
-                                args[j] = (short) 0;
-                            } else if (parameterType == int.class || parameterType == Integer.class) {
-                                args[j] = 0;
-                            } else if (parameterType == long.class || parameterType == Long.class) {
-                                args[j] = 0L;
-                            } else if (parameterType == float.class || parameterType == Float.class) {
-                                args[j] = 0f;
-                            } else if (parameterType == double.class || parameterType == Double.class) {
-                                args[j] = 0.0;
-                            } else if (parameterType == char.class || parameterType == Character.class) {
-                                args[j] = '\u0000';
-                            } else if (parameterType == boolean.class || parameterType == Boolean.class) {
-                                args[j] = false;
-                            } else if (parameterType == String.class) {
-                                args[j] = "";
-                            } else if (parameterType.isInterface()) {
-                                args[j] = Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{parameterType}, new InvocationHandler() {
-                                    @Override
-                                    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-                                        throw new IllegalAccessException("Trying to call a method on a " +
-                                                "stub object created by Moshi as requested using the JsonConstructor" +
-                                                "annotation.");
-                                    }
-                                });
-                            } else if (parameterType.isEnum() && parameterType.getEnumConstants().length > 0) {
-                                args[j] = parameterType.getEnumConstants()[0];
-                            } else {
-                                args[j] = ClassFactory.get(parameterType).newInstance();
-                            }
-                        }
-
-                        return (T) constructor.newInstance(args);
-                    }
-
-                    @Override
-                    public String toString() {
-                        return rawType.getName();
-                    }
-                };
-                unsafeFactories.put(rawType, factory);
-                return factory;
-            }
-        }
-
-        // Try to find a no-args constructor. May be any visibility including private.
-        try {
-            final Constructor<?> constructor = rawType.getDeclaredConstructor();
-            constructor.setAccessible(true);
-            ClassFactory<T> factory = new ClassFactory<T>() {
-                @SuppressWarnings("unchecked") // T is the same raw type as is requested
-                @Override
-                public T newInstance() throws IllegalAccessException, InvocationTargetException,
-                        InstantiationException {
-                    Object[] args = null;
-                    return (T) constructor.newInstance(args);
-                }
-
-                @Override
-                public String toString() {
-                    return rawType.getName();
-                }
-            };
-            unsafeFactories.put(rawType, factory);
-            return factory;
-        } catch (NoSuchMethodException ignored) {
-            // No no-args constructor. Fall back to something more magical...
-        }
-
-        // Try the JVM's Unsafe mechanism.
-        // public class Unsafe {
-        //   public Object allocateInstance(Class<?> type);
-        // }
-        try {
-            Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
-            Field f = unsafeClass.getDeclaredField("theUnsafe");
-            f.setAccessible(true);
-            final Object unsafe = f.get(null);
-            final Method allocateInstance = unsafeClass.getMethod("allocateInstance", Class.class);
-            ClassFactory<T> factory = new ClassFactory<T>() {
-                @SuppressWarnings("unchecked")
-                @Override
-                public T newInstance() throws InvocationTargetException, IllegalAccessException {
-                    return (T) allocateInstance.invoke(unsafe, rawType);
-                }
-
-                @Override
-                public String toString() {
-                    return rawType.getName();
-                }
-            };
-            unsafeFactories.put(rawType, factory);
-            return factory;
-        } catch (IllegalAccessException e) {
-            throw new AssertionError();
-        } catch (ClassNotFoundException | NoSuchMethodException | NoSuchFieldException ignored) {
-            // Not the expected version of the Oracle Java library!
-        }
-
-        // Try (post-Gingerbread) Dalvik/libcore's ObjectStreamClass mechanism.
-        // public class ObjectStreamClass {
-        //   private static native int getConstructorId(Class<?> c);
-        //   private static native Object newInstance(Class<?> instantiationClass, int methodId);
-        // }
-        try {
-            Method getConstructorId = ObjectStreamClass.class.getDeclaredMethod(
-                    "getConstructorId", Class.class);
-            getConstructorId.setAccessible(true);
-            final int constructorId = (Integer) getConstructorId.invoke(null, Object.class);
-            final Method newInstance = ObjectStreamClass.class.getDeclaredMethod("newInstance",
-                    Class.class, int.class);
-            newInstance.setAccessible(true);
-            ClassFactory<T> factory = new ClassFactory<T>() {
-                @SuppressWarnings("unchecked")
-                @Override
-                public T newInstance() throws InvocationTargetException, IllegalAccessException {
-                    return (T) newInstance.invoke(null, rawType, constructorId);
-                }
-
-                @Override
-                public String toString() {
-                    return rawType.getName();
-                }
-            };
-            unsafeFactories.put(rawType, factory);
-            return factory;
-        } catch (IllegalAccessException e) {
-            throw new AssertionError();
-        } catch (InvocationTargetException e) {
-            throw new RuntimeException(e);
-        } catch (NoSuchMethodException ignored) {
-            // Not the expected version of Dalvik/libcore!
-        }
-
-        // Try (pre-Gingerbread) Dalvik/libcore's ObjectInputStream mechanism.
-        // public class ObjectInputStream {
-        //   private static native Object newInstance(
-        //     Class<?> instantiationClass, Class<?> constructorClass);
-        // }
-        try {
-            final Method newInstance = ObjectInputStream.class.getDeclaredMethod(
-                    "newInstance", Class.class, Class.class);
-            newInstance.setAccessible(true);
-            ClassFactory<T> factory = new ClassFactory<T>() {
-                @SuppressWarnings("unchecked")
-                @Override
-                public T newInstance() throws InvocationTargetException, IllegalAccessException {
-                    return (T) newInstance.invoke(null, rawType, Object.class);
-                }
-
-                @Override
-                public String toString() {
-                    return rawType.getName();
-                }
-            };
-            unsafeFactories.put(rawType, factory);
-            return factory;
-        } catch (Exception ignored) {
-        }
-
-        throw new IllegalArgumentException("cannot construct instances of " + rawType.getName());
+  public static <T> ClassFactory<T> get(final Class<?> rawType) {
+    if (unsafeFactories.containsKey(rawType)) {
+      //noinspection unchecked
+      return (ClassFactory<T>) unsafeFactories.get(rawType);
     }
+
+    // Try to find a constructor with the JsonConstructor annotation
+    for (int i = 0; i < rawType.getDeclaredConstructors().length; i++) {
+      final Constructor<?> constructor = rawType.getDeclaredConstructors()[i];
+      boolean hasAnnotation = constructor.isAnnotationPresent(JsonConstructor.class);
+
+      if (hasAnnotation) {
+        constructor.setAccessible(true);
+        ClassFactory<T> factory = new ClassFactory<T>() {
+          @SuppressWarnings("unchecked")
+          @Override
+          T newInstance() throws InvocationTargetException, IllegalAccessException, InstantiationException {
+            Class<?>[] parameterTypes = constructor.getParameterTypes();
+            Object[] args = new Object[parameterTypes.length];
+            for (int j = 0; j < parameterTypes.length; j++) {
+              Class<?> parameterType = parameterTypes[j];
+              // Default values according to
+              // https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html
+              if (parameterType == byte.class || parameterType == Byte.class) {
+                args[j] = (byte) 0;
+              } else if (parameterType == short.class || parameterType == Short.class) {
+                args[j] = (short) 0;
+              } else if (parameterType == int.class || parameterType == Integer.class) {
+                args[j] = 0;
+              } else if (parameterType == long.class || parameterType == Long.class) {
+                args[j] = 0L;
+              } else if (parameterType == float.class || parameterType == Float.class) {
+                args[j] = 0f;
+              } else if (parameterType == double.class || parameterType == Double.class) {
+                args[j] = 0.0;
+              } else if (parameterType == char.class || parameterType == Character.class) {
+                args[j] = '\u0000';
+              } else if (parameterType == boolean.class || parameterType == Boolean.class) {
+                args[j] = false;
+              } else if (parameterType == String.class) {
+                args[j] = "";
+              } else if (parameterType.isInterface()) {
+                args[j] = Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{parameterType}, new InvocationHandler() {
+                  @Override
+                  public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                    throw new IllegalAccessException("Trying to call a method on a " +
+                        "stub object created by Moshi as requested using the JsonConstructor" +
+                        "annotation.");
+                  }
+                });
+              } else if (parameterType.isEnum() && parameterType.getEnumConstants().length > 0) {
+                args[j] = parameterType.getEnumConstants()[0];
+              } else {
+                args[j] = ClassFactory.get(parameterType).newInstance();
+              }
+            }
+
+            return (T) constructor.newInstance(args);
+          }
+
+          @Override
+          public String toString() {
+            return rawType.getName();
+          }
+        };
+        unsafeFactories.put(rawType, factory);
+        return factory;
+      }
+    }
+
+    // Try to find a no-args constructor. May be any visibility including private.
+    try {
+      final Constructor<?> constructor = rawType.getDeclaredConstructor();
+      constructor.setAccessible(true);
+      ClassFactory<T> factory = new ClassFactory<T>() {
+        @SuppressWarnings("unchecked") // T is the same raw type as is requested
+        @Override
+        public T newInstance() throws IllegalAccessException, InvocationTargetException,
+            InstantiationException {
+          Object[] args = null;
+          return (T) constructor.newInstance(args);
+        }
+
+        @Override
+        public String toString() {
+          return rawType.getName();
+        }
+      };
+      unsafeFactories.put(rawType, factory);
+      return factory;
+    } catch (NoSuchMethodException ignored) {
+      // No no-args constructor. Fall back to something more magical...
+    }
+
+    // Try the JVM's Unsafe mechanism.
+    // public class Unsafe {
+    //   public Object allocateInstance(Class<?> type);
+    // }
+    try {
+      Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+      Field f = unsafeClass.getDeclaredField("theUnsafe");
+      f.setAccessible(true);
+      final Object unsafe = f.get(null);
+      final Method allocateInstance = unsafeClass.getMethod("allocateInstance", Class.class);
+      ClassFactory<T> factory = new ClassFactory<T>() {
+        @SuppressWarnings("unchecked")
+        @Override
+        public T newInstance() throws InvocationTargetException, IllegalAccessException {
+          return (T) allocateInstance.invoke(unsafe, rawType);
+        }
+
+        @Override
+        public String toString() {
+          return rawType.getName();
+        }
+      };
+      unsafeFactories.put(rawType, factory);
+      return factory;
+    } catch (IllegalAccessException e) {
+      throw new AssertionError();
+    } catch (ClassNotFoundException | NoSuchMethodException | NoSuchFieldException ignored) {
+      // Not the expected version of the Oracle Java library!
+    }
+
+    // Try (post-Gingerbread) Dalvik/libcore's ObjectStreamClass mechanism.
+    // public class ObjectStreamClass {
+    //   private static native int getConstructorId(Class<?> c);
+    //   private static native Object newInstance(Class<?> instantiationClass, int methodId);
+    // }
+    try {
+      Method getConstructorId = ObjectStreamClass.class.getDeclaredMethod(
+          "getConstructorId", Class.class);
+      getConstructorId.setAccessible(true);
+      final int constructorId = (Integer) getConstructorId.invoke(null, Object.class);
+      final Method newInstance = ObjectStreamClass.class.getDeclaredMethod("newInstance",
+          Class.class, int.class);
+      newInstance.setAccessible(true);
+      ClassFactory<T> factory = new ClassFactory<T>() {
+        @SuppressWarnings("unchecked")
+        @Override
+        public T newInstance() throws InvocationTargetException, IllegalAccessException {
+          return (T) newInstance.invoke(null, rawType, constructorId);
+        }
+
+        @Override
+        public String toString() {
+          return rawType.getName();
+        }
+      };
+      unsafeFactories.put(rawType, factory);
+      return factory;
+    } catch (IllegalAccessException e) {
+      throw new AssertionError();
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e);
+    } catch (NoSuchMethodException ignored) {
+      // Not the expected version of Dalvik/libcore!
+    }
+
+    // Try (pre-Gingerbread) Dalvik/libcore's ObjectInputStream mechanism.
+    // public class ObjectInputStream {
+    //   private static native Object newInstance(
+    //     Class<?> instantiationClass, Class<?> constructorClass);
+    // }
+    try {
+      final Method newInstance = ObjectInputStream.class.getDeclaredMethod(
+          "newInstance", Class.class, Class.class);
+      newInstance.setAccessible(true);
+      ClassFactory<T> factory = new ClassFactory<T>() {
+        @SuppressWarnings("unchecked")
+        @Override
+        public T newInstance() throws InvocationTargetException, IllegalAccessException {
+          return (T) newInstance.invoke(null, rawType, Object.class);
+        }
+
+        @Override
+        public String toString() {
+          return rawType.getName();
+        }
+      };
+      unsafeFactories.put(rawType, factory);
+      return factory;
+    } catch (Exception ignored) {
+    }
+
+    throw new IllegalArgumentException("cannot construct instances of " + rawType.getName());
+  }
 }

--- a/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
@@ -17,10 +17,9 @@ package com.squareup.moshi;
 
 import java.io.ObjectInputStream;
 import java.io.ObjectStreamClass;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import java.lang.reflect.*;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Magic that creates instances of arbitrary concrete classes. Derived from Gson's UnsafeAllocator
@@ -30,105 +29,202 @@ import java.lang.reflect.Method;
  * @author Jesse Wilson
  */
 abstract class ClassFactory<T> {
-  abstract T newInstance() throws
-      InvocationTargetException, IllegalAccessException, InstantiationException;
 
-  public static <T> ClassFactory<T> get(final Class<?> rawType) {
-    // Try to find a no-args constructor. May be any visibility including private.
-    try {
-      final Constructor<?> constructor = rawType.getDeclaredConstructor();
-      constructor.setAccessible(true);
-      return new ClassFactory<T>() {
-        @SuppressWarnings("unchecked") // T is the same raw type as is requested
-        @Override public T newInstance() throws IllegalAccessException, InvocationTargetException,
-            InstantiationException {
-          Object[] args = null;
-          return (T) constructor.newInstance(args);
+    /**
+     * This can't be a {@link LinkedHashTreeMap} since {@link Class}
+     * does not implement {@link Comparable}.
+     */
+    private static Map<Class<?>, ClassFactory<?>> unsafeFactories = new HashMap<>();
+
+    abstract T newInstance() throws
+            InvocationTargetException, IllegalAccessException, InstantiationException;
+
+    public static <T> ClassFactory<T> get(final Class<?> rawType) {
+        if (unsafeFactories.containsKey(rawType)) {
+            //noinspection unchecked
+            return (ClassFactory<T>) unsafeFactories.get(rawType);
         }
-        @Override public String toString() {
-          return rawType.getName();
+
+        // Try to find a constructor with the JsonConstructor annotation
+        for (int i = 0; i < rawType.getConstructors().length; i++) {
+            final Constructor<?> constructor = rawType.getConstructors()[i];
+            boolean hasAnnotation = constructor.isAnnotationPresent(JsonConstructor.class);
+
+            if (hasAnnotation) {
+                constructor.setAccessible(true);
+                ClassFactory<T> factory = new ClassFactory<T>() {
+                    @SuppressWarnings("unchecked")
+                    @Override
+                    T newInstance() throws InvocationTargetException, IllegalAccessException, InstantiationException {
+                        Class<?>[] parameterTypes = constructor.getParameterTypes();
+                        Object[] args = new Object[parameterTypes.length];
+                        for (int j = 0; j < parameterTypes.length; j++) {
+                            Class<?> parameterType = parameterTypes[j];
+                            // Default values according to
+                            // https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html
+                            if (parameterType == byte.class || parameterType == Byte.class) {
+                                args[j] = (byte) 0;
+                            } else if (parameterType == short.class || parameterType == Short.class) {
+                                args[j] = (short) 0;
+                            } else if (parameterType == int.class || parameterType == Integer.class) {
+                                args[j] = 0;
+                            } else if (parameterType == long.class || parameterType == Long.class) {
+                                args[j] = 0L;
+                            } else if (parameterType == float.class || parameterType == Float.class) {
+                                args[j] = 0f;
+                            } else if (parameterType == double.class || parameterType == Double.class) {
+                                args[j] = 0.0;
+                            } else if (parameterType == char.class || parameterType == Character.class) {
+                                args[j] = '\u0000';
+                            } else if (parameterType == boolean.class || parameterType == Boolean.class) {
+                                args[j] = false;
+                            } else if (parameterType == String.class) {
+                                args[j] = "";
+                            } else if (parameterType.isInterface()) {
+                                args[j] = Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{parameterType}, new InvocationHandler() {
+                                    @Override
+                                    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                                        throw new IllegalAccessException("Trying to call a method on a " +
+                                                "stub object created by Moshi as requested using the JsonConstructor" +
+                                                "annotation.");
+                                    }
+                                });
+                            } else if (parameterType.isEnum() && parameterType.getEnumConstants().length > 0) {
+                                args[j] = parameterType.getEnumConstants()[0];
+                            } else {
+                                args[j] = ClassFactory.get(parameterType).newInstance();
+                            }
+                            System.out.println("Constructed " + j + "/" + parameterTypes.length);
+                        }
+
+                        return (T) constructor.newInstance(args);
+                    }
+
+                    @Override
+                    public String toString() {
+                        return rawType.getName();
+                    }
+                };
+                unsafeFactories.put(rawType, factory);
+                return factory;
+            }
         }
-      };
-    } catch (NoSuchMethodException ignored) {
-      // No no-args constructor. Fall back to something more magical...
+
+        // Try to find a no-args constructor. May be any visibility including private.
+        try {
+            final Constructor<?> constructor = rawType.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            ClassFactory<T> factory = new ClassFactory<T>() {
+                @SuppressWarnings("unchecked") // T is the same raw type as is requested
+                @Override
+                public T newInstance() throws IllegalAccessException, InvocationTargetException,
+                        InstantiationException {
+                    Object[] args = null;
+                    return (T) constructor.newInstance(args);
+                }
+
+                @Override
+                public String toString() {
+                    return rawType.getName();
+                }
+            };
+            unsafeFactories.put(rawType, factory);
+            return factory;
+        } catch (NoSuchMethodException ignored) {
+            // No no-args constructor. Fall back to something more magical...
+        }
+
+        // Try the JVM's Unsafe mechanism.
+        // public class Unsafe {
+        //   public Object allocateInstance(Class<?> type);
+        // }
+        try {
+            Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+            Field f = unsafeClass.getDeclaredField("theUnsafe");
+            f.setAccessible(true);
+            final Object unsafe = f.get(null);
+            final Method allocateInstance = unsafeClass.getMethod("allocateInstance", Class.class);
+            ClassFactory<T> factory = new ClassFactory<T>() {
+                @SuppressWarnings("unchecked")
+                @Override
+                public T newInstance() throws InvocationTargetException, IllegalAccessException {
+                    return (T) allocateInstance.invoke(unsafe, rawType);
+                }
+
+                @Override
+                public String toString() {
+                    return rawType.getName();
+                }
+            };
+            unsafeFactories.put(rawType, factory);
+            return factory;
+        } catch (IllegalAccessException e) {
+            throw new AssertionError();
+        } catch (ClassNotFoundException | NoSuchMethodException | NoSuchFieldException ignored) {
+            // Not the expected version of the Oracle Java library!
+        }
+
+        // Try (post-Gingerbread) Dalvik/libcore's ObjectStreamClass mechanism.
+        // public class ObjectStreamClass {
+        //   private static native int getConstructorId(Class<?> c);
+        //   private static native Object newInstance(Class<?> instantiationClass, int methodId);
+        // }
+        try {
+            Method getConstructorId = ObjectStreamClass.class.getDeclaredMethod(
+                    "getConstructorId", Class.class);
+            getConstructorId.setAccessible(true);
+            final int constructorId = (Integer) getConstructorId.invoke(null, Object.class);
+            final Method newInstance = ObjectStreamClass.class.getDeclaredMethod("newInstance",
+                    Class.class, int.class);
+            newInstance.setAccessible(true);
+            ClassFactory<T> factory = new ClassFactory<T>() {
+                @SuppressWarnings("unchecked")
+                @Override
+                public T newInstance() throws InvocationTargetException, IllegalAccessException {
+                    return (T) newInstance.invoke(null, rawType, constructorId);
+                }
+
+                @Override
+                public String toString() {
+                    return rawType.getName();
+                }
+            };
+            unsafeFactories.put(rawType, factory);
+            return factory;
+        } catch (IllegalAccessException e) {
+            throw new AssertionError();
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        } catch (NoSuchMethodException ignored) {
+            // Not the expected version of Dalvik/libcore!
+        }
+
+        // Try (pre-Gingerbread) Dalvik/libcore's ObjectInputStream mechanism.
+        // public class ObjectInputStream {
+        //   private static native Object newInstance(
+        //     Class<?> instantiationClass, Class<?> constructorClass);
+        // }
+        try {
+            final Method newInstance = ObjectInputStream.class.getDeclaredMethod(
+                    "newInstance", Class.class, Class.class);
+            newInstance.setAccessible(true);
+            ClassFactory<T> factory = new ClassFactory<T>() {
+                @SuppressWarnings("unchecked")
+                @Override
+                public T newInstance() throws InvocationTargetException, IllegalAccessException {
+                    return (T) newInstance.invoke(null, rawType, Object.class);
+                }
+
+                @Override
+                public String toString() {
+                    return rawType.getName();
+                }
+            };
+            unsafeFactories.put(rawType, factory);
+            return factory;
+        } catch (Exception ignored) {
+        }
+
+        throw new IllegalArgumentException("cannot construct instances of " + rawType.getName());
     }
-
-    // Try the JVM's Unsafe mechanism.
-    // public class Unsafe {
-    //   public Object allocateInstance(Class<?> type);
-    // }
-    try {
-      Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
-      Field f = unsafeClass.getDeclaredField("theUnsafe");
-      f.setAccessible(true);
-      final Object unsafe = f.get(null);
-      final Method allocateInstance = unsafeClass.getMethod("allocateInstance", Class.class);
-      return new ClassFactory<T>() {
-        @SuppressWarnings("unchecked")
-        @Override public T newInstance() throws InvocationTargetException, IllegalAccessException {
-          return (T) allocateInstance.invoke(unsafe, rawType);
-        }
-        @Override public String toString() {
-          return rawType.getName();
-        }
-      };
-    } catch (IllegalAccessException e) {
-      throw new AssertionError();
-    } catch (ClassNotFoundException | NoSuchMethodException | NoSuchFieldException ignored) {
-      // Not the expected version of the Oracle Java library!
-    }
-
-    // Try (post-Gingerbread) Dalvik/libcore's ObjectStreamClass mechanism.
-    // public class ObjectStreamClass {
-    //   private static native int getConstructorId(Class<?> c);
-    //   private static native Object newInstance(Class<?> instantiationClass, int methodId);
-    // }
-    try {
-      Method getConstructorId = ObjectStreamClass.class.getDeclaredMethod(
-          "getConstructorId", Class.class);
-      getConstructorId.setAccessible(true);
-      final int constructorId = (Integer) getConstructorId.invoke(null, Object.class);
-      final Method newInstance = ObjectStreamClass.class.getDeclaredMethod("newInstance",
-          Class.class, int.class);
-      newInstance.setAccessible(true);
-      return new ClassFactory<T>() {
-        @SuppressWarnings("unchecked")
-        @Override public T newInstance() throws InvocationTargetException, IllegalAccessException {
-          return (T) newInstance.invoke(null, rawType, constructorId);
-        }
-        @Override public String toString() {
-          return rawType.getName();
-        }
-      };
-    } catch (IllegalAccessException e) {
-      throw new AssertionError();
-    } catch (InvocationTargetException e) {
-      throw new RuntimeException(e);
-    } catch (NoSuchMethodException ignored) {
-      // Not the expected version of Dalvik/libcore!
-    }
-
-    // Try (pre-Gingerbread) Dalvik/libcore's ObjectInputStream mechanism.
-    // public class ObjectInputStream {
-    //   private static native Object newInstance(
-    //     Class<?> instantiationClass, Class<?> constructorClass);
-    // }
-    try {
-      final Method newInstance = ObjectInputStream.class.getDeclaredMethod(
-          "newInstance", Class.class, Class.class);
-      newInstance.setAccessible(true);
-      return new ClassFactory<T>() {
-        @SuppressWarnings("unchecked")
-        @Override public T newInstance() throws InvocationTargetException, IllegalAccessException {
-          return (T) newInstance.invoke(null, rawType, Object.class);
-        }
-        @Override public String toString() {
-          return rawType.getName();
-        }
-      };
-    } catch (Exception ignored) {
-    }
-
-    throw new IllegalArgumentException("cannot construct instances of " + rawType.getName());
-  }
 }

--- a/moshi/src/main/java/com/squareup/moshi/JsonConstructor.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonConstructor.java
@@ -1,0 +1,13 @@
+package com.squareup.moshi;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotate a single constructor with this annotation
+ * to force Moshi to call it with default values for
+ * primitive types and empty instances for reference types.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JsonConstructor {
+}

--- a/moshi/src/test/java/com/squareup/moshi/JsonConstructorTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonConstructorTest.java
@@ -32,10 +32,22 @@ public class JsonConstructorTest {
       this.date = date;
       this.runnable = runnable;
     }
+
+    DemoModel() {
+      throw new UnsupportedOperationException("Should call annotated constructor");
+    }
   }
 
   enum Enum {
     VALUE
+  }
+
+  static class InvalidModel {
+    @JsonConstructor InvalidModel(int i) {
+    }
+
+    @JsonConstructor InvalidModel(String s) {
+    }
   }
 
   @Test public void testJsonConstructorAnnotation()
@@ -56,6 +68,12 @@ public class JsonConstructorTest {
     ClassFactory<DemoModel> factory = ClassFactory.get(DemoModel.class);
     DemoModel demoModel = factory.newInstance();
     demoModel.runnable.run();
+  }
+
+  @Test(expected = IllegalArgumentException.class) public void testChecksForMultipleAnnotatedConstructors()
+      throws IllegalAccessException, InstantiationException, InvocationTargetException {
+    ClassFactory<InvalidModel> factory = ClassFactory.get(InvalidModel.class);
+    InvalidModel invalidModel = factory.newInstance();
   }
 
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonConstructorTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonConstructorTest.java
@@ -17,10 +17,11 @@ public class JsonConstructorTest {
     private final List<?> list;
     private final Enum testEnum;
     private final Date date;
+    private final Runnable runnable;
 
-    @JsonConstructor
-    DemoModel(short s, int i, Integer i2,
-              String str, List<?> list, Enum testEnum, Date date) {
+    @JsonConstructor DemoModel(short s, int i, Integer i2,
+                               String str, List<?> list, Enum testEnum, Date date,
+                               Runnable runnable) {
 
       this.s = s;
       this.i = i;
@@ -29,6 +30,7 @@ public class JsonConstructorTest {
       this.list = list;
       this.testEnum = testEnum;
       this.date = date;
+      this.runnable = runnable;
     }
   }
 
@@ -36,23 +38,24 @@ public class JsonConstructorTest {
     VALUE
   }
 
-  @Test
-  public void testJsonConstructorAnnotation() {
-    try {
-      ClassFactory<DemoModel> factory = ClassFactory.get(DemoModel.class);
-      DemoModel demoModel = factory.newInstance();
-      Assert.assertEquals(0, demoModel.s);
-      Assert.assertEquals(0, demoModel.i);
-      Assert.assertEquals(Integer.valueOf(0), demoModel.i2);
-      Assert.assertEquals("", demoModel.str);
-      Assert.assertNotNull("Interface parameters should be passed proxy objects.", demoModel.list);
-      Assert.assertEquals("Enum parameters should be passed the first enum value.", Enum.VALUE, demoModel.testEnum);
-      Assert.assertNotNull("Other objects should be created using a no-arg constructor.", demoModel.date);
-    } catch (IllegalArgumentException e) {
-      Assert.fail("Should be able to construct ClassFactory.");
-    } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
-      Assert.fail("Should be able to construct object using ClassFactory.");
-    }
+  @Test public void testJsonConstructorAnnotation()
+      throws IllegalAccessException, InstantiationException, InvocationTargetException {
+    ClassFactory<DemoModel> factory = ClassFactory.get(DemoModel.class);
+    DemoModel demoModel = factory.newInstance();
+    Assert.assertEquals(0, demoModel.s);
+    Assert.assertEquals(0, demoModel.i);
+    Assert.assertEquals(Integer.valueOf(0), demoModel.i2);
+    Assert.assertEquals("", demoModel.str);
+    Assert.assertNotNull("Interface parameters should be passed proxy objects.", demoModel.list);
+    Assert.assertEquals("Enum parameters should be passed the first enum value.", Enum.VALUE, demoModel.testEnum);
+    Assert.assertNotNull("Other objects should be created using a no-arg constructor.", demoModel.date);
+  }
+
+  @Test(expected = UnsupportedOperationException.class) public void testProxyThrows()
+      throws IllegalAccessException, InstantiationException, InvocationTargetException {
+    ClassFactory<DemoModel> factory = ClassFactory.get(DemoModel.class);
+    DemoModel demoModel = factory.newInstance();
+    demoModel.runnable.run();
   }
 
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonConstructorTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonConstructorTest.java
@@ -1,0 +1,58 @@
+package com.squareup.moshi;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Date;
+import java.util.List;
+
+public class JsonConstructorTest {
+
+    static class DemoModel {
+        private final short s;
+        private final int i;
+        private final Integer i2;
+        private final String str;
+        private final List<?> list;
+        private final Enum testEnum;
+        private final Date date;
+
+        @JsonConstructor
+        DemoModel(short s, int i, Integer i2,
+                  String str, List<?> list, Enum testEnum, Date date) {
+
+            this.s = s;
+            this.i = i;
+            this.i2 = i2;
+            this.str = str;
+            this.list = list;
+            this.testEnum = testEnum;
+            this.date = date;
+        }
+    }
+
+    enum Enum {
+        VALUE
+    }
+
+    @Test
+    public void testJsonConstructorAnnotation() {
+        try {
+            ClassFactory<DemoModel> factory = ClassFactory.get(DemoModel.class);
+            DemoModel demoModel = factory.newInstance();
+            Assert.assertEquals(0, demoModel.s);
+            Assert.assertEquals(0, demoModel.i);
+            Assert.assertEquals(Integer.valueOf(0), demoModel.i2);
+            Assert.assertEquals("", demoModel.str);
+            Assert.assertNotNull("Interface parameters should be passed proxy objects.", demoModel.list);
+            Assert.assertEquals("Enum parameters should be passed the first enum value.", Enum.VALUE, demoModel.testEnum);
+            Assert.assertNotNull("Other objects should be created using a no-arg constructor.", demoModel.date);
+        } catch (IllegalArgumentException e) {
+            Assert.fail("Should be able to construct ClassFactory.");
+        } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
+            Assert.fail("Should be able to construct object using ClassFactory.");
+        }
+    }
+
+}

--- a/moshi/src/test/java/com/squareup/moshi/JsonConstructorTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonConstructorTest.java
@@ -9,50 +9,50 @@ import java.util.List;
 
 public class JsonConstructorTest {
 
-    static class DemoModel {
-        private final short s;
-        private final int i;
-        private final Integer i2;
-        private final String str;
-        private final List<?> list;
-        private final Enum testEnum;
-        private final Date date;
+  static class DemoModel {
+    private final short s;
+    private final int i;
+    private final Integer i2;
+    private final String str;
+    private final List<?> list;
+    private final Enum testEnum;
+    private final Date date;
 
-        @JsonConstructor
-        DemoModel(short s, int i, Integer i2,
-                  String str, List<?> list, Enum testEnum, Date date) {
+    @JsonConstructor
+    DemoModel(short s, int i, Integer i2,
+              String str, List<?> list, Enum testEnum, Date date) {
 
-            this.s = s;
-            this.i = i;
-            this.i2 = i2;
-            this.str = str;
-            this.list = list;
-            this.testEnum = testEnum;
-            this.date = date;
-        }
+      this.s = s;
+      this.i = i;
+      this.i2 = i2;
+      this.str = str;
+      this.list = list;
+      this.testEnum = testEnum;
+      this.date = date;
     }
+  }
 
-    enum Enum {
-        VALUE
-    }
+  enum Enum {
+    VALUE
+  }
 
-    @Test
-    public void testJsonConstructorAnnotation() {
-        try {
-            ClassFactory<DemoModel> factory = ClassFactory.get(DemoModel.class);
-            DemoModel demoModel = factory.newInstance();
-            Assert.assertEquals(0, demoModel.s);
-            Assert.assertEquals(0, demoModel.i);
-            Assert.assertEquals(Integer.valueOf(0), demoModel.i2);
-            Assert.assertEquals("", demoModel.str);
-            Assert.assertNotNull("Interface parameters should be passed proxy objects.", demoModel.list);
-            Assert.assertEquals("Enum parameters should be passed the first enum value.", Enum.VALUE, demoModel.testEnum);
-            Assert.assertNotNull("Other objects should be created using a no-arg constructor.", demoModel.date);
-        } catch (IllegalArgumentException e) {
-            Assert.fail("Should be able to construct ClassFactory.");
-        } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
-            Assert.fail("Should be able to construct object using ClassFactory.");
-        }
+  @Test
+  public void testJsonConstructorAnnotation() {
+    try {
+      ClassFactory<DemoModel> factory = ClassFactory.get(DemoModel.class);
+      DemoModel demoModel = factory.newInstance();
+      Assert.assertEquals(0, demoModel.s);
+      Assert.assertEquals(0, demoModel.i);
+      Assert.assertEquals(Integer.valueOf(0), demoModel.i2);
+      Assert.assertEquals("", demoModel.str);
+      Assert.assertNotNull("Interface parameters should be passed proxy objects.", demoModel.list);
+      Assert.assertEquals("Enum parameters should be passed the first enum value.", Enum.VALUE, demoModel.testEnum);
+      Assert.assertNotNull("Other objects should be created using a no-arg constructor.", demoModel.date);
+    } catch (IllegalArgumentException e) {
+      Assert.fail("Should be able to construct ClassFactory.");
+    } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
+      Assert.fail("Should be able to construct object using ClassFactory.");
     }
+  }
 
 }


### PR DESCRIPTION
This PR implements a method to force Moshi to construct instances of specific types using a constructor annotation. The main use case is Kotlin, but I imagine this could apply to Java code as well. Consider the following example:

```
data class Foo(val bar: Bar) {
  @delegate:Transient val fooBar by lazy { doSomethingWith(bar) }
}
```

Currently, Moshi supports deserializing a JSON into this type by unsafely creating the object, bypassing the constructor. A workaround is the [Kotlin no-arg plugin](https://blog.jetbrains.com/kotlin/2016/12/kotlin-1-0-6-is-here/) introduced in Kotlin 1.0.6 which generates an empty constructor for annotated classes, but unfortunately both ways are problematic, as they don't initialize the hidden delegate instance for the `lazy` property.

This problem is solved by the PR. The following modification is required in the code:

```
data class Foo @JsonConstructor constructor(val bar: Bar) {
  @delegate:Transient val fooBar by lazy { doSomethingWith(bar) }
}
```

This change will tell Moshi to use the primary constructor to construct the object. The way Moshi generates values for the parameters of the constructor after this PR is pretty straight-forward:

- Primitive types and their associated reference types get the default value, such as `0` for `int` and `Integer`, `0.0` for `double` and `Double` and so on.
- Strings get `""`.
- Interfaces get a proxy instance that simply throws on method calls.
- Enums get the first value in the `values` field.
- Other types are recursively constructed using `ClassFactory.get(...).newInstance()`.

To reduce cost, `ClassFactory` instances are cached. The reason why parameters of reference types aren't simply set to `null` is that constructors may check for parameters to be non-null. Kotlin does this by default.

Afterwards, Moshi proceeds as normal by deserializing the JSON values into the appropriate fields of the newly created instance. However, since the real constructor was called, the delegate is initialized correctly.