### PR TITLE
Fix Types.equals for arrays.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/Types.java
+++ b/moshi/src/main/java/com/squareup/moshi/Types.java
@@ -210,6 +210,10 @@ public final class Types {
       return true; // Also handles (a == null && b == null).
 
     } else if (a instanceof Class) {
+      if (b instanceof GenericArrayType) {
+        return equals(((Class) a).getComponentType(),
+            ((GenericArrayType) b).getGenericComponentType());
+      }
       return a.equals(b); // Class already specifies equals().
 
     } else if (a instanceof ParameterizedType) {
@@ -227,6 +231,10 @@ public final class Types {
           && Arrays.equals(aTypeArguments, bTypeArguments);
 
     } else if (a instanceof GenericArrayType) {
+      if (b instanceof Class) {
+        return equals(((Class) b).getComponentType(),
+            ((GenericArrayType) a).getGenericComponentType());
+      }
       if (!(b instanceof GenericArrayType)) return false;
       GenericArrayType ga = (GenericArrayType) a;
       GenericArrayType gb = (GenericArrayType) b;

--- a/moshi/src/test/java/com/squareup/moshi/TypesTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/TypesTest.java
@@ -220,4 +220,11 @@ public final class TypesTest {
     assertThat(actual.hashCode()).isEqualTo(expected.hashCode());
     assertThat(actual.getClass()).isNotEqualTo(TestQualifier.class);
   }
+
+  @Test public void arrayEqualsGenericTypeArray() {
+    assertThat(Types.equals(int[].class, Types.arrayOf(int.class))).isTrue();
+    assertThat(Types.equals(Types.arrayOf(int.class), int[].class)).isTrue();
+    assertThat(Types.equals(String[].class, Types.arrayOf(String.class))).isTrue();
+    assertThat(Types.equals(Types.arrayOf(String.class), String[].class)).isTrue();
+  }
 }


### PR DESCRIPTION
I get the feeling this was not supposed to work at some point, or I am misunderstanding something.