### PR TITLE
Fix Javadoc builds with the jsr305 dependency.

### DIFF
--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -18,6 +18,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Because multiple modules share a package we need to share the dependency on
everything in package-info.java.