### PR TITLE
Disallow null annotation set in adapter lookup.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -66,6 +66,9 @@ public final class Moshi {
 
   @CheckReturnValue
   public <T> JsonAdapter<T> adapter(Type type, Class<? extends Annotation> annotationType) {
+    if (annotationType == null) {
+      throw new NullPointerException("annotationType == null");
+    }
     return adapter(type,
         Collections.singleton(Types.createJsonQualifierImplementation(annotationType)));
   }
@@ -73,6 +76,10 @@ public final class Moshi {
   @CheckReturnValue
   @SuppressWarnings("unchecked") // Factories are required to return only matching JsonAdapters.
   public <T> JsonAdapter<T> adapter(Type type, Set<? extends Annotation> annotations) {
+    if (annotations == null) {
+      throw new NullPointerException("annotations == null");
+    }
+
     type = Types.canonicalize(type);
 
     // If there's an equivalent adapter in the cache, we're done!

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -724,8 +724,21 @@ public final class MoshiTest {
         .isEqualTo("{\"shout\":\"WHAT'S UP\",\"speak\":\"Yo dog\"}");
   }
 
-  @Uppercase
-  static String uppercaseString;
+  @Test public void adapterLookupDisallowsNullAnnotations() {
+    Moshi moshi = new Moshi.Builder().build();
+    try {
+      moshi.adapter(String.class, (Class<? extends Annotation>) null);
+      fail();
+    } catch (NullPointerException expected) {
+      assertThat(expected).hasMessage("annotationType == null");
+    }
+    try {
+      moshi.adapter(String.class, (Set<? extends Annotation>) null);
+      fail();
+    } catch (NullPointerException expected) {
+      assertThat(expected).hasMessage("annotations == null");
+    }
+  }
 
   @Test public void nextJsonAdapterDisallowsNullAnnotations() throws Exception {
     JsonAdapter.Factory badFactory = new JsonAdapter.Factory() {
@@ -743,6 +756,9 @@ public final class MoshiTest {
       assertThat(expected).hasMessage("annotations == null");
     }
   }
+
+  @Uppercase
+  static String uppercaseString;
 
   @Test public void delegatingJsonAdapterFactory() throws Exception {
     Moshi moshi = new Moshi.Builder()


### PR DESCRIPTION
This just happened to me because I wasn't null checking the result of `Types.nextAnnotations`. might as well fail here instead of in Moshi.cacheKey.