### PR TITLE
JsonAdapter.Factory.create rejects the null Type.

### DIFF
--- a/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
+++ b/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
@@ -148,7 +148,7 @@ internal class KotlinJsonAdapter<T>(
 }
 
 class KotlinJsonAdapterFactory : JsonAdapter.Factory {
-  override fun create(type: Type?, annotations: MutableSet<out Annotation>, moshi: Moshi)
+  override fun create(type: Type, annotations: MutableSet<out Annotation>, moshi: Moshi)
       : JsonAdapter<*>? {
     if (!annotations.isEmpty()) return null
 


### PR DESCRIPTION
This fails already in Types.getRawType, but a compiler error is preferable.