### PR TITLE
Support reading values with up to 255 levels of nesting

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -198,18 +198,6 @@ public abstract class JsonReader implements Closeable {
     // Package-private to control subclasses.
   }
 
-  final void pushScope(int newTop) {
-    if (stackSize == scopes.length) {
-      if (stackSize == 256) {
-        throw new JsonDataException("Nesting too deep at " + getPath());
-      }
-      scopes = Util.doubleArray(scopes);
-      pathNames = Util.doubleArray(pathNames);
-      pathIndices = Util.doubleArray(pathIndices);
-    }
-    scopes[stackSize++] = newTop;
-  }
-
   /**
    * Throws a new IO exception with the given message and a context snippet
    * with this reader's content.
@@ -225,6 +213,21 @@ public abstract class JsonReader implements Closeable {
     } else {
       return new JsonDataException("Expected " + expected + " but was " + value + ", a "
           + value.getClass().getName() + ", at path " + getPath());
+    }
+  }
+
+  /**
+   * Ensures that the scopes, pathNames, and pathIndicies all have the capacity to hold an
+   * additional element.
+   */
+  void checkStack() {
+    if (stackSize == scopes.length) {
+      if (stackSize == 256) {
+        throw new JsonDataException("Nesting too deep at " + getPath());
+      }
+      scopes = Util.doubleArray(scopes);
+      pathNames = Util.doubleArray(pathNames);
+      pathIndices = Util.doubleArray(pathIndices);
     }
   }
 

--- a/moshi/src/main/java/com/squareup/moshi/JsonUtf8Reader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonUtf8Reader.java
@@ -98,6 +98,11 @@ final class JsonUtf8Reader extends JsonReader {
     pushScope(JsonScope.EMPTY_DOCUMENT);
   }
 
