### PR TITLE
Defensively check if generated constructor is accessible and fix if not

### DIFF
--- a/kotlin-codegen/runtime/src/main/java/com/squareup/moshi/MoshiSerializable.kt
+++ b/kotlin-codegen/runtime/src/main/java/com/squareup/moshi/MoshiSerializable.kt
@@ -50,6 +50,10 @@ class MoshiSerializableFactory : JsonAdapter.Factory {
       throw RuntimeException("Unable to find generated Moshi adapter class for $clsName", e)
     } catch (e: NoSuchMethodException) {
       throw RuntimeException("Unable to find generated Moshi adapter constructor for $clsName", e)
+    }.apply {
+      if (!isAccessible) {
+        isAccessible = true
+      }
     }
 
     try {


### PR DESCRIPTION
Part of #461

Proguard will make unused constructors private if possible, so this defensively makes them accessible if they're not already.