### PR TITLE
Clarify error message for transient parameters.

### DIFF
--- a/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
+++ b/kotlin/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
@@ -164,9 +164,16 @@ class KotlinJsonAdapterFactory : JsonAdapter.Factory {
     val bindingsByName = LinkedHashMap<String, KotlinJsonAdapter.Binding<Any, Any?>>()
 
     for (property in rawType.kotlin.memberProperties) {
-      if (Modifier.isTransient(property.javaField?.modifiers ?: 0)) continue
-
       val parameter = parametersByName[property.name]
+
+      if (Modifier.isTransient(property.javaField?.modifiers ?: 0)) {
+        if (parameter != null && !parameter.isOptional) {
+          throw IllegalArgumentException(
+              "No default value for transient constructor $parameter")
+        }
+        continue
+      }
+
       if (property !is KMutableProperty1 && parameter == null) continue
 
       property.isAccessible = true

--- a/kotlin/src/test/java/com/squareup/moshi/KotlinJsonAdapterTest.kt
+++ b/kotlin/src/test/java/com/squareup/moshi/KotlinJsonAdapterTest.kt
@@ -277,6 +277,20 @@ class KotlinJsonAdapterTest {
 
   class TransientConstructorParameter(@Transient var a: Int = -1, var b: Int = -1)
 
+  @Test fun requiredTransientConstructorParameterFails() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    try {
+      moshi.adapter(RequiredTransientConstructorParameter::class.java)
+      fail()
+    } catch (expected: IllegalArgumentException) {
+      assertThat(expected).hasMessage("No default value for transient constructor parameter #0 " +
+          "a of fun <init>(kotlin.Int): " +
+          "com.squareup.moshi.KotlinJsonAdapterTest.RequiredTransientConstructorParameter")
+    }
+  }
+
+  class RequiredTransientConstructorParameter(@Transient var a: Int)
+
   @Test fun transientProperty() {
     val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
     val jsonAdapter = moshi.adapter(TransientProperty::class.java)
@@ -516,7 +530,7 @@ class KotlinJsonAdapterTest {
       fail()
     } catch(expected: IllegalArgumentException) {
       assertThat(expected).hasMessage(
-          "No property for required constructor parameter #0 a of " + "fun <init>(" +
+          "No property for required constructor parameter #0 a of fun <init>(" +
               "kotlin.Int, kotlin.Int): ${NonPropertyConstructorParameter::class.qualifiedName}")
     }
   }


### PR DESCRIPTION
Otherwise, the error message is misleading: "No property for required constructor $parameter"