### PR TITLE
Remove trailing zeros and exponent notation from JsonValueReader.next…

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
@@ -159,7 +159,7 @@ final class JsonValueReader extends JsonReader {
     }
     if (peeked instanceof Number) {
       remove();
-      return peeked.toString();
+      return new BigDecimal(peeked.toString()).stripTrailingZeros().toPlainString();
     }
     if (peeked == JSON_READER_CLOSED) {
       throw new IllegalStateException("JsonReader is closed");

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
@@ -437,6 +437,14 @@ public final class JsonValueReaderTest {
     reader.endArray();
   }
 
+  @Test public void numberToStringCoersionIsPlainText() throws Exception {
+    JsonReader reader = new JsonValueReader(Arrays.asList(4.0, 10000000f));
+    reader.beginArray();
+    assertThat(reader.nextString()).isEqualTo("4");
+    assertThat(reader.nextString()).isEqualTo("10000000");
+    reader.endArray();
+  }
+
   @Test public void tooDeeplyNestedArrays() throws IOException {
     Object root = Collections.emptyList();
     for (int i = 0; i < 32; i++) {


### PR DESCRIPTION
…String.

I remembered what I was worried about [here](https://github.com/square/moshi/pull/390#discussion_r152438517). sorry about that.