### PR TITLE
Minor improvements

### DIFF
--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -86,5 +86,4 @@
       </plugin>
     </plugins>
   </build>
-
 </project>

--- a/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
+++ b/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
@@ -36,7 +36,7 @@ private val KOTLIN_METADATA = Class.forName("kotlin.Metadata") as Class<out Anno
  * Placeholder value used when a field is absent from the JSON. Note that this code
  * distinguishes between absent values and present-but-null values.
  */
-private val ABSENT_VALUE = object : Any() {}
+private object ABSENT_VALUE
 
 /**
  * This class encodes Kotlin classes using their properties. It decodes them by first invoking the
@@ -68,8 +68,7 @@ internal class KotlinJsonAdapter<T> private constructor(
             "Multiple values for ${constructor.parameters[index].name} at ${reader.path}")
       }
 
-      val value = binding.adapter.fromJson(reader)
-      values[index] = value
+      values[index] = binding.adapter.fromJson(reader)
     }
     reader.endObject()
 
@@ -84,7 +83,7 @@ internal class KotlinJsonAdapter<T> private constructor(
 
     // Set remaining properties.
     for (i in constructorSize until bindings.size) {
-      bindings[i]!!.set(result, values[i])
+      bindings[i]!![result] = values[i]
     }
 
     return result
@@ -96,7 +95,7 @@ internal class KotlinJsonAdapter<T> private constructor(
       if (binding == null) continue // Skip constructor parameters that aren't properties.
 
       writer.name(binding.name)
-      binding.adapter.toJson(writer, binding.get(value))
+      binding.adapter.toJson(writer, binding[value])
     }
     writer.endObject()
   }
@@ -114,9 +113,9 @@ internal class KotlinJsonAdapter<T> private constructor(
       }
     }
 
-    fun get(value: K) = property.get(value)
+    operator fun get(value: K) = property.get(value)
 
-    fun set(result: K, value: P) {
+    operator fun set(result: K, value: P) {
       if (value !== ABSENT_VALUE) {
         (property as KMutableProperty1<K, P>).set(result, value)
       }
@@ -165,7 +164,7 @@ internal class KotlinJsonAdapter<T> private constructor(
         if (Modifier.isTransient(property.javaField?.modifiers ?: 0)) continue
 
         property.isAccessible = true
-        var allAnnotations = property.annotations
+        val allAnnotations = property.annotations.toMutableList()
         var jsonAnnotation = property.findAnnotation<Json>()
 
         val parameter = parametersByName[property.name]

--- a/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
+++ b/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
@@ -1,194 +1,204 @@
-@file:Suppress("UNCHECKED_CAST")
-
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.moshi
 
-import com.squareup.moshi.ClassJsonAdapter.*
-import java.lang.reflect.Field
-import java.lang.reflect.Type
+import java.lang.reflect.Modifier
+import java.util.AbstractMap.SimpleEntry
+import kotlin.collections.Map.Entry
 import kotlin.reflect.KFunction
+import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty1
-import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.javaField
+import kotlin.reflect.jvm.javaType
+
+/** Classes annotated with this are eligible for this adapter. */
+private val KOTLIN_METADATA = Class.forName("kotlin.Metadata") as Class<out Annotation>
 
 /**
- * A [JsonAdapter.Factory] for Kotlin data classes. If this is added to Moshi,
- * data classes will be treated differently from other classes.
- *
- * Moshi will call its primary constructor to create the object. This allows for delegated properties
- * to be initialized correctly. If the JSON does not contain a value for a parameter with a default value
- * the default value is used. If no default value is present a [JsonDataException] will be
- * thrown during deserialization.
- *
- * Data classes to be (de-)serialized must conform to the following rules:
- *
- * - The primary constructor may not contain transient properties unless a default value is provided.
- * - If the class is a platform type (kotlin.*), it may not contain private fields.
- *
- * In most cases, delegated properties should be annotated with `@delegate:Transient` to
- * avoid the inclusion of the delegate in the serialized JSON.
+ * Placeholder value used when a field is absent from the JSON. Note that this code
+ * distinguishes between absent values and present-but-null values.
  */
