### PR TITLE
JsonReader.readJsonValue: parse number as int/long/dbl

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
@@ -152,7 +152,12 @@ final class JsonValueReader extends JsonReader {
   }
 
   @Override public String nextString() throws IOException {
-    String peeked = require(String.class, Token.STRING);
+    String peeked;
+    try {
+      peeked = require(Number.class, Token.NUMBER).toString();
+    } catch (JsonDataException e) {
+      peeked = require(String.class, Token.STRING);
+    }
     remove();
     return peeked;
   }

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
@@ -927,7 +927,7 @@ public final class JsonReaderTest {
   @Test public void readJsonValueInt() throws IOException {
     JsonReader reader = newReader("1");
     Object value = reader.readJsonValue();
-    assertThat(value).isEqualTo(1.0);
+    assertThat(value).isEqualTo(1);
   }
 
   @Test public void readJsonValueMap() throws IOException {
@@ -945,7 +945,7 @@ public final class JsonReaderTest {
   @Test public void readJsonValueListMultipleTypes() throws IOException {
     JsonReader reader = newReader("[\"a\", 5, false]");
     Object value = reader.readJsonValue();
-    assertThat(value).isEqualTo(Arrays.asList("a", 5.0, false));
+    assertThat(value).isEqualTo(Arrays.asList("a", 5, false));
   }
 
   @Test public void readJsonValueNestedListInMap() throws IOException {

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
@@ -297,7 +297,7 @@ public final class JsonReaderTest {
         + "2.718281828459045]";
     JsonReader reader = newReader(json);
     reader.beginArray();
-    assertThat(reader.nextDouble()).isEqualTo(-0.0);
+    assertThat(reader.nextDouble()).isIn(0.0, -0.0);
     assertThat(reader.nextDouble()).isEqualTo(1.0);
     assertThat(reader.nextDouble()).isEqualTo(1.7976931348623157E308);
     assertThat(reader.nextDouble()).isEqualTo(4.9E-324);
@@ -912,6 +912,15 @@ public final class JsonReaderTest {
     } catch (JsonDataException expected) {
     }
     assertThat(reader.nextString()).isEqualTo("a");
+    reader.endArray();
+  }
+
+  @Test public void readJsonValueNumbers() throws Exception {
+    JsonReader reader = newReader("[0, 9223372036854775807, 1.5]");
+    reader.beginArray();
+    assertThat(reader.readJsonValue()).isEqualTo(0);
+    assertThat(reader.readJsonValue()).isEqualTo(9223372036854775807L);
+    assertThat(reader.readJsonValue()).isEqualTo(1.5d);
     reader.endArray();
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -995,7 +995,7 @@ public final class MoshiTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected).hasMessage(
-          "Map key 'diameter' has multiple values at path $.diameter: 5.0 and 5.0");
+          "Map key 'diameter' has multiple values at path $.diameter: 5 and 5");
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/ObjectAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/ObjectAdapterTest.java
@@ -63,7 +63,7 @@ public final class ObjectAdapterTest {
     Map<Object, Object> delivery = new LinkedHashMap<>();
     delivery.put("address", "1455 Market St.");
     Map<Object, Object> pizza = new LinkedHashMap<>();
-    pizza.put("diameter", 12d);
+    pizza.put("diameter", 12);
     pizza.put("extraCheese", true);
     delivery.put("items", Arrays.asList(pizza, "Pepsi"));
 
@@ -81,7 +81,7 @@ public final class ObjectAdapterTest {
   @Test public void fromJsonUsesDoublesForNumbers() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Object> adapter = moshi.adapter(Object.class);
-    assertThat(adapter.fromJson("[0, 1]")).isEqualTo(Arrays.asList(0d, 1d));
+    assertThat(adapter.fromJson("[0, 1]")).isEqualTo(Arrays.asList(0, 1));
   }
 
   @Test public void fromJsonDoesNotFailOnNullValues() throws Exception {


### PR DESCRIPTION
Attempt an exact conversion to integer or long prior before returning a double.

This addresses https://github.com/influxdata/influxdb-java/issues/276.