### PR TITLE
Throw NPE for null indent string in factory method.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
@@ -204,6 +204,9 @@ public abstract class JsonAdapter<T> {
    * @param indent a string containing only whitespace.
    */
   public JsonAdapter<T> indent(final String indent) {
+    if (indent == null) {
+      throw new NullPointerException("indent == null");
+    }
     final JsonAdapter<T> delegate = this;
     return new JsonAdapter<T>() {
       @Override public T fromJson(JsonReader reader) throws IOException {

--- a/moshi/src/test/java/com/squareup/moshi/JsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonAdapterTest.java
@@ -145,6 +145,24 @@ public final class JsonAdapterTest {
         + "]");
   }
 
+  @Test public void indentDisallowsNull() throws Exception {
+    JsonAdapter<Object> adapter = new JsonAdapter<Object>() {
+      @Override public Object fromJson(JsonReader reader) {
+        throw new AssertionError();
+      }
+
+      @Override public void toJson(JsonWriter writer, Object value) {
+        throw new AssertionError();
+      }
+    };
+    try {
+      adapter.indent(null);
+      fail();
+    } catch (NullPointerException expected) {
+      assertThat(expected).hasMessage("indent == null");
+    }
+  }
+
   @Test public void serializeNulls() throws Exception {
     JsonAdapter<Map<String, String>> serializeNulls = new JsonAdapter<Map<String, String>>() {
       @Override public Map<String, String> fromJson(JsonReader reader) throws IOException {


### PR DESCRIPTION
Fail when creating the JsonAdapter rather than when using it.