### PR TITLE
Add single quotes to variable names (#452)

### DIFF
--- a/kotlin/src/main/java/com/squareup/moshi/kotlin/KotlinJsonAdapter.kt
+++ b/kotlin/src/main/java/com/squareup/moshi/kotlin/KotlinJsonAdapter.kt
@@ -74,7 +74,7 @@ internal class KotlinJsonAdapter<T>(
 
       if (values[index] !== ABSENT_VALUE) {
         throw JsonDataException(
-            "Multiple values for ${constructor.parameters[index].name} at ${reader.path}")
+            "Multiple values for '${constructor.parameters[index].name}' at ${reader.path}")
       }
 
       values[index] = binding.adapter.fromJson(reader)
@@ -86,11 +86,11 @@ internal class KotlinJsonAdapter<T>(
       if (values[i] === ABSENT_VALUE && !constructor.parameters[i].isOptional) {
         if (!constructor.parameters[i].type.isMarkedNullable) {
           throw JsonDataException(
-              "Required value ${constructor.parameters[i].name} missing at ${reader.path}")
+              "Required value '${constructor.parameters[i].name}' missing at ${reader.path}")
         }
         values[i] = null // Replace absent with null.
       } else if (values[i] == null && !constructor.parameters[i].type.isMarkedNullable) {
-        throw JsonDataException("Non-null value ${constructor.parameters[i].name} " +
+        throw JsonDataException("Non-null value '${constructor.parameters[i].name}' " +
             "was null at ${reader.path}")
       }
     }
@@ -103,7 +103,7 @@ internal class KotlinJsonAdapter<T>(
       val binding = bindings[i]!!
       val value = values[i]
       if (value == null && !binding.property.returnType.isMarkedNullable) {
-        throw JsonDataException("Non-null value ${binding.property.name} " +
+        throw JsonDataException("Non-null value '${binding.property.name}' " +
             "was null at ${reader.path}")
       }
       binding.set(result, value)

--- a/kotlin/src/test/java/com/squareup/moshi/kotlin/KotlinJsonAdapterTest.kt
+++ b/kotlin/src/test/java/com/squareup/moshi/kotlin/KotlinJsonAdapterTest.kt
@@ -133,7 +133,7 @@ class KotlinJsonAdapterTest {
       jsonAdapter.fromJson("""{"a":4}""")
       fail()
     } catch(expected: JsonDataException) {
-      assertThat(expected).hasMessage("Required value b missing at $")
+      assertThat(expected).hasMessage("Required value 'b' missing at $")
     }
   }
 
@@ -147,7 +147,7 @@ class KotlinJsonAdapterTest {
       jsonAdapter.fromJson("{\"a\":null}")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessage("Non-null value a was null at \$")
+      assertThat(expected).hasMessage("Non-null value 'a' was null at \$")
     }
   }
 
@@ -161,7 +161,7 @@ class KotlinJsonAdapterTest {
       jsonAdapter.fromJson("{\"a\":null}")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessage("Non-null value a was null at \$")
+      assertThat(expected).hasMessage("Non-null value 'a' was null at \$")
     }
   }
 
@@ -177,7 +177,7 @@ class KotlinJsonAdapterTest {
       jsonAdapter.fromJson("""{"a":4,"a":4}""")
       fail()
     } catch(expected: JsonDataException) {
-      assertThat(expected).hasMessage("Multiple values for a at $.a")
+      assertThat(expected).hasMessage("Multiple values for 'a' at $.a")
     }
   }
 


### PR DESCRIPTION
Adding single quotes to variable names really improves readability of error stack-trace.