### PR TITLE
Let JsonValueReader.nextString read numbers.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
@@ -152,9 +152,19 @@ final class JsonValueReader extends JsonReader {
   }
 
   @Override public String nextString() throws IOException {
-    String peeked = require(String.class, Token.STRING);
-    remove();
-    return peeked;
+    Object peeked = (stackSize != 0 ? stack[stackSize - 1] : null);
+    if (peeked instanceof String) {
+      remove();
+      return (String) peeked;
+    }
+    if (peeked instanceof Number) {
+      remove();
+      return peeked.toString();
+    }
+    if (peeked == JSON_READER_CLOSED) {
+      throw new IllegalStateException("JsonReader is closed");
+    }
+    throw typeMismatch(peeked, Token.STRING);
   }
 
   @Override public int selectString(Options options) throws IOException {

--- a/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
@@ -336,6 +336,18 @@ public final class JsonUtf8ReaderTest {
     assertEquals("-0", reader.nextString());
   }
 
+  @Test public void numberToStringCoersion() throws Exception {
+    JsonReader reader = newReader("[0, 9223372036854775807, 2.5, 3.010, \"a\", \"5\"]");
+    reader.beginArray();
+    assertThat(reader.nextString()).isEqualTo("0");
+    assertThat(reader.nextString()).isEqualTo("9223372036854775807");
+    assertThat(reader.nextString()).isEqualTo("2.5");
+    assertThat(reader.nextString()).isEqualTo("3.010");
+    assertThat(reader.nextString()).isEqualTo("a");
+    assertThat(reader.nextString()).isEqualTo("5");
+    reader.endArray();
+  }
+
   @Test public void quotedNumberWithEscape() throws IOException {
     JsonReader reader = newReader("[\"12\u00334\"]");
     reader.setLenient(true);

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
@@ -425,7 +425,8 @@ public final class JsonValueReaderTest {
   }
 
   @Test public void numberToStringCoersion() throws Exception {
-    JsonReader reader = new JsonValueReader(Arrays.asList(0, 9223372036854775807L, 2.5d, 3.010f, "a", "5"));
+    JsonReader reader =
+        new JsonValueReader(Arrays.asList(0, 9223372036854775807L, 2.5d, 3.01f, "a", "5"));
     reader.beginArray();
     assertThat(reader.nextString()).isEqualTo("0");
     assertThat(reader.nextString()).isEqualTo("9223372036854775807");

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
@@ -17,6 +17,7 @@ package com.squareup.moshi;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -421,6 +422,18 @@ public final class JsonValueReaderTest {
       fail();
     } catch (IllegalStateException expected) {
     }
+  }
+
+  @Test public void numberToStringCoersion() throws Exception {
+    JsonReader reader = new JsonValueReader(Arrays.asList(0, 9223372036854775807L, 2.5d, 3.010f, "a", "5"));
+    reader.beginArray();
+    assertThat(reader.nextString()).isEqualTo("0");
+    assertThat(reader.nextString()).isEqualTo("9223372036854775807");
+    assertThat(reader.nextString()).isEqualTo("2.5");
+    assertThat(reader.nextString()).isEqualTo("3.01");
+    assertThat(reader.nextString()).isEqualTo("a");
+    assertThat(reader.nextString()).isEqualTo("5");
+    reader.endArray();
   }
 
   @Test public void tooDeeplyNestedArrays() throws IOException {


### PR DESCRIPTION
This adds parity with JsonUtf8Reader and lets big number literals in JSON be read in as strings in Java.

PR note:
```java
Moshi moshi = new Moshi.Builder().build();
JsonAdapter<String> adapter = moshi.adapter(String.class);
JsonReader reader = JsonReader.of(new Buffer().writeUtf8("9223372036854775808"));
String bigMoney = adapter.fromJsonValue(reader.readJsonValue());
```
This change will make the above work (instead of throwing, expecting a double), so that you can use big numbers in polymorphic adapters where you need to read in the map.

Closes #388.