-class KotlinJsonAdapterFactory : JsonAdapter.Factory {
-  override fun create(type: Type, annotations: Set<Annotation>, moshi: Moshi): JsonAdapter<*>? {
-    val kclass = (type as? Class<*>)?.kotlin ?: return null
-    if (!kclass.isData) return null
-    // This gives us a few guarantees:
-    // 1. Primary constructor exists
-    // 2. Constructor params are var/val and have backing fields
-    // 3. Class is not abstract or an interface
-    // 4. Class is final
+private val ABSENT_VALUE = object : Any() {}
 
-    val constructor = kclass.primaryConstructor!!
-    constructor.isAccessible = true
-
-    val concretePropertyByName = kclass.declaredMemberProperties
-        .filter { it.javaField != null }
-        .associateBy { it.name }
-    val constructorParameterByName = constructor.parameters.associateBy { it.name }
-
-    constructor.parameters
-        .asSequence()
-        .filterNot { it.isOptional }
-        .map { concretePropertyByName[it.name]!! }
-        .firstOrNull { it.findAnnotation<Transient>() != null }
-        ?.let { throw IllegalArgumentException("Transient properties in primary constructor " +
-            "without default values are unsupported. ($it)") }
-
-    val isPlatformType = isPlatformType(Types.getRawType(type))
-    val notIncludedParams = constructorParameterByName
-        .filterNot { it.value.isOptional }
-        .keys.map { concretePropertyByName[it]!! }
-        .filter { !includeField(isPlatformType, it.javaField!!.modifiers) }
-    if (notIncludedParams.isNotEmpty()) {
-      throw IllegalArgumentException("Primary constructor contains parameters " +
-          "not found in serialized JSON: $notIncludedParams")
-    }
-
-    val propertyByParam = constructor.parameters.associate { it to concretePropertyByName[it.name]!! }
-    val adapterByParam = constructor.parameters.map { param ->
-      val javaField = propertyByParam[param]!!.javaField!!
-      val paramType = Types.resolve(javaField.type, Types.getRawType(javaField.type), javaField.genericType)
-      val paramAnnotations = param.annotations.toSet()
-
-      return@map moshi.adapter<Any>(paramType, paramAnnotations)
-    }.toTypedArray<JsonAdapter<*>>()
-
-    return KotlinJsonAdapter(constructor, type.createFieldBindings(moshi), propertyByParam, adapterByParam)
-  }
-
-  /**
-   * A [Sequence] of supertypes, including the type itself
-   * and excluding [Object].
-   */
-  private val Type.hierarchy get() = generateSequence(this) {
-    val superClass = Types.getGenericSuperclass(it)
-    return@generateSequence if (superClass != Object::class.java) superClass else null
-  }
-
-  private fun Type.createFieldBindings(moshi: Moshi): LinkedHashMap<String, ClassJsonAdapter.FieldBinding<*>> {
-    val fields = LinkedHashMap<String, FieldBinding<*>>()
-    for (type in hierarchy) {
-      ClassJsonAdapter.createFieldBindings(moshi, type, fields)
-    }
-    return fields
-  }
-
-}
-
-@Suppress("LoopToCallChain")
-internal class KotlinJsonAdapter<T>(
-    private val constructor: KFunction<T>,
-    fieldBindings: LinkedHashMap<String, ClassJsonAdapter.FieldBinding<*>>,
-    propertyByParam: Map<KParameter, KProperty1<out Any, Any?>>,
-    private val adapterByParamIdx: Array<JsonAdapter<*>>
-) : JsonAdapter<T>() {
-
-  private val options: JsonReader.Options
-  private val fullFieldsArray = fieldBindings.values.toTypedArray()
-  private val nonParamFieldsArray: Array<FieldBinding<*>>
-
-  init {
-    val paramNames = constructor.parameters.map { it.name!! }.toSet()
-    val jsonNamesForParams = constructor.parameters
-        .map { propertyByParam[it]!! }
-        .map { it.javaField!!.getAnnotation(Json::class.java)?.name ?: it.name }
-        .toTypedArray()
-    val jsonNamesForFields = fieldBindings
-        .keys
-        .filter { it !in paramNames }
-        .toTypedArray()
-    nonParamFieldsArray = fieldBindings
-        .entries
-        .filter { it.key !in paramNames }
-        .map { it.value }
-        .toTypedArray()
-
-    options = JsonReader.Options.of(*(jsonNamesForParams + jsonNamesForFields))
-  }
+/**
+ * This class encodes Kotlin classes using their properties. It decodes them by first invoking the
+ * constructor, and then by setting any additional properties that exist, if any.
+ */
+internal class KotlinJsonAdapter<T> private constructor(
+    val constructor: KFunction<T>,
+    val bindings: List<Binding<T, Any?>?>,
+    val options: JsonReader.Options) : JsonAdapter<T>() {
 
   override fun fromJson(reader: JsonReader): T {
-    try {
-      val valuesByParam = mutableMapOf<KParameter, Any?>()
-      var lazyPendingBindings: MutableList<Pair<Field, Any>>? = null
+    val constructorSize = constructor.parameters.size
 
-      reader.beginObject()
-      while (reader.hasNext()) {
-        val index = reader.selectName(options)
-        if (index == -1) {
-          reader.nextName()
-          reader.skipValue()
-          continue
-        }
+    // Read each value into its slot in the array.
+    val values = Array<Any?>(bindings.size) { ABSENT_VALUE }
+    reader.beginObject()
+    while (reader.hasNext()) {
+      val index = reader.selectName(options)
+      val binding = if (index != -1) bindings[index] else null
 
-        val numParams = constructor.parameters.size
-        if (index < numParams) {
-          val param = constructor.parameters[index]
-          valuesByParam[param] = adapterByParamIdx[index].fromJson(reader)
-        } else {
-          val fieldBinding = nonParamFieldsArray[index - numParams]
-          val field = fieldBinding.field
-          val fieldValue = fieldBinding.adapter.fromJson(reader)
-
-          // Many data classes do not contain any properties
-          // outside of the primary constructor, so the allocation
-          // of the list is deferred to here.
-          if (lazyPendingBindings == null) {
-            lazyPendingBindings = mutableListOf()
-          }
-          lazyPendingBindings.add(field to fieldValue)
-        }
-      }
-      reader.endObject()
-
-      for (param in constructor.parameters) {
-        if (!param.isOptional && param !in valuesByParam) {
-          throw JsonDataException("JSON is missing value for ${param.name}")
-        }
+      if (binding == null) {
+        reader.nextName()
+        reader.skipValue()
+        continue
       }
 
-      return constructor.callBy(valuesByParam).apply {
-        lazyPendingBindings?.forEach { it.first.set(this, it.second) }
+      if (values[index] !== ABSENT_VALUE) {
+        throw JsonDataException(
+            "Multiple values for ${constructor.parameters[index].name} at ${reader.path}")
       }
-    } catch (e: IllegalAccessException) {
-      throw AssertionError()
+
+      val value = binding.adapter.fromJson(reader)
+      values[index] = value
     }
+    reader.endObject()
+
+    // Call the constructor using a Map so that absent optionals get defaults.
+    for (i in 0 until constructorSize) {
+      if (!constructor.parameters[i].isOptional && values[i] === ABSENT_VALUE) {
+        throw JsonDataException(
+            "Required value ${constructor.parameters[i].name} missing at ${reader.path}")
+      }
+    }
+    val result = constructor.callBy(IndexedParameterMap(constructor.parameters, values))
+
+    // Set remaining properties.
+    for (i in constructorSize until bindings.size) {
+      bindings[i]!!.set(result, values[i])
+    }
+
+    return result
   }
 
   override fun toJson(writer: JsonWriter, value: T) {
-    try {
-      writer.beginObject()
-      for (fieldBinding in fullFieldsArray) {
-        writer.name(fieldBinding.name)
-        fieldBinding.write(writer, value)
-      }
-      writer.endObject()
-    } catch (e: IllegalAccessException) {
-      throw AssertionError()
-    }
+    writer.beginObject()
+    for (binding in bindings) {
+      if (binding == null) continue // Skip constructor parameters that aren't properties.
 
+      writer.name(binding.name)
+      binding.adapter.toJson(writer, binding.get(value))
+    }
+    writer.endObject()
   }
 
+  override fun toString() = "KotlinJsonAdapter(${constructor.returnType})"
+
+  data class Binding<K, P>(
+      val name: String,
+      val adapter: JsonAdapter<P>,
+      val property: KProperty1<K, P>,
+      val parameter: KParameter?) {
+    init {
+      if (property !is KMutableProperty1 && parameter == null) {
+        throw IllegalArgumentException("No constructor or var property for ${property.name}")
+      }
+    }
+
+    fun get(value: K) = property.get(value)
+
+    fun set(result: K, value: P) {
+      if (value !== ABSENT_VALUE) {
+        (property as KMutableProperty1<K, P>).set(result, value)
+      }
+    }
+  }
+
+  /** A simple [Map] that uses parameter indexes instead of sorting or hashing. */
+  class IndexedParameterMap(val parameterKeys: List<KParameter>, val parameterValues: Array<Any?>)
+    : AbstractMap<KParameter, Any?>() {
+
+    override val entries: Set<Entry<KParameter, Any?>>
+      get() {
+        val allPossibleEntries = parameterKeys.mapIndexed { index, value ->
+          SimpleEntry<KParameter, Any?>(value, parameterValues[index])
+        }
+        return allPossibleEntries.filterTo(LinkedHashSet<Entry<KParameter, Any?>>()) {
+          it.value !== ABSENT_VALUE
+        }
+      }
+
+    override fun containsKey(key: KParameter) = parameterValues[key.index] !== ABSENT_VALUE
+
+    override fun get(key: KParameter): Any? {
+      val value = parameterValues[key.index]
+      return if (value !== ABSENT_VALUE) value else null
+    }
+  }
+
+  companion object {
+    val FACTORY = Factory { type, annotations, moshi ->
+      if (!annotations.isEmpty()) return@Factory null
+
+      val rawType = Types.getRawType(type)
+      val platformType = ClassJsonAdapter.isPlatformType(rawType)
+      if (platformType) return@Factory null
+
+      if (!rawType.isAnnotationPresent(KOTLIN_METADATA)) return@Factory null
+
+      val constructor = rawType.kotlin.primaryConstructor ?: return@Factory null
+      val parametersByName = constructor.parameters.associateBy { it.name }
+      constructor.isAccessible = true
+
+      val bindingsByName = LinkedHashMap<String, Binding<Any, Any?>>()
+
+      for (property in rawType.kotlin.memberProperties) {
+        if (Modifier.isTransient(property.javaField?.modifiers ?: 0)) continue
+
+        property.isAccessible = true
+        var allAnnotations = property.annotations
+        var jsonAnnotation = property.findAnnotation<Json>()
+
+        val parameter = parametersByName[property.name]
+        if (parameter != null) {
+          allAnnotations += parameter.annotations
+          if (jsonAnnotation == null) {
+            jsonAnnotation = parameter.findAnnotation<Json>()
+          }
+        }
+
+        val name = jsonAnnotation?.name ?: property.name
+        val adapter = moshi.adapter<Any>(
+            property.returnType.javaType, Util.jsonAnnotations(allAnnotations.toTypedArray()))
+
+        bindingsByName[property.name] =
+            Binding(name, adapter, property as KProperty1<Any, Any?>, parameter)
+      }
+
+      val bindings = ArrayList<Binding<Any, Any?>?>()
+
+      for (parameter in constructor.parameters) {
+        val binding = bindingsByName.remove(parameter.name)
+        if (binding == null && !parameter.isOptional) {
+          throw IllegalArgumentException(
+              "No property for required constructor parameter ${parameter.name}")
+        }
+        bindings += binding
+      }
+
+      bindings += bindingsByName.values
+
+      val options = JsonReader.Options.of(*bindings.map { it?.name ?: "\u0000" }.toTypedArray())
+      KotlinJsonAdapter(constructor, bindings, options)
+    }
+  }
 }

--- a/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
+++ b/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
@@ -83,7 +83,7 @@ internal class KotlinJsonAdapter<T> private constructor(
 
     // Set remaining properties.
     for (i in constructorSize until bindings.size) {
-      bindings[i]!![result] = values[i]
+      bindings[i]!!.set(result, values[i])
     }
 
     return result
@@ -95,7 +95,7 @@ internal class KotlinJsonAdapter<T> private constructor(
       if (binding == null) continue // Skip constructor parameters that aren't properties.
 
       writer.name(binding.name)
-      binding.adapter.toJson(writer, binding[value])
+      binding.adapter.toJson(writer, binding.get(value))
     }
     writer.endObject()
   }
@@ -113,9 +113,9 @@ internal class KotlinJsonAdapter<T> private constructor(
       }
     }
 
-    operator fun get(value: K) = property.get(value)
+    fun get(value: K) = property.get(value)
 
-    operator fun set(result: K, value: P) {
+    fun set(result: K, value: P) {
       if (value !== ABSENT_VALUE) {
         (property as KMutableProperty1<K, P>).set(result, value)
       }

--- a/kotlin/src/test/java/com/squareup/moshi/KotlinJsonAdapterFactoryTest.kt
+++ b/kotlin/src/test/java/com/squareup/moshi/KotlinJsonAdapterFactoryTest.kt
@@ -1,0 +1,77 @@
+package com.squareup.moshi
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class KotlinJsonAdapterFactoryTest {
+
+  private val moshi = Moshi.Builder()
+      .add(KotlinJsonAdapter.FACTORY)
+      .build()
+
+  private data class FooBar(val foo: String, @Json(name = "other_name") val named: String) {
+    @Transient val otherProperty = ""
+    @delegate:Transient val delegated by lazy { "" }
+  }
+
+  @Test fun test() {
+    val adapter = moshi.adapter(FooBar::class.java)
+
+    val json = "{\"foo\":\"foo\", \"other_name\": \"other_name\"}"
+    val deserialized = adapter.fromJson(json)
+    assertEquals("foo", deserialized.foo, "val deserialization without @Json annotation failed.")
+    assertEquals("other_name", deserialized.named, "@Json(name = ...) was not respected.")
+    assertEquals("", deserialized.otherProperty, "Transient property was not initialized. " +
+        "Was the primary constructor called?")
+    assertEquals("", deserialized.delegated, "Delegated property was not initialized. " +
+        "Was the primary constructor called?")
+
+    assertEquals(deserialized, adapter.fromJson(adapter.toJson(deserialized)),
+        "Object should still be equal after serialization and deserialization.")
+  }
+
+  private data class TransientProperty(@Transient val nonBacking: String)
+
+  @Test(expected = IllegalArgumentException::class) fun testTransient() {
+    moshi.adapter(TransientProperty::class.java)
+  }
+
+  private open class Superclass {
+    var x: String = ""
+  }
+  private data class NonTransientNonConstructorProperty(val ignored: String): Superclass() {
+    var y: String = ""
+  }
+
+  @Test() fun testNonTransientNonConstructorProperty() {
+    val adapter = moshi.adapter(NonTransientNonConstructorProperty::class.java)
+    val test = adapter.fromJson("{\"ignored\": \"\", \"x\": \"\", \"y\": \"\"}")
+    assertEquals("", test.x, "Non-constructor parameter from superclass should be deserialized correctly.")
+    assertEquals("", test.y, "Non-constructor parameter should be deserialized correctly.")
+    assertEquals(test, adapter.fromJson(adapter.toJson(test)), "Object should still be equal after serialization and deserialization.")
+  }
+
+  // def can be transient since a default value is provided
+  data class DefaultParam(val x: String, @Transient val def: String = "")
+
+  @Test fun testDefaultParam() {
+    val json = "{\"x\":\"x\"}"
+    val deserialized = moshi.adapter(DefaultParam::class.java).fromJson(json)
+    assertEquals("x", deserialized.x, "Existing value should be used from JSON.")
+    assertEquals("", deserialized.def, "Default value from constructor should be used.")
+  }
+
+  @Test(expected = JsonDataException::class) fun testMissingJsonValue() {
+    val json = "{}"
+    moshi.adapter(DefaultParam::class.java).fromJson(json)
+  }
+
+  data class Inner(val x: String)
+  data class Outer(val inner: Inner)
+
+  @Test fun testInnerOuter() {
+    val json = "{\"inner\": {\"x\": \"\"}}"
+    val deserialized = moshi.adapter(Outer::class.java).fromJson(json)
+    assertEquals("", deserialized.inner.x, "Nested objects should be deserialized corretly.")
+  }
+}

--- a/kotlin/src/test/java/com/squareup/moshi/KotlinJsonAdapterTest.kt
+++ b/kotlin/src/test/java/com/squareup/moshi/KotlinJsonAdapterTest.kt
@@ -1,77 +1,434 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.moshi
 
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.fail
 import org.junit.Test
-import kotlin.test.assertEquals
+import java.io.ByteArrayOutputStream
+import java.util.Locale
+import java.util.SimpleTimeZone
+import kotlin.annotation.AnnotationRetention.RUNTIME
 
-class KotlinJsonAdapterFactoryTest {
+class KotlinJsonAdapterTest {
+  @Test fun constructorParameters() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(ConstructorParameters::class.java)
 
-  private val moshi = Moshi.Builder()
-      .add(KotlinJsonAdapterFactory())
-      .build()
+    val encoded = ConstructorParameters(3, 5)
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"a\":3,\"b\":5}")
 
-  private data class FooBar(val foo: String, @Json(name = "other_name") val named: String) {
-    @Transient val otherProperty = ""
-    @delegate:Transient val delegated by lazy { "" }
+    val decoded = jsonAdapter.fromJson("{\"a\":4,\"b\":6}")
+    assertThat(decoded.a).isEqualTo(4)
+    assertThat(decoded.b).isEqualTo(6)
   }
 
-  @Test fun test() {
-    val adapter = moshi.adapter(FooBar::class.java)
+  class ConstructorParameters(var a: Int, var b: Int)
 
-    val json = "{\"foo\":\"foo\", \"other_name\": \"other_name\"}"
-    val deserialized = adapter.fromJson(json)
-    assertEquals("foo", deserialized.foo, "val deserialization without @Json annotation failed.")
-    assertEquals("other_name", deserialized.named, "@Json(name = ...) was not respected.")
-    assertEquals("", deserialized.otherProperty, "Transient property was not initialized. " +
-        "Was the primary constructor called?")
-    assertEquals("", deserialized.delegated, "Delegated property was not initialized. " +
-        "Was the primary constructor called?")
+  @Test fun properties() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(Properties::class.java)
 
-    assertEquals(deserialized, adapter.fromJson(adapter.toJson(deserialized)),
-        "Object should still be equal after serialization and deserialization.")
+    val encoded = Properties()
+    encoded.a = 3
+    encoded.b = 5
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"a\":3,\"b\":5}")
+
+    val decoded = jsonAdapter.fromJson("{\"a\":3,\"b\":5}")
+    assertThat(decoded.a).isEqualTo(3)
+    assertThat(decoded.b).isEqualTo(5)
   }
 
-  private data class TransientProperty(@Transient val nonBacking: String)
-
-  @Test(expected = IllegalArgumentException::class) fun testTransient() {
-    moshi.adapter(TransientProperty::class.java)
+  class Properties {
+    var a: Int = -1
+    var b: Int = -1
   }
 
-  private open class Superclass {
-    var x: String = ""
-  }
-  private data class NonTransientNonConstructorProperty(val ignored: String): Superclass() {
-    var y: String = ""
-  }
+  @Test fun constructorParametersAndProperties() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(ConstructorParametersAndProperties::class.java)
 
-  @Test() fun testNonTransientNonConstructorProperty() {
-    val adapter = moshi.adapter(NonTransientNonConstructorProperty::class.java)
-    val test = adapter.fromJson("{\"ignored\": \"\", \"x\": \"\", \"y\": \"\"}")
-    assertEquals("", test.x, "Non-constructor parameter from superclass should be deserialized correctly.")
-    assertEquals("", test.y, "Non-constructor parameter should be deserialized correctly.")
-    assertEquals(test, adapter.fromJson(adapter.toJson(test)), "Object should still be equal after serialization and deserialization.")
+    val encoded = ConstructorParametersAndProperties(3)
+    encoded.b = 5
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"a\":3,\"b\":5}")
+
+    val decoded = jsonAdapter.fromJson("{\"a\":4,\"b\":6}")
+    assertThat(decoded.a).isEqualTo(4)
+    assertThat(decoded.b).isEqualTo(6)
   }
 
-  // def can be transient since a default value is provided
-  data class DefaultParam(val x: String, @Transient val def: String = "")
-
-  @Test fun testDefaultParam() {
-    val json = "{\"x\":\"x\"}"
-    val deserialized = moshi.adapter(DefaultParam::class.java).fromJson(json)
-    assertEquals("x", deserialized.x, "Existing value should be used from JSON.")
-    assertEquals("", deserialized.def, "Default value from constructor should be used.")
+  class ConstructorParametersAndProperties(var a: Int) {
+    var b: Int = -1
   }
 
-  @Test(expected = JsonDataException::class) fun testMissingJsonValue() {
-    val json = "{}"
-    moshi.adapter(DefaultParam::class.java).fromJson(json)
+  @Test fun immutableConstructorParameters() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(ImmutableConstructorParameters::class.java)
+
+    val encoded = ImmutableConstructorParameters(3, 5)
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"a\":3,\"b\":5}")
+
+    val decoded = jsonAdapter.fromJson("{\"a\":4,\"b\":6}")
+    assertThat(decoded.a).isEqualTo(4)
+    assertThat(decoded.b).isEqualTo(6)
   }
 
-  data class Inner(val x: String)
-  data class Outer(val inner: Inner)
+  class ImmutableConstructorParameters(val a: Int, val b: Int)
 
-  @Test fun testInnerOuter() {
-    val json = "{\"inner\": {\"x\": \"\"}}"
-    val deserialized = moshi.adapter(Outer::class.java).fromJson(json)
-    assertEquals("", deserialized.inner.x, "Nested objects should be deserialized corretly.")
+  @Test fun immutableProperties() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(ImmutableProperties::class.java)
+
+    val encoded = ImmutableProperties(3, 5)
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"a\":3,\"b\":5}")
+
+    val decoded = jsonAdapter.fromJson("{\"a\":3,\"b\":5}")
+    assertThat(decoded.a).isEqualTo(3)
+    assertThat(decoded.b).isEqualTo(5)
+  }
+
+  class ImmutableProperties(a: Int, b: Int) {
+    val a = a
+    val b = b
+  }
+
+  @Test fun constructorDefaults() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(ConstructorDefaultValues::class.java)
+
+    val encoded = ConstructorDefaultValues(3, 5)
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"a\":3,\"b\":5}")
+
+    val decoded = jsonAdapter.fromJson("{\"b\":6}")
+    assertThat(decoded.a).isEqualTo(-1)
+    assertThat(decoded.b).isEqualTo(6)
+  }
+
+  class ConstructorDefaultValues(var a: Int = -1, var b: Int = -2)
+
+  @Test fun requiredValueAbsent() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(RequiredValueAbsent::class.java)
+
+    try {
+      jsonAdapter.fromJson("{\"a\":4}")
+      fail()
+    } catch(expected: JsonDataException) {
+      assertThat(expected).hasMessage("Required value b missing at $")
+    }
+  }
+
+  class RequiredValueAbsent(var a: Int = 3, var b: Int)
+
+  @Test fun duplicatedValue() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(DuplicateValue::class.java)
+
+    try {
+      jsonAdapter.fromJson("{\"a\":4,\"a\":4}")
+      fail()
+    } catch(expected: JsonDataException) {
+      assertThat(expected).hasMessage("Multiple values for a at $.a")
+    }
+  }
+
+  class DuplicateValue(var a: Int = -1, var b: Int = -2)
+
+  @Test fun explicitNull() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(ExplicitNull::class.java)
+
+    val encoded = ExplicitNull(null, 5)
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"b\":5}")
+    assertThat(jsonAdapter.serializeNulls().toJson(encoded)).isEqualTo("{\"a\":null,\"b\":5}")
+
+    val decoded = jsonAdapter.fromJson("{\"a\":null,\"b\":6}")
+    assertThat(decoded.a).isEqualTo(null)
+    assertThat(decoded.b).isEqualTo(6)
+  }
+
+  class ExplicitNull(var a: Int?, var b: Int?)
+
+  // TODO(jwilson): if a nullable field is absent, just do the obvious thing instead of crashing?
+  @Test fun absentNull() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(AbsentNull::class.java)
+
+    val encoded = AbsentNull(null, 5)
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"b\":5}")
+    assertThat(jsonAdapter.serializeNulls().toJson(encoded)).isEqualTo("{\"a\":null,\"b\":5}")
+
+    try {
+      jsonAdapter.fromJson("{\"b\":6}")
+      fail()
+    } catch(expected: JsonDataException) {
+      assertThat(expected).hasMessage("Required value a missing at $")
+    }
+  }
+
+  class AbsentNull(var a: Int?, var b: Int?)
+
+  @Test fun constructorParameterWithQualifier() {
+    val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapter.FACTORY)
+        .add(UppercaseJsonAdapter())
+        .build()
+    val jsonAdapter = moshi.adapter(ConstructorParameterWithQualifier::class.java)
+
+    val encoded = ConstructorParameterWithQualifier("Android", "Banana")
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"a\":\"ANDROID\",\"b\":\"Banana\"}")
+
+    val decoded = jsonAdapter.fromJson("{\"a\":\"Android\",\"b\":\"Banana\"}")
+    assertThat(decoded.a).isEqualTo("android")
+    assertThat(decoded.b).isEqualTo("Banana")
+  }
+
+  class ConstructorParameterWithQualifier(@Uppercase var a: String, var b: String)
+
+  @Test fun propertyWithQualifier() {
+    val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapter.FACTORY)
+        .add(UppercaseJsonAdapter())
+        .build()
+    val jsonAdapter = moshi.adapter(PropertyWithQualifier::class.java)
+
+    val encoded = PropertyWithQualifier()
+    encoded.a = "Android"
+    encoded.b = "Banana"
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"a\":\"ANDROID\",\"b\":\"Banana\"}")
+
+    val decoded = jsonAdapter.fromJson("{\"a\":\"Android\",\"b\":\"Banana\"}")
+    assertThat(decoded.a).isEqualTo("android")
+    assertThat(decoded.b).isEqualTo("Banana")
+  }
+
+  class PropertyWithQualifier {
+    @Uppercase var a: String = ""
+    var b: String = ""
+  }
+
+  @Test fun constructorParameterWithJsonName() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(ConstructorParameterWithJsonName::class.java)
+
+    val encoded = ConstructorParameterWithJsonName(3, 5)
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"key a\":3,\"b\":5}")
+
+    val decoded = jsonAdapter.fromJson("{\"key a\":4,\"b\":6}")
+    assertThat(decoded.a).isEqualTo(4)
+    assertThat(decoded.b).isEqualTo(6)
+  }
+
+  class ConstructorParameterWithJsonName(@Json(name = "key a") var a: Int, var b: Int)
+
+  @Test fun propertyWithJsonName() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(PropertyWithJsonName::class.java)
+
+    val encoded = PropertyWithJsonName()
+    encoded.a = 3
+    encoded.b = 5
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"key a\":3,\"b\":5}")
+
+    val decoded = jsonAdapter.fromJson("{\"key a\":4,\"b\":6}")
+    assertThat(decoded.a).isEqualTo(4)
+    assertThat(decoded.b).isEqualTo(6)
+  }
+
+  class PropertyWithJsonName {
+    @Json(name = "key a") var a: Int = -1
+    var b: Int = -1
+  }
+
+  @Test fun transientConstructorParameter() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(TransientConstructorParameter::class.java)
+
+    val encoded = TransientConstructorParameter(3, 5)
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"b\":5}")
+
+    val decoded = jsonAdapter.fromJson("{\"a\":4,\"b\":6}")
+    assertThat(decoded.a).isEqualTo(-1)
+    assertThat(decoded.b).isEqualTo(6)
+  }
+
+  class TransientConstructorParameter(@Transient var a: Int = -1, var b: Int = -1)
+
+  @Test fun transientProperty() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(TransientProperty::class.java)
+
+    val encoded = TransientProperty()
+    encoded.a = 3
+    encoded.b = 5
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"b\":5}")
+
+    val decoded = jsonAdapter.fromJson("{\"a\":4,\"b\":6}")
+    assertThat(decoded.a).isEqualTo(-1)
+    assertThat(decoded.b).isEqualTo(6)
+  }
+
+  class TransientProperty {
+    @Transient var a: Int = -1
+    var b: Int = -1
+  }
+
+  @Test fun supertypeConstructorParameters() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(SubtypeConstructorParameters::class.java)
+
+    val encoded = SubtypeConstructorParameters(3, 5)
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"a\":3,\"b\":5}")
+
+    val decoded = jsonAdapter.fromJson("{\"a\":4,\"b\":6}")
+    assertThat(decoded.a).isEqualTo(4)
+    assertThat(decoded.b).isEqualTo(6)
+  }
+
+  open class SupertypeConstructorParameters(var a: Int)
+
+  class SubtypeConstructorParameters(a: Int, var b: Int) : SupertypeConstructorParameters(a)
+
+  @Test fun supertypeProperties() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(SubtypeProperties::class.java)
+
+    val encoded = SubtypeProperties()
+    encoded.a = 3
+    encoded.b = 5
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"b\":5,\"a\":3}")
+
+    val decoded = jsonAdapter.fromJson("{\"a\":4,\"b\":6}")
+    assertThat(decoded.a).isEqualTo(4)
+    assertThat(decoded.b).isEqualTo(6)
+  }
+
+  open class SupertypeProperties {
+    var a: Int = -1
+  }
+
+  class SubtypeProperties : SupertypeProperties() {
+    var b: Int = -1
+  }
+
+  @Test fun extendsPlatformClassWithPrivateField() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(ExtendsPlatformClassWithPrivateField::class.java)
+
+    val encoded = ExtendsPlatformClassWithPrivateField(3)
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"a\":3}")
+
+    val decoded = jsonAdapter.fromJson("{\"a\":4,\"id\":\"B\"}")
+    assertThat(decoded.a).isEqualTo(4)
+    assertThat(decoded.id).isEqualTo("C")
+  }
+
+  internal class ExtendsPlatformClassWithPrivateField(var a: Int) : SimpleTimeZone(0, "C")
+
+  @Test fun extendsPlatformClassWithProtectedField() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(ExtendsPlatformClassWithProtectedField::class.java)
+
+    val encoded = ExtendsPlatformClassWithProtectedField(3)
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"a\":3,\"buf\":[0,0],\"count\":0}")
+
+    val decoded = jsonAdapter.fromJson("{\"a\":4,\"buf\":[0,0],\"size\":0}")
+    assertThat(decoded.a).isEqualTo(4)
+    assertThat(decoded.buf()).isEqualTo(ByteArray(2, { 0 }))
+    assertThat(decoded.count()).isEqualTo(0)
+  }
+
+  internal class ExtendsPlatformClassWithProtectedField(var a: Int) : ByteArrayOutputStream(2) {
+    fun buf() = buf
+    fun count() = count
+  }
+
+  @Test fun platformTypeThrows() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    try {
+      moshi.adapter(Triple::class.java)
+      fail()
+    } catch (e: IllegalArgumentException) {
+      assertThat(e).hasMessage("Platform class kotlin.Triple annotated [] "
+          + "requires explicit JsonAdapter to be registered")
+    }
+  }
+
+  @Test fun privateConstructorParameters() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(PrivateConstructorParameters::class.java)
+
+    val encoded = PrivateConstructorParameters(3, 5)
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"a\":3,\"b\":5}")
+
+    val decoded = jsonAdapter.fromJson("{\"a\":4,\"b\":6}")
+    assertThat(decoded.a()).isEqualTo(4)
+    assertThat(decoded.b()).isEqualTo(6)
+  }
+
+  class PrivateConstructorParameters(private var a: Int, private var b: Int) {
+    fun a() = a
+    fun b() = b
+  }
+
+  @Test fun privateProperties() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapter.FACTORY).build()
+    val jsonAdapter = moshi.adapter(PrivateProperties::class.java)
+
+    val encoded = PrivateProperties()
+    encoded.a(3)
+    encoded.b(5)
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("{\"a\":3,\"b\":5}")
+
+    val decoded = jsonAdapter.fromJson("{\"a\":4,\"b\":6}")
+    assertThat(decoded.a()).isEqualTo(4)
+    assertThat(decoded.b()).isEqualTo(6)
+  }
+
+  class PrivateProperties {
+    var a: Int = -1
+    var b: Int = -1
+
+    fun a() = a
+
+    fun a(a: Int) {
+      this.a = a
+    }
+
+    fun b() = b
+
+    fun b(b: Int) {
+      this.b = b
+    }
+  }
+
+  // TODO(jwilson): resolve generic types?
+  // TODO(jwilson): inaccessible constructors?
+  // TODO(jwilson): constructors parameter that is not a property
+
+  @Retention(RUNTIME)
+  @JsonQualifier
+  annotation class Uppercase
+
+  class UppercaseJsonAdapter {
+    @ToJson fun toJson(@Uppercase s: String) : String {
+      return s.toUpperCase(Locale.US)
+    }
+    @FromJson @Uppercase fun fromJson(s: String) : String {
+      return s.toLowerCase(Locale.US)
+    }
   }
 }

