### PR TITLE
Document adding the KotlinJsonAdapterFactory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,9 +474,10 @@ public final class BlackjackHand {
 
 ### Kotlin Support
 
-Kotlin classes work with Moshi out of the box, with the exception of annotations. If you need to annotate your Kotlin classes with an `@Json` annotation or otherwise, you will need to use the `moshi-kotlin` artifact, and set up Moshi to use its converter factory:
+Kotlin classes work with Moshi out of the box, with the exception of annotations. If you need to annotate your Kotlin classes with an `@Json` annotation or otherwise, you will need to use the `moshi-kotlin` artifact, and set up Moshi to use its converter factory. Add the KotlinJsonAdapterFactory last to allow other installed Kotlin type factories to be used, since factories are called in order.
 ```kotlin
 val moshi = Moshi.Builder()
+    // Add any other JsonAdapter factories.
     .add(KotlinJsonAdapterFactory())
     .build()
 ```


### PR DESCRIPTION
If you add a custom Kotlin JsonAdapter factory after the KotlinJsonAdapterFactory, you're going to have a bad time.
</br>
see #351

I think my app code is going to have a function like:
```kotlin
fun withKotlinJsonAdapterFactories(moshi: Moshi): Moshi =
    moshi.newBuilder().add(KotlinJsonAdapterFactory()).build()
```
</br>
Feel free to better the explanation.