### PR TITLE
Add ProGuard rule for JsonQualifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ If you are using ProGuard you might need to add the following options:
 -keepclasseswithmembers class * {
     @com.squareup.moshi.* <methods>;
 }
+-keep @com.squareup.moshi.JsonQualifier class *
 ```
 Additional rules are needed if you are using the Kotlin artifact:
 ```

--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ If you are using ProGuard you might need to add the following options:
 -keepclasseswithmembers class * {
     @com.squareup.moshi.* <methods>;
 }
--keep @com.squareup.moshi.JsonQualifier class *
+-keep @com.squareup.moshi.JsonQualifier interface *
 ```
 Additional rules are needed if you are using the Kotlin artifact:
 ```


### PR DESCRIPTION
Hopefully, this will save others from the 3+ hours of ProGuard hell I just dredged through. 

Looks like annotations meant for `@JsonQualifier` were getting stripped by ProGuard, which does not cause builds to fail, so it is extremely subtle. It also would not cause runtime errors all the time, just for specific cases, such as if you had two `java.util.Date` formats, like so:
```
new Moshi.Builder()
                .add(new DashDateAdapter())
                .add(new SlashDateAdapter())
                .build();
```
It would presumably fail to find the annotations, and would just use DashDateAdapter for all `java.util.Date`s, since it is added to Moshi first. Therefore the error would typically come from that adapter trying to parse a date that is meant for another adapter entirely. 

The rule is a derivation of one I found for [LoganSquare](https://github.com/bluelinelabs/LoganSquare) which appears as:
`-keep @com.bluelinelabs.logansquare.annotation.JsonObject class *`

I believe the new rule is specific enough, since it will force keep all annotation classes that are annotated with `@JsonQualifier` but honestly, ProGuard rules can be hard for me to grasp. Please let me know if there is a more restrictive rule that would suit this case better. Regardless, this one fixed the problem for me, and I believe is the general rule that will work for everyone.