--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -75,36 +75,42 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
       }
       return new ClassJsonAdapter<>(classFactory, fields).nullSafe();
     }
-  };
 
-  /** Creates a field binding for each of declared field of {@code type}. */
-  static void createFieldBindings(
-      Moshi moshi, Type type, Map<String, FieldBinding<?>> fieldBindings) {
-    Class<?> rawType = Types.getRawType(type);
-    boolean platformType = isPlatformType(rawType);
-    for (Field field : rawType.getDeclaredFields()) {
-      if (!includeField(platformType, field.getModifiers())) continue;
+    /** Creates a field binding for each of declared field of {@code type}. */
+    private void createFieldBindings(
+        Moshi moshi, Type type, Map<String, FieldBinding<?>> fieldBindings) {
+      Class<?> rawType = Types.getRawType(type);
+      boolean platformType = isPlatformType(rawType);
+      for (Field field : rawType.getDeclaredFields()) {
+        if (!includeField(platformType, field.getModifiers())) continue;
 
-      // Look up a type adapter for this type.
-      Type fieldType = Types.resolve(type, rawType, field.getGenericType());
-      Set<? extends Annotation> annotations = Util.jsonAnnotations(field);
-      JsonAdapter<Object> adapter = moshi.adapter(fieldType, annotations);
+        // Look up a type adapter for this type.
+        Type fieldType = Types.resolve(type, rawType, field.getGenericType());
+        Set<? extends Annotation> annotations = Util.jsonAnnotations(field);
+        JsonAdapter<Object> adapter = moshi.adapter(fieldType, annotations);
 
-      // Create the binding between field and JSON.
-      field.setAccessible(true);
+        // Create the binding between field and JSON.
+        field.setAccessible(true);
 
-      // Store it using the field's name. If there was already a field with this name, fail!
-      Json jsonAnnotation = field.getAnnotation(Json.class);
-      String name = jsonAnnotation != null ? jsonAnnotation.name() : field.getName();
-      FieldBinding<Object> fieldBinding = new FieldBinding<>(name, field, adapter);
-      FieldBinding<?> replaced = fieldBindings.put(name, fieldBinding);
-      if (replaced != null) {
-        throw new IllegalArgumentException("Conflicting fields:\n"
-            + "    " + replaced.field + "\n"
-            + "    " + fieldBinding.field);
+        // Store it using the field's name. If there was already a field with this name, fail!
+        Json jsonAnnotation = field.getAnnotation(Json.class);
+        String name = jsonAnnotation != null ? jsonAnnotation.name() : field.getName();
+        FieldBinding<Object> fieldBinding = new FieldBinding<>(name, field, adapter);
+        FieldBinding<?> replaced = fieldBindings.put(name, fieldBinding);
+        if (replaced != null) {
+          throw new IllegalArgumentException("Conflicting fields:\n"
+              + "    " + replaced.field + "\n"
+              + "    " + fieldBinding.field);
+        }
       }
     }
-  }
+
+    /** Returns true if fields with {@code modifiers} are included in the emitted JSON. */
+    private boolean includeField(boolean platformType, int modifiers) {
+      if (Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)) return false;
+      return Modifier.isPublic(modifiers) || Modifier.isProtected(modifiers) || !platformType;
+    }
+  };
 
   /**
    * Returns true if {@code rawType} is built in. We don't reflect on private fields of platform
@@ -117,12 +123,6 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
         || name.startsWith("javax.")
         || name.startsWith("kotlin.")
         || name.startsWith("scala.");
-  }
-
-  /** Returns true if fields with {@code modifiers} are included in the emitted JSON. */
-  static boolean includeField(boolean platformType, int modifiers) {
-    if (Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)) return false;
-    return Modifier.isPublic(modifiers) || Modifier.isProtected(modifiers) || !platformType;
   }
 
   private final ClassFactory<T> classFactory;