+  private void pushScope(int newTop) {
+    checkStack();
+    scopes[stackSize++] = newTop;
+  }
+
   @Override public void beginArray() throws IOException {
     int p = peeked;
     if (p == PEEKED_NONE) {

--- a/moshi/src/main/java/com/squareup/moshi/JsonUtf8Writer.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonUtf8Writer.java
@@ -101,6 +101,7 @@ final class JsonUtf8Writer extends JsonWriter {
    */
   private JsonWriter open(int empty, String openBracket) throws IOException {
     beforeValue();
+    checkStack();
     pushScope(empty);
     pathIndices[stackSize - 1] = 0;
     sink.writeUtf8(openBracket);

--- a/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
@@ -49,7 +49,7 @@ final class JsonValueReader extends JsonReader {
   /** Sentinel object pushed on {@link #stack} when the reader is closed. */
   private static final Object JSON_READER_CLOSED = new Object();
 
-  private final Object[] stack = new Object[32];
+  private Object[] stack = new Object[32];
 
   JsonValueReader(Object root) {
     scopes[stackSize] = JsonScope.NONEMPTY_DOCUMENT;
@@ -288,10 +288,19 @@ final class JsonValueReader extends JsonReader {
   }
 
   private void push(Object newTop) {
-    if (stackSize == stack.length) {
-      throw new JsonDataException("Nesting too deep at " + getPath());
-    }
+    checkStack();
     stack[stackSize++] = newTop;
+  }
+
+  @Override
+  void checkStack() {
+    super.checkStack();
+
+    // super.checkStack() checks for maximum size. If we get here it's safe to say the stack size
+    // is under its limit.
+    if (stackSize == stack.length) {
+      stack = Util.doubleArray(stack);
+    }
   }
 
   /**

--- a/moshi/src/main/java/com/squareup/moshi/JsonValueWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonValueWriter.java
@@ -31,7 +31,7 @@ import static java.lang.Double.POSITIVE_INFINITY;
 
 /** Writes JSON by building a Java object comprising maps, lists, and JSON primitives. */
 final class JsonValueWriter extends JsonWriter {
-  private final Object[] stack = new Object[32];
+  Object[] stack = new Object[32];
   private @Nullable String deferredName;
 
   JsonValueWriter() {
@@ -47,9 +47,7 @@ final class JsonValueWriter extends JsonWriter {
   }
 
   @Override public JsonWriter beginArray() throws IOException {
-    if (stackSize == stack.length) {
-      throw new JsonDataException("Nesting too deep at " + getPath() + ": circular reference?");
-    }
+    checkStack();
     List<Object> list = new ArrayList<>();
     add(list);
     stack[stackSize] = list;
@@ -69,9 +67,7 @@ final class JsonValueWriter extends JsonWriter {
   }
 
   @Override public JsonWriter beginObject() throws IOException {
-    if (stackSize == stack.length) {
-      throw new JsonDataException("Nesting too deep at " + getPath() + ": circular reference?");
-    }
+    checkStack();
     Map<String, Object> map = new LinkedHashTreeMap<>();
     add(map);
     stack[stackSize] = map;

--- a/moshi/src/main/java/com/squareup/moshi/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/Util.java
@@ -17,6 +17,7 @@ package com.squareup.moshi;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Array;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -65,5 +66,18 @@ final class Util {
       }
     }
     return false;
+  }
+
+  public static int[] doubleArray(int[] array) {
+    int[] result = new int[array.length * 2];
+    System.arraycopy(array, 0, result, 0, array.length);
+    return result;
+  }
+
+  public static <T> T[] doubleArray(T[] array) {
+    @SuppressWarnings("unchecked") // We use the same type as 'array'.
+    T[] result = (T[]) Array.newInstance(array.getClass().getComponentType(), array.length * 2);
+    System.arraycopy(array, 0, result, 0, array.length);
+    return result;
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
@@ -554,35 +554,34 @@ public final class JsonReaderTest {
   }
 
   @Test public void deeplyNestedArrays() throws IOException {
-    JsonReader reader = newReader("[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]");
-    for (int i = 0; i < 31; i++) {
+    JsonReader reader = newReader(repeat("[", 255) + repeat("]", 255));
+    for (int i = 0; i < 255; i++) {
       reader.beginArray();
     }
-    assertThat(reader.getPath()).isEqualTo("$[0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0]"
-        + "[0][0][0][0][0][0][0][0][0][0][0][0][0]");
-    for (int i = 0; i < 31; i++) {
+    assertThat(reader.getPath()).isEqualTo("$" + repeat("[0]", 255));
+    for (int i = 0; i < 255; i++) {
       reader.endArray();
     }
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
   }
 
   @Test public void deeplyNestedObjects() throws IOException {
-    // Build a JSON document structured like {"a":{"a":{"a":{"a":true}}}}, but 31 levels deep.
+    // Build a JSON document structured like {"a":{"a":{"a":{"a":true}}}}, but 255 levels deep.
     String array = "{\"a\":%s}";
     String json = "true";
-    for (int i = 0; i < 31; i++) {
+    for (int i = 0; i < 255; i++) {
       json = String.format(array, json);
     }
 
     JsonReader reader = newReader(json);
-    for (int i = 0; i < 31; i++) {
+    for (int i = 0; i < 255; i++) {
       reader.beginObject();
       assertThat(reader.nextName()).isEqualTo("a");
     }
     assertThat(reader.getPath())
-        .isEqualTo("$.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a");
+        .isEqualTo("$" + repeat(".a", 255));
     assertThat(reader.nextBoolean()).isTrue();
-    for (int i = 0; i < 31; i++) {
+    for (int i = 0; i < 255; i++) {
       reader.endObject();
     }
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);

--- a/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
@@ -1011,17 +1011,15 @@ public final class JsonUtf8ReaderTest {
   }
 
   @Test public void tooDeeplyNestedArrays() throws IOException {
-    JsonReader reader = newReader(
-        "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]");
-    for (int i = 0; i < 31; i++) {
+    JsonReader reader = newReader(repeat("[", 256) + repeat("]", 256));
+    for (int i = 0; i < 255; i++) {
       reader.beginArray();
     }
     try {
       reader.beginArray();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Nesting too deep at $[0][0][0][0][0][0][0][0][0][0][0][0][0]"
-          + "[0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0]");
+      assertThat(expected).hasMessage("Nesting too deep at $" + repeat("[0]", 255));
     }
   }
 
@@ -1029,12 +1027,12 @@ public final class JsonUtf8ReaderTest {
     // Build a JSON document structured like {"a":{"a":{"a":{"a":true}}}}, but 31 levels deep.
     String array = "{\"a\":%s}";
     String json = "true";
-    for (int i = 0; i < 32; i++) {
+    for (int i = 0; i < 256; i++) {
       json = String.format(array, json);
     }
 
     JsonReader reader = newReader(json);
-    for (int i = 0; i < 31; i++) {
+    for (int i = 0; i < 255; i++) {
       reader.beginObject();
       assertThat(reader.nextName()).isEqualTo("a");
     }
@@ -1042,8 +1040,7 @@ public final class JsonUtf8ReaderTest {
       reader.beginObject();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage(
-          "Nesting too deep at $.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a");
+      assertThat(expected).hasMessage("Nesting too deep at $" + repeat(".a", 255));
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
@@ -16,17 +16,15 @@
 package com.squareup.moshi;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import org.junit.Test;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
+import static com.squareup.moshi.TestUtil.repeat;
 
 public final class JsonValueReaderTest {
   @Test public void array() throws Exception {
@@ -425,29 +423,28 @@ public final class JsonValueReaderTest {
 
   @Test public void tooDeeplyNestedArrays() throws IOException {
     Object root = Collections.emptyList();
-    for (int i = 0; i < 32; i++) {
+    for (int i = 0; i < 256; i++) {
       root = singletonList(root);
     }
     JsonReader reader = new JsonValueReader(root);
-    for (int i = 0; i < 31; i++) {
+    for (int i = 0; i < 255; i++) {
       reader.beginArray();
     }
     try {
       reader.beginArray();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Nesting too deep at $[0][0][0][0][0][0][0][0][0][0][0][0][0]"
-          + "[0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0]");
+      assertThat(expected).hasMessage("Nesting too deep at $" + repeat("[0]", 256));
     }
   }
 
   @Test public void tooDeeplyNestedObjects() throws IOException {
     Object root = Boolean.TRUE;
-    for (int i = 0; i < 32; i++) {
+    for (int i = 0; i < 256; i++) {
       root = singletonMap("a", root);
     }
     JsonReader reader = new JsonValueReader(root);
-    for (int i = 0; i < 31; i++) {
+    for (int i = 0; i < 255; i++) {
       reader.beginObject();
       assertThat(reader.nextName()).isEqualTo("a");
     }
@@ -456,7 +453,7 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected).hasMessage(
-          "Nesting too deep at $.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.");
+          "Nesting too deep at $." + repeat("a.", 255));
     }
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
@@ -25,6 +25,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
+import static com.squareup.moshi.TestUtil.repeat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
@@ -434,15 +435,15 @@ public final class JsonWriterTest {
 
   @Test public void tooDeepNestingArrays() throws IOException {
     JsonWriter writer = factory.newWriter();
-    for (int i = 0; i < 31; i++) {
+    for (int i = 0; i < 255; i++) {
       writer.beginArray();
     }
     try {
       writer.beginArray();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Nesting too deep at $[0][0][0][0][0][0][0][0][0][0][0][0][0]"
-          + "[0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0]: circular reference?");
+      assertThat(expected).hasMessage("Nesting too deep at $"
+          + repeat("[0]", 255) + ": circular reference?");
     }
   }
 
@@ -464,7 +465,7 @@ public final class JsonWriterTest {
 
   @Test public void tooDeepNestingObjects() throws IOException {
     JsonWriter writer = factory.newWriter();
-    for (int i = 0; i < 31; i++) {
+    for (int i = 0; i < 255; i++) {
       writer.beginObject();
       writer.name("a");
     }
@@ -472,8 +473,8 @@ public final class JsonWriterTest {
       writer.beginObject();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Nesting too deep at $.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a."
-          + "a.a.a.a.a.a.a.a.a.a.a.a: circular reference?");
+      assertThat(expected).hasMessage("Nesting too deep at $"
+          + repeat(".a", 255) + ": circular reference?");
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -38,6 +38,7 @@ import okio.Buffer;
 import org.junit.Test;
 
 import static com.squareup.moshi.TestUtil.newReader;
+import static com.squareup.moshi.TestUtil.repeat;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
@@ -971,8 +972,8 @@ public final class MoshiTest {
       moshi.adapter(Object.class).toJson(map);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Nesting too deep at $.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a."
-          + "a.a.a.a.a.a.a.a.a.a.a.a: circular reference?");
+      assertThat(expected).hasMessage("Nesting too deep at $"
+          + repeat(".a", 255) + ": circular reference?");
     }
   }
 
@@ -984,8 +985,8 @@ public final class MoshiTest {
       moshi.adapter(Object.class).toJson(list);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Nesting too deep at $[0][0][0][0][0][0][0][0][0][0][0][0][0]"
-          + "[0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0]: circular reference?");
+      assertThat(expected).hasMessage("Nesting too deep at $"
+          + repeat("[0]", 255) + ": circular reference?");
     }
   }
 
@@ -999,8 +1000,8 @@ public final class MoshiTest {
       moshi.adapter(Object.class).toJson(list);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Nesting too deep at $[0].a[0].a[0].a[0].a[0].a[0].a[0].a[0]."
-          + "a[0].a[0].a[0].a[0].a[0].a[0].a[0].a[0]: circular reference?");
+      assertThat(expected).hasMessage("Nesting too deep at $[0]"
+          + repeat(".a[0]", 127) + ": circular reference?");
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/TestUtil.java
+++ b/moshi/src/test/java/com/squareup/moshi/TestUtil.java
@@ -30,6 +30,14 @@ final class TestUtil {
     return new String(array);
   }
 
+  static String repeat(String s, int count) {
+    StringBuilder result = new StringBuilder(s.length() * count);
+    for (int i = 0; i < count; i++) {
+      result.append(s);
+    }
+    return result.toString();
+  }
+
   private TestUtil() {
     throw new AssertionError("No instances.");
   }


### PR DESCRIPTION
Not sure if I'm doing this right, but this PR patches #349 to allow JsonValueReader to handle up to 255 levels of nesting.