### PR TITLE
Add kotlin-module with support for Kotlin data classes

### DIFF
--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -11,10 +11,6 @@
 
   <artifactId>moshi-kotlin</artifactId>
 
-  <properties>
-    <kotlin.version>1.1.1</kotlin.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>com.squareup.moshi</groupId>
@@ -34,17 +30,14 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>${kotlin.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-reflect</artifactId>
-      <version>${kotlin.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-test</artifactId>
-      <version>${kotlin.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -54,7 +47,6 @@
       <plugin>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-maven-plugin</artifactId>
-        <version>${kotlin.version}</version>
         <executions>
           <execution>
             <id>compile</id>
@@ -94,6 +86,5 @@
       </plugin>
     </plugins>
   </build>
-
 
 </project>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.squareup.moshi</groupId>
+    <artifactId>moshi-parent</artifactId>
+    <version>1.5.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>moshi-kotlin</artifactId>
+
+  <properties>
+    <kotlin.version>1.1.1</kotlin.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.squareup.moshi</groupId>
+      <artifactId>moshi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-reflect</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-test</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>testCompile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+
+</project>

--- a/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
+++ b/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
@@ -21,7 +21,7 @@ import kotlin.reflect.jvm.javaField
  *
  * Moshi will call its primary constructor to create the object. This allows for delegated properties
  * to be initialized correctly. If the JSON does not contain a value for a parameter with a default value
- * the default value is used. If no default value is present an [IllegalArgumentException] will be
+ * the default value is used. If no default value is present a [JsonDataException] will be
  * thrown during deserialization.
  *
  * Data classes to be (de-)serialized must conform to the following rules:
@@ -124,7 +124,7 @@ internal class KotlinJsonAdapter<T>(
 
       for (param in constructor.parameters) {
         if (!param.isOptional && param !in valuesByParam) {
-          throw IllegalArgumentException("JSON is missing value for ${param.name}")
+          throw JsonDataException("JSON is missing value for ${param.name}")
         }
       }
 

--- a/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
+++ b/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
@@ -61,8 +61,8 @@ class KotlinJsonAdapterFactory(private val crashOnMissingValues: Boolean = false
                 .asSequence()
                 .filterNot { it.isOptional }
                 .map { concretePropertyByName[it.name]!! }
-                .filter { it.findAnnotation<Transient>() != null }
-                .forEach { throw IllegalArgumentException("Transient properties in primary constructor are unsupported.") }
+                .firstOrNull { it.findAnnotation<Transient>() != null }
+                ?.run { throw IllegalArgumentException("Transient properties in primary constructor are unsupported.") }
 
         val isPlatformType = isPlatformType(Types.getRawType(type))
         val notIncludedParams = constructorParameterByName

--- a/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
+++ b/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
@@ -62,7 +62,7 @@ class KotlinJsonAdapterFactory(private val crashOnMissingValues: Boolean = false
         .filterNot { it.isOptional }
         .map { concretePropertyByName[it.name]!! }
         .firstOrNull { it.findAnnotation<Transient>() != null }
-        ?.run { throw IllegalArgumentException("Transient properties in primary constructor are unsupported.") }
+        ?.let { throw IllegalArgumentException("Transient properties in primary constructor are unsupported. ($it)") }
 
     val isPlatformType = isPlatformType(Types.getRawType(type))
     val notIncludedParams = constructorParameterByName

--- a/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
+++ b/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
@@ -1,0 +1,148 @@
+@file:Suppress("UNCHECKED_CAST")
+
+package com.squareup.moshi
+
+import com.squareup.moshi.ClassJsonAdapter.includeField
+import com.squareup.moshi.ClassJsonAdapter.isPlatformType
+import java.lang.reflect.Modifier
+import java.lang.reflect.Type
+import kotlin.reflect.KFunction
+import kotlin.reflect.KParameter
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.isAccessible
+import kotlin.reflect.jvm.javaField
+
+/**
+ * A [JsonAdapter.Factory] for Kotlin data classes. If this is added to Moshi,
+ * data classes will be treated differently from other classes.
+ *
+ * Moshi will call its primary constructor to create the object. This allows for delegated properties
+ * to be initialized correctly. If the JSON does not contain a value for a parameter with a default value
+ * and [crashOnMissingValues] is set to false, the default value is used. If no default value is present,
+ * an [IllegalArgumentException] will be thrown during deserialization.
+ *
+ * Data classes to be (de-)serialized must conform to the following rules:
+ *
+ * - Any properties not found in the primary constructor must be transient, including delegated properties.
+ * - The primary constructor may not contain transient properties unless a default value is provided.
+ * - If the class is a platform type (kotlin.*), it may not contain private fields.
+ */
+class KotlinJsonAdapterFactory(private val crashOnMissingValues: Boolean = false) : JsonAdapter.Factory {
+    override fun create(type: Type, annotations: MutableSet<out Annotation>, moshi: Moshi): JsonAdapter<*>? {
+        val kclass = (type as? Class<*>)?.kotlin ?: return null
+        if (!kclass.isData) return null
+        // This gives us a few guarantees:
+        // 1. Primary constructor exists
+        // 2. Constructor params are var/val and have backing fields
+        // 3. Class is not abstract or an interface
+        // 4. Class is final
+
+        val constructor = kclass.primaryConstructor!!
+        constructor.isAccessible = true
+
+        val concretePropertyByName = kclass.declaredMemberProperties
+                .filter { it.javaField != null }
+                .associateBy { it.name }
+        val constructorParameterByName = constructor.parameters.associateBy { it.name }
+        for ((name, property) in concretePropertyByName) {
+            if (name !in constructorParameterByName.keys &&
+                    !Modifier.isTransient(property.javaField!!.modifiers)) {
+                throw IllegalArgumentException("Property $name is not transient. " +
+                        "Any properties not found in the primary constructor need to be transient. " +
+                        "If this is a delegated property, mark the delegate as transient " +
+                        "using @delegate:Transient.")
+            }
+        }
+
+        constructor.parameters
+                .asSequence()
+                .filterNot { it.isOptional }
+                .map { concretePropertyByName[it.name]!! }
+                .filter { it.findAnnotation<Transient>() != null }
+                .forEach { throw IllegalArgumentException("Transient properties in primary constructor are unsupported.") }
+
+        val isPlatformType = isPlatformType(Types.getRawType(type))
+        val notIncludedParams = constructorParameterByName
+                .filterNot { it.value.isOptional }
+                .keys.map { concretePropertyByName[it]!! }
+                .filter { !includeField(isPlatformType, it.javaField!!.modifiers) }
+        if (notIncludedParams.isNotEmpty()) {
+            throw IllegalArgumentException("Primary constructor contains parameters " +
+                    "not found in serialized JSON: $notIncludedParams")
+        }
+
+        val toJsonAdapter = ClassJsonAdapter.FACTORY.create(type, annotations, moshi)
+        val propertyByParam = constructor.parameters.associate { it to concretePropertyByName[it.name]!! }
+        val adapterByParam = constructor.parameters.associate { param ->
+            val javaField = propertyByParam[param]!!.javaField!!
+            val paramType = Types.resolve(javaField.type, Types.getRawType(javaField.type), javaField.genericType)
+            val annotations = param.annotations.toSet()
+
+            param to moshi.adapter<Any>(paramType, annotations)
+        }
+
+        return KotlinJsonAdapter(
+                constructor,
+                toJsonAdapter as JsonAdapter<Any?>,
+                propertyByParam,
+                adapterByParam,
+                crashOnMissingValues
+        )
+    }
+
+}
+
+@Suppress("LoopToCallChain")
+internal class KotlinJsonAdapter<T>(
+        private val constructor: KFunction<T>,
+        private val toJsonAdapter: JsonAdapter<T>,
+        propertyByParam: Map<KParameter, KProperty1<out Any, Any?>>,
+        private val adapterByParam: Map<KParameter, JsonAdapter<*>>,
+        private val crashOnMissingValues: Boolean
+) : JsonAdapter<T>() {
+
+    private val jsonNames = constructor.parameters
+            .map { propertyByParam[it]!! }
+            .map { it.javaField!!.getAnnotation(Json::class.java)?.name ?: it.name }
+            .toTypedArray()
+    private val options = JsonReader.Options.of(*jsonNames)
+
+    override fun fromJson(reader: JsonReader): T {
+        try {
+            val valuesByParam = mutableMapOf<KParameter, Any?>()
+
+            reader.beginObject()
+            while (reader.hasNext()) {
+                val index = reader.selectName(options)
+                val param = if (index != -1) {
+                    constructor.parameters[index]
+                } else {
+                    reader.nextName()
+                    reader.skipValue()
+                    continue
+                }
+
+                valuesByParam[param] = adapterByParam[param]!!.fromJson(reader)
+            }
+            reader.endObject()
+
+            for (param in constructor.parameters) {
+                if ((crashOnMissingValues || !param.isOptional) && param !in valuesByParam) {
+                    throw IllegalArgumentException("JSON is missing value for ${param.name}")
+                }
+            }
+
+            return constructor.callBy(valuesByParam)
+        } catch (e: IllegalAccessException) {
+            throw AssertionError()
+        }
+    }
+
+    override fun toJson(writer: JsonWriter, value: T) {
+        toJsonAdapter.toJson(writer, value)
+    }
+
+}

--- a/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
+++ b/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
@@ -94,7 +94,7 @@ internal class KotlinJsonAdapter<T>(
     private val constructor: KFunction<T>,
     private val toJsonAdapter: JsonAdapter<T>,
     private val propertyByParam: Map<KParameter, KProperty1<out Any, Any?>>,
-    private val adapterByParam: Map<KParameter, JsonAdapter<*>>,
+    private val adapterByParam: Map<KParameter, JsonAdapter<*>>
     ) : JsonAdapter<T>() {
 
   private val jsonNames = constructor.parameters

--- a/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
+++ b/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
@@ -31,7 +31,7 @@ import kotlin.reflect.jvm.javaField
  * - If the class is a platform type (kotlin.*), it may not contain private fields.
  */
 class KotlinJsonAdapterFactory : JsonAdapter.Factory {
-  override fun create(type: Type, annotations: MutableSet<out Annotation>, moshi: Moshi): JsonAdapter<*>? {
+  override fun create(type: Type, annotations: Set<Annotation>, moshi: Moshi): JsonAdapter<*>? {
     val kclass = (type as? Class<*>)?.kotlin ?: return null
     if (!kclass.isData) return null
     // This gives us a few guarantees:

--- a/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
+++ b/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
@@ -31,118 +31,118 @@ import kotlin.reflect.jvm.javaField
  * - If the class is a platform type (kotlin.*), it may not contain private fields.
  */
 class KotlinJsonAdapterFactory(private val crashOnMissingValues: Boolean = false) : JsonAdapter.Factory {
-    override fun create(type: Type, annotations: MutableSet<out Annotation>, moshi: Moshi): JsonAdapter<*>? {
-        val kclass = (type as? Class<*>)?.kotlin ?: return null
-        if (!kclass.isData) return null
-        // This gives us a few guarantees:
-        // 1. Primary constructor exists
-        // 2. Constructor params are var/val and have backing fields
-        // 3. Class is not abstract or an interface
-        // 4. Class is final
+  override fun create(type: Type, annotations: MutableSet<out Annotation>, moshi: Moshi): JsonAdapter<*>? {
+    val kclass = (type as? Class<*>)?.kotlin ?: return null
+    if (!kclass.isData) return null
+    // This gives us a few guarantees:
+    // 1. Primary constructor exists
+    // 2. Constructor params are var/val and have backing fields
+    // 3. Class is not abstract or an interface
+    // 4. Class is final
 
-        val constructor = kclass.primaryConstructor!!
-        constructor.isAccessible = true
+    val constructor = kclass.primaryConstructor!!
+    constructor.isAccessible = true
 
-        val concretePropertyByName = kclass.declaredMemberProperties
-                .filter { it.javaField != null }
-                .associateBy { it.name }
-        val constructorParameterByName = constructor.parameters.associateBy { it.name }
-        for ((name, property) in concretePropertyByName) {
-            if (name !in constructorParameterByName.keys &&
-                    !Modifier.isTransient(property.javaField!!.modifiers)) {
-                throw IllegalArgumentException("Property $name is not transient. " +
-                        "Any properties not found in the primary constructor need to be transient. " +
-                        "If this is a delegated property, mark the delegate as transient " +
-                        "using @delegate:Transient.")
-            }
-        }
-
-        constructor.parameters
-                .asSequence()
-                .filterNot { it.isOptional }
-                .map { concretePropertyByName[it.name]!! }
-                .firstOrNull { it.findAnnotation<Transient>() != null }
-                ?.run { throw IllegalArgumentException("Transient properties in primary constructor are unsupported.") }
-
-        val isPlatformType = isPlatformType(Types.getRawType(type))
-        val notIncludedParams = constructorParameterByName
-                .filterNot { it.value.isOptional }
-                .keys.map { concretePropertyByName[it]!! }
-                .filter { !includeField(isPlatformType, it.javaField!!.modifiers) }
-        if (notIncludedParams.isNotEmpty()) {
-            throw IllegalArgumentException("Primary constructor contains parameters " +
-                    "not found in serialized JSON: $notIncludedParams")
-        }
-
-        val toJsonAdapter = ClassJsonAdapter.FACTORY.create(type, annotations, moshi)
-        val propertyByParam = constructor.parameters.associate { it to concretePropertyByName[it.name]!! }
-        val adapterByParam = constructor.parameters.associate { param ->
-            val javaField = propertyByParam[param]!!.javaField!!
-            val paramType = Types.resolve(javaField.type, Types.getRawType(javaField.type), javaField.genericType)
-            val annotations = param.annotations.toSet()
-
-            param to moshi.adapter<Any>(paramType, annotations)
-        }
-
-        return KotlinJsonAdapter(
-                constructor,
-                toJsonAdapter as JsonAdapter<Any?>,
-                propertyByParam,
-                adapterByParam,
-                crashOnMissingValues
-        )
+    val concretePropertyByName = kclass.declaredMemberProperties
+        .filter { it.javaField != null }
+        .associateBy { it.name }
+    val constructorParameterByName = constructor.parameters.associateBy { it.name }
+    for ((name, property) in concretePropertyByName) {
+      if (name !in constructorParameterByName.keys &&
+          !Modifier.isTransient(property.javaField!!.modifiers)) {
+        throw IllegalArgumentException("Property $name is not transient. " +
+            "Any properties not found in the primary constructor need to be transient. " +
+            "If this is a delegated property, mark the delegate as transient " +
+            "using @delegate:Transient.")
+      }
     }
+
+    constructor.parameters
+        .asSequence()
+        .filterNot { it.isOptional }
+        .map { concretePropertyByName[it.name]!! }
+        .firstOrNull { it.findAnnotation<Transient>() != null }
+        ?.run { throw IllegalArgumentException("Transient properties in primary constructor are unsupported.") }
+
+    val isPlatformType = isPlatformType(Types.getRawType(type))
+    val notIncludedParams = constructorParameterByName
+        .filterNot { it.value.isOptional }
+        .keys.map { concretePropertyByName[it]!! }
+        .filter { !includeField(isPlatformType, it.javaField!!.modifiers) }
+    if (notIncludedParams.isNotEmpty()) {
+      throw IllegalArgumentException("Primary constructor contains parameters " +
+          "not found in serialized JSON: $notIncludedParams")
+    }
+
+    val toJsonAdapter = ClassJsonAdapter.FACTORY.create(type, annotations, moshi)
+    val propertyByParam = constructor.parameters.associate { it to concretePropertyByName[it.name]!! }
+    val adapterByParam = constructor.parameters.associate { param ->
+      val javaField = propertyByParam[param]!!.javaField!!
+      val paramType = Types.resolve(javaField.type, Types.getRawType(javaField.type), javaField.genericType)
+      val annotations = param.annotations.toSet()
+
+      param to moshi.adapter<Any>(paramType, annotations)
+    }
+
+    return KotlinJsonAdapter(
+        constructor,
+        toJsonAdapter as JsonAdapter<Any?>,
+        propertyByParam,
+        adapterByParam,
+        crashOnMissingValues
+    )
+  }
 
 }
 
 @Suppress("LoopToCallChain")
 internal class KotlinJsonAdapter<T>(
-        private val constructor: KFunction<T>,
-        private val toJsonAdapter: JsonAdapter<T>,
-        propertyByParam: Map<KParameter, KProperty1<out Any, Any?>>,
-        private val adapterByParam: Map<KParameter, JsonAdapter<*>>,
-        private val crashOnMissingValues: Boolean
+    private val constructor: KFunction<T>,
+    private val toJsonAdapter: JsonAdapter<T>,
+    propertyByParam: Map<KParameter, KProperty1<out Any, Any?>>,
+    private val adapterByParam: Map<KParameter, JsonAdapter<*>>,
+    private val crashOnMissingValues: Boolean
 ) : JsonAdapter<T>() {
 
-    private val jsonNames = constructor.parameters
-            .map { propertyByParam[it]!! }
-            .map { it.javaField!!.getAnnotation(Json::class.java)?.name ?: it.name }
-            .toTypedArray()
-    private val options = JsonReader.Options.of(*jsonNames)
+  private val jsonNames = constructor.parameters
+      .map { propertyByParam[it]!! }
+      .map { it.javaField!!.getAnnotation(Json::class.java)?.name ?: it.name }
+      .toTypedArray()
+  private val options = JsonReader.Options.of(*jsonNames)
 
-    override fun fromJson(reader: JsonReader): T {
-        try {
-            val valuesByParam = mutableMapOf<KParameter, Any?>()
+  override fun fromJson(reader: JsonReader): T {
+    try {
+      val valuesByParam = mutableMapOf<KParameter, Any?>()
 
-            reader.beginObject()
-            while (reader.hasNext()) {
-                val index = reader.selectName(options)
-                val param = if (index != -1) {
-                    constructor.parameters[index]
-                } else {
-                    reader.nextName()
-                    reader.skipValue()
-                    continue
-                }
-
-                valuesByParam[param] = adapterByParam[param]!!.fromJson(reader)
-            }
-            reader.endObject()
-
-            for (param in constructor.parameters) {
-                if ((crashOnMissingValues || !param.isOptional) && param !in valuesByParam) {
-                    throw IllegalArgumentException("JSON is missing value for ${param.name}")
-                }
-            }
-
-            return constructor.callBy(valuesByParam)
-        } catch (e: IllegalAccessException) {
-            throw AssertionError()
+      reader.beginObject()
+      while (reader.hasNext()) {
+        val index = reader.selectName(options)
+        val param = if (index != -1) {
+          constructor.parameters[index]
+        } else {
+          reader.nextName()
+          reader.skipValue()
+          continue
         }
-    }
 
-    override fun toJson(writer: JsonWriter, value: T) {
-        toJsonAdapter.toJson(writer, value)
+        valuesByParam[param] = adapterByParam[param]!!.fromJson(reader)
+      }
+      reader.endObject()
+
+      for (param in constructor.parameters) {
+        if ((crashOnMissingValues || !param.isOptional) && param !in valuesByParam) {
+          throw IllegalArgumentException("JSON is missing value for ${param.name}")
+        }
+      }
+
+      return constructor.callBy(valuesByParam)
+    } catch (e: IllegalAccessException) {
+      throw AssertionError()
     }
+  }
+
+  override fun toJson(writer: JsonWriter, value: T) {
+    toJsonAdapter.toJson(writer, value)
+  }
 
 }

--- a/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
+++ b/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
@@ -81,7 +81,7 @@ class KotlinJsonAdapterFactory : JsonAdapter.Factory {
       val paramType = Types.resolve(javaField.type, Types.getRawType(javaField.type), javaField.genericType)
       val annotations = param.annotations.toSet()
 
-      param to moshi.adapter<Any>(paramType, annotations)
+      return@associate param to moshi.adapter<Any>(paramType, annotations)
     }
 
     return KotlinJsonAdapter(constructor, toJsonAdapter as JsonAdapter<Any?>, propertyByParam, adapterByParam)

--- a/kotlin/src/test/java/com/squareup/moshi/KotlinJsonAdapterTest.kt
+++ b/kotlin/src/test/java/com/squareup/moshi/KotlinJsonAdapterTest.kt
@@ -54,17 +54,6 @@ class KotlinJsonAdapterFactoryTest {
     assertEquals("", deserialized.def, "Default value from constructor should be used.")
   }
 
-  data class CrashOnMissing(val x: String = "")
-
-  @Test(expected = IllegalArgumentException::class) fun testCrashOnMissing() {
-    val json = "{}"
-    Moshi.Builder()
-        .add(KotlinJsonAdapterFactory(crashOnMissingValues = true))
-        .build()
-        .adapter(CrashOnMissing::class.java)
-        .fromJson(json)
-  }
-
   @Test(expected = IllegalArgumentException::class) fun testMissingJsonValue() {
     val json = "{}"
     moshi.adapter(DefaultParam::class.java).fromJson(json)

--- a/kotlin/src/test/java/com/squareup/moshi/KotlinJsonAdapterTest.kt
+++ b/kotlin/src/test/java/com/squareup/moshi/KotlinJsonAdapterTest.kt
@@ -54,7 +54,7 @@ class KotlinJsonAdapterFactoryTest {
     assertEquals("", deserialized.def, "Default value from constructor should be used.")
   }
 
-  @Test(expected = IllegalArgumentException::class) fun testMissingJsonValue() {
+  @Test(expected = JsonDataException::class) fun testMissingJsonValue() {
     val json = "{}"
     moshi.adapter(DefaultParam::class.java).fromJson(json)
   }

--- a/kotlin/src/test/java/com/squareup/moshi/KotlinJsonAdapterTest.kt
+++ b/kotlin/src/test/java/com/squareup/moshi/KotlinJsonAdapterTest.kt
@@ -1,0 +1,81 @@
+package com.squareup.moshi
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class KotlinJsonAdapterFactoryTest {
+
+    private val moshi = Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build()
+
+    private data class FooBar(val foo: String, @Json(name = "other_name") val named: String) {
+        @Transient val otherProperty = ""
+        @delegate:Transient val delegated by lazy { "" }
+    }
+
+    @Test fun test() {
+        val adapter = moshi.adapter(FooBar::class.java)
+
+        val json = "{\"foo\":\"foo\", \"other_name\": \"other_name\"}"
+        val deserialized = adapter.fromJson(json)
+        assertEquals("foo", deserialized.foo, "val deserialization without @Json annotation failed.")
+        assertEquals("other_name", deserialized.named, "@Json(name = ...) was not respected.")
+        assertEquals("", deserialized.otherProperty, "Transient property was not initialized. " +
+                "Was the primary constructor called?")
+        assertEquals("", deserialized.delegated, "Delegated property was not initialized. " +
+                "Was the primary constructor called?")
+
+        assertEquals(deserialized, adapter.fromJson(adapter.toJson(deserialized)),
+                "Object should still be equal after serialization and deserialization.")
+    }
+
+    private data class TransientProperty(@Transient val nonBacking: String)
+
+    @Test(expected = IllegalArgumentException::class) fun testTransient() {
+        moshi.adapter(TransientProperty::class.java)
+    }
+
+    private data class NonTransientNonConstructorProperty(val ignored: String) {
+        var x: String = ""
+    }
+
+    @Test(expected = IllegalArgumentException::class) fun testNonTransientNonConstructorProperty() {
+        moshi.adapter(NonTransientNonConstructorProperty::class.java)
+    }
+
+    // def can be transient since a default value is provided
+    data class DefaultParam(val x: String, @Transient val def: String = "")
+
+    @Test fun testDefaultParam() {
+        val json = "{\"x\":\"x\"}"
+        val deserialized = moshi.adapter(DefaultParam::class.java).fromJson(json)
+        assertEquals("x", deserialized.x, "Existing value should be used from JSON.")
+        assertEquals("", deserialized.def, "Default value from constructor should be used.")
+    }
+
+    data class CrashOnMissing(val x: String = "")
+
+    @Test(expected = IllegalArgumentException::class) fun testCrashOnMissing() {
+        val json = "{}"
+        Moshi.Builder()
+                .add(KotlinJsonAdapterFactory(crashOnMissingValues = true))
+                .build()
+                .adapter(CrashOnMissing::class.java)
+                .fromJson(json)
+    }
+
+    @Test(expected = IllegalArgumentException::class) fun testMissingJsonValue() {
+        val json = "{}"
+        moshi.adapter(DefaultParam::class.java).fromJson(json)
+    }
+
+    data class Inner(val x: String)
+    data class Outer(val inner: Inner)
+
+    @Test fun testInnerOuter() {
+        val json = "{\"inner\": {\"x\": \"\"}}"
+        val deserialized = moshi.adapter(Outer::class.java).fromJson(json)
+        assertEquals("", deserialized.inner.x, "Nested objects should be deserialized corretly.")
+    }
+}

--- a/kotlin/src/test/java/com/squareup/moshi/KotlinJsonAdapterTest.kt
+++ b/kotlin/src/test/java/com/squareup/moshi/KotlinJsonAdapterTest.kt
@@ -36,12 +36,19 @@ class KotlinJsonAdapterFactoryTest {
     moshi.adapter(TransientProperty::class.java)
   }
 
-  private data class NonTransientNonConstructorProperty(val ignored: String) {
+  private open class Superclass {
     var x: String = ""
   }
+  private data class NonTransientNonConstructorProperty(val ignored: String): Superclass() {
+    var y: String = ""
+  }
 
-  @Test(expected = IllegalArgumentException::class) fun testNonTransientNonConstructorProperty() {
-    moshi.adapter(NonTransientNonConstructorProperty::class.java)
+  @Test() fun testNonTransientNonConstructorProperty() {
+    val adapter = moshi.adapter(NonTransientNonConstructorProperty::class.java)
+    val test = adapter.fromJson("{\"ignored\": \"\", \"x\": \"\", \"y\": \"\"}")
+    assertEquals("", test.x, "Non-constructor parameter from superclass should be deserialized correctly.")
+    assertEquals("", test.y, "Non-constructor parameter should be deserialized correctly.")
+    assertEquals(test, adapter.fromJson(adapter.toJson(test)), "Object should still be equal after serialization and deserialization.")
   }
 
   // def can be transient since a default value is provided

--- a/kotlin/src/test/java/com/squareup/moshi/KotlinJsonAdapterTest.kt
+++ b/kotlin/src/test/java/com/squareup/moshi/KotlinJsonAdapterTest.kt
@@ -5,77 +5,77 @@ import kotlin.test.assertEquals
 
 class KotlinJsonAdapterFactoryTest {
 
-    private val moshi = Moshi.Builder()
-            .add(KotlinJsonAdapterFactory())
-            .build()
+  private val moshi = Moshi.Builder()
+      .add(KotlinJsonAdapterFactory())
+      .build()
 
-    private data class FooBar(val foo: String, @Json(name = "other_name") val named: String) {
-        @Transient val otherProperty = ""
-        @delegate:Transient val delegated by lazy { "" }
-    }
+  private data class FooBar(val foo: String, @Json(name = "other_name") val named: String) {
+    @Transient val otherProperty = ""
+    @delegate:Transient val delegated by lazy { "" }
+  }
 
-    @Test fun test() {
-        val adapter = moshi.adapter(FooBar::class.java)
+  @Test fun test() {
+    val adapter = moshi.adapter(FooBar::class.java)
 
-        val json = "{\"foo\":\"foo\", \"other_name\": \"other_name\"}"
-        val deserialized = adapter.fromJson(json)
-        assertEquals("foo", deserialized.foo, "val deserialization without @Json annotation failed.")
-        assertEquals("other_name", deserialized.named, "@Json(name = ...) was not respected.")
-        assertEquals("", deserialized.otherProperty, "Transient property was not initialized. " +
-                "Was the primary constructor called?")
-        assertEquals("", deserialized.delegated, "Delegated property was not initialized. " +
-                "Was the primary constructor called?")
+    val json = "{\"foo\":\"foo\", \"other_name\": \"other_name\"}"
+    val deserialized = adapter.fromJson(json)
+    assertEquals("foo", deserialized.foo, "val deserialization without @Json annotation failed.")
+    assertEquals("other_name", deserialized.named, "@Json(name = ...) was not respected.")
+    assertEquals("", deserialized.otherProperty, "Transient property was not initialized. " +
+        "Was the primary constructor called?")
+    assertEquals("", deserialized.delegated, "Delegated property was not initialized. " +
+        "Was the primary constructor called?")
 
-        assertEquals(deserialized, adapter.fromJson(adapter.toJson(deserialized)),
-                "Object should still be equal after serialization and deserialization.")
-    }
+    assertEquals(deserialized, adapter.fromJson(adapter.toJson(deserialized)),
+        "Object should still be equal after serialization and deserialization.")
+  }
 
-    private data class TransientProperty(@Transient val nonBacking: String)
+  private data class TransientProperty(@Transient val nonBacking: String)
 
-    @Test(expected = IllegalArgumentException::class) fun testTransient() {
-        moshi.adapter(TransientProperty::class.java)
-    }
+  @Test(expected = IllegalArgumentException::class) fun testTransient() {
+    moshi.adapter(TransientProperty::class.java)
+  }
 
-    private data class NonTransientNonConstructorProperty(val ignored: String) {
-        var x: String = ""
-    }
+  private data class NonTransientNonConstructorProperty(val ignored: String) {
+    var x: String = ""
+  }
 
-    @Test(expected = IllegalArgumentException::class) fun testNonTransientNonConstructorProperty() {
-        moshi.adapter(NonTransientNonConstructorProperty::class.java)
-    }
+  @Test(expected = IllegalArgumentException::class) fun testNonTransientNonConstructorProperty() {
+    moshi.adapter(NonTransientNonConstructorProperty::class.java)
+  }
 
-    // def can be transient since a default value is provided
-    data class DefaultParam(val x: String, @Transient val def: String = "")
+  // def can be transient since a default value is provided
+  data class DefaultParam(val x: String, @Transient val def: String = "")
 
-    @Test fun testDefaultParam() {
-        val json = "{\"x\":\"x\"}"
-        val deserialized = moshi.adapter(DefaultParam::class.java).fromJson(json)
-        assertEquals("x", deserialized.x, "Existing value should be used from JSON.")
-        assertEquals("", deserialized.def, "Default value from constructor should be used.")
-    }
+  @Test fun testDefaultParam() {
+    val json = "{\"x\":\"x\"}"
+    val deserialized = moshi.adapter(DefaultParam::class.java).fromJson(json)
+    assertEquals("x", deserialized.x, "Existing value should be used from JSON.")
+    assertEquals("", deserialized.def, "Default value from constructor should be used.")
+  }
 
-    data class CrashOnMissing(val x: String = "")
+  data class CrashOnMissing(val x: String = "")
 
-    @Test(expected = IllegalArgumentException::class) fun testCrashOnMissing() {
-        val json = "{}"
-        Moshi.Builder()
-                .add(KotlinJsonAdapterFactory(crashOnMissingValues = true))
-                .build()
-                .adapter(CrashOnMissing::class.java)
-                .fromJson(json)
-    }
+  @Test(expected = IllegalArgumentException::class) fun testCrashOnMissing() {
+    val json = "{}"
+    Moshi.Builder()
+        .add(KotlinJsonAdapterFactory(crashOnMissingValues = true))
+        .build()
+        .adapter(CrashOnMissing::class.java)
+        .fromJson(json)
+  }
 
-    @Test(expected = IllegalArgumentException::class) fun testMissingJsonValue() {
-        val json = "{}"
-        moshi.adapter(DefaultParam::class.java).fromJson(json)
-    }
+  @Test(expected = IllegalArgumentException::class) fun testMissingJsonValue() {
+    val json = "{}"
+    moshi.adapter(DefaultParam::class.java).fromJson(json)
+  }
 
-    data class Inner(val x: String)
-    data class Outer(val inner: Inner)
+  data class Inner(val x: String)
+  data class Outer(val inner: Inner)
 
-    @Test fun testInnerOuter() {
-        val json = "{\"inner\": {\"x\": \"\"}}"
-        val deserialized = moshi.adapter(Outer::class.java).fromJson(json)
-        assertEquals("", deserialized.inner.x, "Nested objects should be deserialized corretly.")
-    }
+  @Test fun testInnerOuter() {
+    val json = "{\"inner\": {\"x\": \"\"}}"
+    val deserialized = moshi.adapter(Outer::class.java).fromJson(json)
+    assertEquals("", deserialized.inner.x, "Nested objects should be deserialized corretly.")
+  }
 }

--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -75,36 +75,36 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
       }
       return new ClassJsonAdapter<>(classFactory, fields).nullSafe();
     }
+  };
 
-    /** Creates a field binding for each of declared field of {@code type}. */
-    private void createFieldBindings(
-        Moshi moshi, Type type, Map<String, FieldBinding<?>> fieldBindings) {
-      Class<?> rawType = Types.getRawType(type);
-      boolean platformType = isPlatformType(rawType);
-      for (Field field : rawType.getDeclaredFields()) {
-        if (!includeField(platformType, field.getModifiers())) continue;
+  /** Creates a field binding for each of declared field of {@code type}. */
+  static void createFieldBindings(
+      Moshi moshi, Type type, Map<String, FieldBinding<?>> fieldBindings) {
+    Class<?> rawType = Types.getRawType(type);
+    boolean platformType = isPlatformType(rawType);
+    for (Field field : rawType.getDeclaredFields()) {
+      if (!includeField(platformType, field.getModifiers())) continue;
 
-        // Look up a type adapter for this type.
-        Type fieldType = Types.resolve(type, rawType, field.getGenericType());
-        Set<? extends Annotation> annotations = Util.jsonAnnotations(field);
-        JsonAdapter<Object> adapter = moshi.adapter(fieldType, annotations);
+      // Look up a type adapter for this type.
+      Type fieldType = Types.resolve(type, rawType, field.getGenericType());
+      Set<? extends Annotation> annotations = Util.jsonAnnotations(field);
+      JsonAdapter<Object> adapter = moshi.adapter(fieldType, annotations);
 
-        // Create the binding between field and JSON.
-        field.setAccessible(true);
+      // Create the binding between field and JSON.
+      field.setAccessible(true);
 
-        // Store it using the field's name. If there was already a field with this name, fail!
-        Json jsonAnnotation = field.getAnnotation(Json.class);
-        String name = jsonAnnotation != null ? jsonAnnotation.name() : field.getName();
-        FieldBinding<Object> fieldBinding = new FieldBinding<>(name, field, adapter);
-        FieldBinding<?> replaced = fieldBindings.put(name, fieldBinding);
-        if (replaced != null) {
-          throw new IllegalArgumentException("Conflicting fields:\n"
-              + "    " + replaced.field + "\n"
-              + "    " + fieldBinding.field);
-        }
+      // Store it using the field's name. If there was already a field with this name, fail!
+      Json jsonAnnotation = field.getAnnotation(Json.class);
+      String name = jsonAnnotation != null ? jsonAnnotation.name() : field.getName();
+      FieldBinding<Object> fieldBinding = new FieldBinding<>(name, field, adapter);
+      FieldBinding<?> replaced = fieldBindings.put(name, fieldBinding);
+      if (replaced != null) {
+        throw new IllegalArgumentException("Conflicting fields:\n"
+            + "    " + replaced.field + "\n"
+            + "    " + fieldBinding.field);
       }
     }
-  };
+  }
 
   /**
    * Returns true if {@code rawType} is built in. We don't reflect on private fields of platform

--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -104,26 +104,26 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
         }
       }
     }
-
-    /**
-     * Returns true if {@code rawType} is built in. We don't reflect on private fields of platform
-     * types because they're unspecified and likely to be different on Java vs. Android.
-     */
-    private boolean isPlatformType(Class<?> rawType) {
-      String name = rawType.getName();
-      return name.startsWith("android.")
-          || name.startsWith("java.")
-          || name.startsWith("javax.")
-          || name.startsWith("kotlin.")
-          || name.startsWith("scala.");
-    }
-
-    /** Returns true if fields with {@code modifiers} are included in the emitted JSON. */
-    private boolean includeField(boolean platformType, int modifiers) {
-      if (Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)) return false;
-      return Modifier.isPublic(modifiers) || Modifier.isProtected(modifiers) || !platformType;
-    }
   };
+
+  /**
+   * Returns true if {@code rawType} is built in. We don't reflect on private fields of platform
+   * types because they're unspecified and likely to be different on Java vs. Android.
+   */
+  static boolean isPlatformType(Class<?> rawType) {
+    String name = rawType.getName();
+    return name.startsWith("android.")
+        || name.startsWith("java.")
+        || name.startsWith("javax.")
+        || name.startsWith("kotlin.")
+        || name.startsWith("scala.");
+  }
+
+  /** Returns true if fields with {@code modifiers} are included in the emitted JSON. */
+  static boolean includeField(boolean platformType, int modifiers) {
+    if (Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)) return false;
+    return Modifier.isPublic(modifiers) || Modifier.isProtected(modifiers) || !platformType;
+  }
 
   private final ClassFactory<T> classFactory;
   private final FieldBinding<?>[] fieldsArray;

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <module>moshi</module>
     <module>examples</module>
     <module>adapters</module>
+    <module>kotlin</module>
   </modules>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.7</java.version>
+    <kotlin.version>1.1.1</kotlin.version>
 
     <!-- Dependencies -->
     <okio.version>1.11.0</okio.version>
@@ -72,6 +73,22 @@
         <artifactId>assertj-core</artifactId>
         <version>${assertj.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${kotlin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-reflect</artifactId>
+        <version>${kotlin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-test</artifactId>
+        <version>${kotlin.version}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -100,6 +117,11 @@
               <version>2.0.15</version>
             </dependency>
           </dependencies>
+        </plugin>
+        <plugin>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-maven-plugin</artifactId>
+          <version>${kotlin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
This PR adds support for properly deserializing Kotlin data classes. Instead of assigning fields, the `KotlinJsonAdapter` invokes the primary constructor as proposed [here](https://github.com/square/moshi/pull/266#issuecomment-287724888).

To activate this behavior, a library user will need to add a dependency on `moshi-kotlin` and add the `KotlinJsonAdapterFactory` to Moshi. Thus, no existing code using Moshi will break after this PR is merged.

Thanks for your patience. I haven't contributed to many open source projects yet, so any feedback is appreciated.