### PR TITLE
Fail earlier with null annotation set.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -119,6 +119,8 @@ public final class Moshi {
   @SuppressWarnings("unchecked") // Factories are required to return only matching JsonAdapters.
   public <T> JsonAdapter<T> nextAdapter(JsonAdapter.Factory skipPast, Type type,
       Set<? extends Annotation> annotations) {
+    if (annotations == null) throw new NullPointerException("annotations == null");
+
     type = Types.canonicalize(type);
 
     int skipPastIndex = factories.indexOf(skipPast);

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import javax.crypto.KeyGenerator;
 import okio.Buffer;
 import org.junit.Test;
@@ -703,6 +704,23 @@ public final class MoshiTest {
 
   @Uppercase
   static String uppercaseString;
+
+  @Test public void nextJsonAdapterDisallowsNullAnnotations() throws Exception {
+    JsonAdapter.Factory badFactory = new JsonAdapter.Factory() {
+      @Nullable @Override
+      public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations,
+          Moshi moshi) {
+        return moshi.nextAdapter(this, type, null);
+      }
+    };
+    Moshi moshi = new Moshi.Builder().add(badFactory).build();
+    try {
+      moshi.adapter(Object.class);
+      fail();
+    } catch (NullPointerException expected) {
+      assertThat(expected).hasMessage("annotations == null");
+    }
+  }
 
   @Test public void delegatingJsonAdapterFactory() throws Exception {
     Moshi moshi = new Moshi.Builder()


### PR DESCRIPTION
I am concerned someone might misuse Types.nextAnnotations (nullable return type) and get the error deeper in another Factory's usage (like in StandardJsonAdapters.FACTORY) which could be confusing.