### PR TITLE
Make selectString consistent across JsonReaders.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
@@ -168,9 +168,18 @@ final class JsonValueReader extends JsonReader {
   }
 
   @Override public int selectString(Options options) throws IOException {
-    String peeked = require(String.class, Token.STRING);
+    Object peeked = (stackSize != 0 ? stack[stackSize - 1] : null);
+
+    if (!(peeked instanceof String)) {
+      if (peeked == JSON_READER_CLOSED) {
+        throw new IllegalStateException("JsonReader is closed");
+      }
+      return -1;
+    }
+    String peekedString = (String) peeked;
+
     for (int i = 0, length = options.strings.length; i < length; i++) {
-      if (options.strings[i].equals(peeked)) {
+      if (options.strings[i].equals(peekedString)) {
         remove();
         return i;
       }

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
@@ -852,6 +852,21 @@ public final class JsonReaderTest {
     reader.endArray();
   }
 
+  @Test public void selectStringWithoutString() throws IOException {
+    JsonReader.Options numbers = JsonReader.Options.of("1", "2.0", "true", "4");
+
+    JsonReader reader = newReader("[0, 2.0, true, \"4\"]");
+    reader.beginArray();
+    assertThat(reader.selectString(numbers)).isEqualTo(-1);
+    reader.skipValue();
+    assertThat(reader.selectString(numbers)).isEqualTo(-1);
+    reader.skipValue();
+    assertThat(reader.selectString(numbers)).isEqualTo(-1);
+    reader.skipValue();
+    assertThat(reader.selectString(numbers)).isEqualTo(3);
+    reader.endArray();
+  }
+
   @Test public void stringToNumberCoersion() throws Exception {
     JsonReader reader = newReader("[\"0\", \"9223372036854775807\", \"1.5\"]");
     reader.beginArray();
@@ -876,21 +891,6 @@ public final class JsonReaderTest {
     assertThat(reader.nextDouble()).isNaN();
     assertThat(reader.nextDouble()).isEqualTo(Double.POSITIVE_INFINITY);
     assertThat(reader.nextDouble()).isEqualTo(Double.NEGATIVE_INFINITY);
-    reader.endArray();
-  }
-
-  @Test public void selectStringWithoutString() throws IOException {
-    JsonReader.Options numbers = JsonReader.Options.of("1", "2.0", "true", "4");
-
-    JsonReader reader = newReader("[0, 2.0, true, \"4\"]");
-    reader.beginArray();
-    assertThat(reader.selectString(numbers)).isEqualTo(-1);
-    reader.skipValue();
-    assertThat(reader.selectString(numbers)).isEqualTo(-1);
-    reader.skipValue();
-    assertThat(reader.selectString(numbers)).isEqualTo(-1);
-    reader.skipValue();
-    assertThat(reader.selectString(numbers)).isEqualTo(3);
     reader.endArray();
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
@@ -879,6 +879,21 @@ public final class JsonReaderTest {
     reader.endArray();
   }
 
+  @Test public void selectStringWithoutString() throws IOException {
+    JsonReader.Options numbers = JsonReader.Options.of("1", "2.0", "true", "4");
+
+    JsonReader reader = newReader("[0, 2.0, true, \"4\"]");
+    reader.beginArray();
+    assertThat(reader.selectString(numbers)).isEqualTo(-1);
+    reader.skipValue();
+    assertThat(reader.selectString(numbers)).isEqualTo(-1);
+    reader.skipValue();
+    assertThat(reader.selectString(numbers)).isEqualTo(-1);
+    reader.skipValue();
+    assertThat(reader.selectString(numbers)).isEqualTo(3);
+    reader.endArray();
+  }
+
   @Test public void intMismatchWithStringDoesNotAdvance() throws Exception {
     JsonReader reader = newReader("[\"a\"]");
     reader.beginArray();


### PR DESCRIPTION
Make JsonValueReader.selectString return -1 for non-strings instead of throwing.