### PR TITLE
Add error message for accidental primitive usage.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/Types.java
+++ b/moshi/src/main/java/com/squareup/moshi/Types.java
@@ -492,7 +492,7 @@ public final class Types {
 
   static void checkNotPrimitive(Type type) {
     if ((type instanceof Class<?>) && ((Class<?>) type).isPrimitive()) {
-      throw new IllegalArgumentException();
+      throw new IllegalArgumentException("Unexpected primitive " + type + ". Use the boxed type.");
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/TypesTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/TypesTest.java
@@ -227,4 +227,25 @@ public final class TypesTest {
     assertThat(Types.equals(String[].class, Types.arrayOf(String.class))).isTrue();
     assertThat(Types.equals(Types.arrayOf(String.class), String[].class)).isTrue();
   }
+
+  @Test public void parameterizedAndWildcardTypesCannotHavePrimitiveArguments() throws Exception {
+    try {
+      Types.newParameterizedType(List.class, int.class);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessage("Unexpected primitive int. Use the boxed type.");
+    }
+    try {
+      Types.subtypeOf(byte.class);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessage("Unexpected primitive byte. Use the boxed type.");
+    }
+    try {
+      Types.subtypeOf(boolean.class);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessage("Unexpected primitive boolean. Use the boxed type.");
+    }
+  }
 }


### PR DESCRIPTION
Also, add a test for the requirement.

References #391.