### PR TITLE
Treat negative zero as a number, not a long.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonUtf8Reader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonUtf8Reader.java
@@ -464,7 +464,8 @@ final class JsonUtf8Reader extends JsonReader {
     }
 
     // We've read a complete number. Decide if it's a PEEKED_LONG or a PEEKED_NUMBER.
-    if (last == NUMBER_CHAR_DIGIT && fitsInLong && (value != Long.MIN_VALUE || negative)) {
+    if (last == NUMBER_CHAR_DIGIT && fitsInLong && (value != Long.MIN_VALUE || negative)
+        && (value != 0 || !negative)) {
       peekedLong = negative ? value : -value;
       buffer.skip(i);
       return peeked = PEEKED_LONG;

--- a/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
@@ -330,6 +330,12 @@ public final class JsonUtf8ReaderTest {
     assertThat(reader.nextDouble()).isEqualTo(-92233720368547758080d);
   }
 
+  @Test public void negativeZeroIsANumber() throws Exception {
+    JsonReader reader = newReader("-0");
+    assertEquals(NUMBER, reader.peek());
+    assertEquals("-0", reader.nextString());
+  }
+
   @Test public void quotedNumberWithEscape() throws IOException {
     JsonReader reader = newReader("[\"12\u00334\"]");
     reader.setLenient(true);


### PR DESCRIPTION
Updates logic from https://github.com/google/gson/issues/1053