### PR TITLE
make ClassJsonAdapter not final

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -46,6 +46,8 @@ class ClassJsonAdapter<T> extends JsonAdapter<T> {
     @Override public @Nullable JsonAdapter<?> create(
         Type type, Set<? extends Annotation> annotations, Moshi moshi) {
       Class<?> rawType = getRawType(type, annotations);
+      if (rawType == null)
+        return null;
       ClassFactory<Object> classFactory = ClassFactory.get(rawType);
       Map<String, FieldBinding<?>> fields = new TreeMap<>();
       for (Type t = type; t != Object.class; t = Types.getGenericSuperclass(t)) {
@@ -117,7 +119,7 @@ class ClassJsonAdapter<T> extends JsonAdapter<T> {
       if (Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)) return false;
       return Modifier.isPublic(modifiers) || Modifier.isProtected(modifiers) || !platformType;
     }
- 
+
   /**
    * Returns true if {@code rawType} is built in. We don't reflect on private fields of platform
    * types because they're unspecified and likely to be different on Java vs. Android.

--- a/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
@@ -37,7 +37,9 @@ public abstract class JsonAdapter<T> {
   }
 
   public final @Nullable T fromJson(String string) throws IOException {
-    return fromJson(new Buffer().writeUtf8(string));
+    try (Buffer buffer = new Buffer()) {
+    	return fromJson(buffer.writeUtf8(string));
+    }
   }
 
   public abstract void toJson(JsonWriter writer, @Nullable T value) throws IOException;

--- a/moshi/src/main/java/com/squareup/moshi/Types.java
+++ b/moshi/src/main/java/com/squareup/moshi/Types.java
@@ -207,9 +207,9 @@ public final class Types {
     if (a == b) {
       return true; // Also handles (a == null && b == null).
 
-    } else if (a instanceof Class) {
+    } else if (a instanceof Class<?>) {
       if (b instanceof GenericArrayType) {
-        return equals(((Class) a).getComponentType(),
+        return equals(((Class<?>) a).getComponentType(),
             ((GenericArrayType) b).getGenericComponentType());
       }
       return a.equals(b); // Class already specifies equals().
@@ -230,7 +230,7 @@ public final class Types {
 
     } else if (a instanceof GenericArrayType) {
       if (b instanceof Class) {
-        return equals(((Class) b).getComponentType(),
+        return equals(((Class<?>) b).getComponentType(),
             ((GenericArrayType) a).getGenericComponentType());
       }
       if (!(b instanceof GenericArrayType)) return false;

--- a/moshi/src/test/java/com/squareup/moshi/JsonCodecFactory.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonCodecFactory.java
@@ -29,8 +29,10 @@ abstract class JsonCodecFactory {
       Buffer buffer;
 
       @Override public JsonReader newReader(String json) {
-        Buffer buffer = new Buffer().writeUtf8(json);
-        return JsonReader.of(buffer);
+        try (Buffer buffer = new Buffer()) {
+          buffer.writeUtf8(json);
+          return JsonReader.of(buffer);
+        }
       }
 
       @Override JsonWriter newWriter() {


### PR DESCRIPTION
in this PR i made following changes:

- remove final from ClassJsonAdapter to be able to subclass it
- set includeField as static and moe out from the factory same as isPlatformType since they have totally similar purpose
- move out from the factory and make static the createFieldBindings
- factor out getRawType from the JsonAdapter.Factory.create same as all the above includeField, isPlatformType and createFieldBindings

the reason for these cahnges to be able to subclass from ClassJsonAdapter and easily implement other adapter classes for which i'll send another PR. 