--- a/moshi/src/main/java/com/squareup/moshi/Json.java
+++ b/moshi/src/main/java/com/squareup/moshi/Json.java
@@ -19,12 +19,23 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-/** Customizes how a field is encoded as JSON. */
-@Target({FIELD, METHOD})
+/**
+ * Customizes how a field is encoded as JSON.
+ *
+ * <p>Although this annotation doesn't declare a {@link Target}, it is only honored in the following
+ * elements:
+ *
+ * <ul>
+ *   <li><strong>Java class fields</strong>
+ *   <li><strong>Kotlin properties</strong> for use with {@code moshi-kotlin}. This includes both
+ *       properties declared in the constructor and properties declared as members.
+ * </ul>
+ *
+ * <p>Users of the <a href="https://github.com/rharter/auto-value-moshi">AutoValue: Moshi
+ * Extension</a> may also use this annotation on abstract getters.
+ */
 @Retention(RUNTIME)
 @Documented
 public @interface Json {

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -533,15 +533,6 @@ public final class MoshiTest {
   }
 
   @Test public void addNullFails() throws Exception {
-    JsonAdapter jsonAdapter = new JsonAdapter() {
-      @Override public Object fromJson(JsonReader reader) throws IOException {
-        throw new AssertionError();
-      }
-
-      @Override public void toJson(JsonWriter writer, Object value) throws IOException {
-        throw new AssertionError();
-      }
-    };
     Type type = Object.class;
     Class<? extends Annotation> annotation = Annotation.class;
     Moshi.Builder builder = new Moshi.Builder();

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <kotlin.version>1.1.1</kotlin.version>
 
     <!-- Dependencies -->
-    <okio.version>1.11.0</okio.version>
+    <okio.version>1.12.0</okio.version>
 
     <!-- Test Dependencies -->
     <junit.version>4.12</junit.version>


### PR DESCRIPTION
1. As `ABSENT_VALUE` is a singleton with its own type, it can be made an `object` ([docs](https://kotlinlang.org/docs/reference/object-declarations.html#object-declarations)).
2. Performance: `var allAnnotations = property.annotations` where `property.annotations` isn't mutable, calling `allAnnotations += ...` will create a copy of the immutable list. I've made it a `val` now by creating a mutable copy of `property.annotations`.