### PR TITLE
make ClassJsonAdapter not final

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -46,6 +46,8 @@ class ClassJsonAdapter<T> extends JsonAdapter<T> {
     @Override public @Nullable JsonAdapter<?> create(
         Type type, Set<? extends Annotation> annotations, Moshi moshi) {
       Class<?> rawType = getRawType(type, annotations);
+      if (rawType == null)
+        return null;
       ClassFactory<Object> classFactory = ClassFactory.get(rawType);
       Map<String, FieldBinding<?>> fields = new TreeMap<>();
       for (Type t = type; t != Object.class; t = Types.getGenericSuperclass(t)) {
@@ -117,7 +119,7 @@ class ClassJsonAdapter<T> extends JsonAdapter<T> {
       if (Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)) return false;
       return Modifier.isPublic(modifiers) || Modifier.isProtected(modifiers) || !platformType;
     }
- 
+
   /**
    * Returns true if {@code rawType} is built in. We don't reflect on private fields of platform
    * types because they're unspecified and likely to be different on Java vs. Android.


### PR DESCRIPTION
in this PR i made following changes:

- remove final from ClassJsonAdapter to be able to subclass it
- set includeField as static and move out from the factory same as isPlatformType since they have totally similar purpose
- move out from the factory and make static the createFieldBindings
- factor out getRawType from the JsonAdapter.Factory.create same as all the above includeField, isPlatformType and createFieldBindings

the reason for these changes to be able to subclass from ClassJsonAdapter and easily implement other adapter classes for which i'll send another PR (described in #357)