### PR TITLE
Allow configuration of maximum nesting depth.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/Config.java
+++ b/moshi/src/main/java/com/squareup/moshi/Config.java
@@ -1,0 +1,9 @@
+package com.squareup.moshi;
+
+public class Config {
+
+  private Config() {}
+
+  public static int maxDepth = 32;
+
+}

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -175,13 +175,14 @@ import okio.ByteString;
  * of this class are not thread safe.
  */
 public abstract class JsonReader implements Closeable {
-  // The nesting stack. Using a manual array rather than an ArrayList saves 20%. This stack permits
-  // up to 32 levels of nesting including the top-level document. Deeper nesting is prone to trigger
+  // The nesting stack. Using a manual array rather than an ArrayList saves 20%. By default, this stack
+  // permits up to 32 levels of nesting including the top-level document. Deeper nesting is prone to trigger
   // StackOverflowErrors.
   int stackSize = 0;
-  final int[] scopes = new int[32];
-  final String[] pathNames = new String[32];
-  final int[] pathIndices = new int[32];
+  final int maxDepth = Config.maxDepth;
+  final int[] scopes = new int[maxDepth];
+  final String[] pathNames = new String[maxDepth];
+  final int[] pathIndices = new int[maxDepth];
 
   /** True to accept non-spec compliant JSON. */
   boolean lenient;

--- a/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
@@ -49,7 +49,7 @@ final class JsonValueReader extends JsonReader {
   /** Sentinel object pushed on {@link #stack} when the reader is closed. */
   private static final Object JSON_READER_CLOSED = new Object();
 
-  private final Object[] stack = new Object[32];
+  private final Object[] stack = new Object[maxDepth];
 
   JsonValueReader(Object root) {
     scopes[stackSize] = JsonScope.NONEMPTY_DOCUMENT;

--- a/moshi/src/main/java/com/squareup/moshi/JsonValueWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonValueWriter.java
@@ -31,7 +31,7 @@ import static java.lang.Double.POSITIVE_INFINITY;
 
 /** Writes JSON by building a Java object comprising maps, lists, and JSON primitives. */
 final class JsonValueWriter extends JsonWriter {
-  private final Object[] stack = new Object[32];
+  private final Object[] stack = new Object[maxDepth];
   private @Nullable String deferredName;
 
   JsonValueWriter() {

--- a/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
@@ -120,13 +120,14 @@ import static com.squareup.moshi.JsonScope.NONEMPTY_OBJECT;
  * malformed JSON string will fail with an {@link IllegalStateException}.
  */
 public abstract class JsonWriter implements Closeable, Flushable {
-  // The nesting stack. Using a manual array rather than an ArrayList saves 20%. This stack permits
-  // up to 32 levels of nesting including the top-level document. Deeper nesting is prone to trigger
+  // The nesting stack. Using a manual array rather than an ArrayList saves 20%. By default, this stack
+  // permits up to 32 levels of nesting including the top-level document. Deeper nesting is prone to trigger
   // StackOverflowErrors.
   int stackSize = 0;
-  final int[] scopes = new int[32];
-  final String[] pathNames = new String[32];
-  final int[] pathIndices = new int[32];
+  final int maxDepth = Config.maxDepth;
+  final int[] scopes = new int[maxDepth];
+  final String[] pathNames = new String[maxDepth];
+  final int[] pathIndices = new int[maxDepth];
 
   /**
    * A string containing a full set of spaces for a single level of indentation, or null for no

--- a/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
@@ -432,6 +432,24 @@ public final class JsonWriterTest {
         .isEqualTo("[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]");
   }
 
+  @Test public void deeperNestingArrays() throws IOException {
+    ++Config.maxDepth;
+    try {
+      JsonWriter writer = factory.newWriter();
+      for (int i = 0; i < 32; i++) {
+        writer.beginArray();
+      }
+      for (int i = 0; i < 32; i++) {
+        writer.endArray();
+      }
+      assertThat(factory.json())
+        .isEqualTo("[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]");
+    }
+    finally {
+      --Config.maxDepth;
+    }
+  }
+
   @Test public void tooDeepNestingArrays() throws IOException {
     JsonWriter writer = factory.newWriter();
     for (int i = 0; i < 31; i++) {
@@ -460,6 +478,28 @@ public final class JsonWriterTest {
         + "{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":"
         + "{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":"
         + "{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":true}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}");
+  }
+
+  @Test public void deeperNestingObjects() throws IOException {
+    ++Config.maxDepth;
+    try {
+      JsonWriter writer = factory.newWriter();
+      for (int i = 0; i < 32; i++) {
+        writer.beginObject();
+        writer.name("a");
+      }
+      writer.value(true);
+      for (int i = 0; i < 32; i++) {
+        writer.endObject();
+      }
+      assertThat(factory.json()).isEqualTo(""
+        + "{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":"
+        + "{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":"
+        + "{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":{\"a\":true}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}");
+    }
+    finally {
+      --Config.maxDepth;
+    }
   }
 
   @Test public void tooDeepNestingObjects() throws IOException {


### PR DESCRIPTION
I ran into the max depth limit with a (very) complex elastic query.
I think the max depth should be configurable.

I've added a Config object that is used to configure the maximum allowed nesting depth before a JsonDataException is thrown.
The JsonReaders and JsonWriters are using this variable for sizing their internal arrays rather than hardcoding the length to 32.

I experimented with adding additional implementations of JsonReader and JsonWriter, but I couldn't get something clean because of the factory methods. This static Config seemed like the best way to do it.
There's no change to the existing APIs at all, juste an extra Config object to increase (or decrease the max depth allowed).