### PR TITLE
Generate `@Generated` annotation onto adapters when possible

### DIFF
--- a/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/AdapterGenerator.kt
+++ b/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/AdapterGenerator.kt
@@ -104,8 +104,8 @@ internal class AdapterGenerator(
 
     generatedAnnotation(env.elementUtils, env.sourceVersion).ifPresent {
       result.addAnnotation(AnnotationSpec.builder(it.asClassName())
-          .addMember("value = [%S]", MoshiKotlinCodeGenProcessor::class.java.canonicalName)
-          .addMember("comments = %S", "https://github.com/square/moshi")
+          .addMember("%S", MoshiKotlinCodeGenProcessor::class.java.canonicalName)
+          .addMember("%S", "https://github.com/square/moshi")
           .build())
     }
 

--- a/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/AdapterGenerator.kt
+++ b/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/AdapterGenerator.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.moshi
 
-import com.google.auto.common.GeneratedAnnotations.generatedAnnotation
 import com.squareup.kotlinpoet.ARRAY
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
@@ -34,6 +33,7 @@ import org.jetbrains.kotlin.serialization.ProtoBuf
 import java.lang.reflect.Type
 import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.Element
+import javax.lang.model.element.TypeElement
 
 /** Generates a JSON adapter for a target type. */
 internal class AdapterGenerator(
@@ -83,7 +83,7 @@ internal class AdapterGenerator(
 
   val delegateAdapters = propertyList.distinctBy { it.delegateKey() }
 
-  fun generateFile(): FileSpec {
+  fun generateFile(generatedOption: TypeElement?): FileSpec {
     for (property in delegateAdapters) {
       property.reserveDelegateNames(nameAllocator)
     }
@@ -95,16 +95,16 @@ internal class AdapterGenerator(
     if (hasCompanionObject) {
       result.addFunction(generateJsonAdapterFun())
     }
-    result.addType(generateType())
+    result.addType(generateType(generatedOption))
     return result.build()
   }
 
-  private fun generateType(): TypeSpec {
+  private fun generateType(generatedOption: TypeElement?): TypeSpec {
     val result = TypeSpec.classBuilder(adapterName)
 
-    generatedAnnotation(env.elementUtils, env.sourceVersion).ifPresent {
+    generatedOption?.let {
       result.addAnnotation(AnnotationSpec.builder(it.asClassName())
-          .addMember("%S", MoshiKotlinCodeGenProcessor::class.java.canonicalName)
+          .addMember("%S", JsonClassCodeGenProcessor::class.java.canonicalName)
           .addMember("%S", "https://github.com/square/moshi")
           .build())
     }

--- a/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/AdapterGenerator.kt
+++ b/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/AdapterGenerator.kt
@@ -31,9 +31,9 @@ import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
 import org.jetbrains.kotlin.serialization.ProtoBuf
 import java.lang.reflect.Type
+import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.Element
 import javax.lang.model.element.TypeElement
-import javax.lang.model.util.Elements
 
 /** Generates a JSON adapter for a target type. */
 internal class AdapterGenerator(
@@ -43,7 +43,7 @@ internal class AdapterGenerator(
   val isDataClass: Boolean,
   val hasCompanionObject: Boolean,
   val visibility: ProtoBuf.Visibility,
-  val elements: Elements,
+  val env: ProcessingEnvironment,
   val genericTypeNames: List<TypeVariableName>?
 ) {
   val nameAllocator = NameAllocator()

--- a/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/AdapterGenerator.kt
+++ b/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/AdapterGenerator.kt
@@ -31,9 +31,9 @@ import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
 import org.jetbrains.kotlin.serialization.ProtoBuf
 import java.lang.reflect.Type
-import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.Element
 import javax.lang.model.element.TypeElement
+import javax.lang.model.util.Elements
 
 /** Generates a JSON adapter for a target type. */
 internal class AdapterGenerator(
@@ -43,7 +43,7 @@ internal class AdapterGenerator(
   val isDataClass: Boolean,
   val hasCompanionObject: Boolean,
   val visibility: ProtoBuf.Visibility,
-  val env: ProcessingEnvironment,
+  val elements: Elements,
   val genericTypeNames: List<TypeVariableName>?
 ) {
   val nameAllocator = NameAllocator()

--- a/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/JsonClassCodeGenProcessor.kt
+++ b/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/JsonClassCodeGenProcessor.kt
@@ -36,6 +36,7 @@ import me.eugeniomarletti.kotlin.processing.KotlinAbstractProcessor
 import org.jetbrains.kotlin.serialization.ProtoBuf
 import org.jetbrains.kotlin.serialization.ProtoBuf.ValueParameter
 import java.io.File
+import javax.annotation.processing.ProcessingEnvironment
 import javax.annotation.processing.Processor
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.SourceVersion
@@ -61,18 +62,48 @@ import javax.tools.Diagnostic.Kind.ERROR
 @AutoService(Processor::class)
 class JsonClassCodeGenProcessor : KotlinAbstractProcessor(), KotlinMetadataUtils {
 
+  companion object {
+    /**
+     * This annotation processing argument can be specified to have a `@Generated` annotation
+     * included in the generated code. It is not encouraged unless you need it for static analysis
+     * reasons and not enabled by default.
+     *
+     * Note that this can only be one of the following values:
+     *   * `"javax.annotation.processing.Generated"` (JRE 9+)
+     *   * `"javax.annotation.Generated"` (JRE <9)
+     */
+    const val OPTION_GENERATED = "moshi.generated"
+    private val POSSIBLE_GENERATED_NAMES = setOf(
+        "javax.annotation.processing.Generated",
+        "javax.annotation.Generated"
+    )
+  }
+
   private val annotation = JsonClass::class.java
+  private var generatedType: TypeElement? = null
 
   override fun getSupportedAnnotationTypes() = setOf(annotation.canonicalName)
 
   override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latest()
+
+  override fun getSupportedOptions() = setOf(OPTION_GENERATED)
+
+  override fun init(processingEnv: ProcessingEnvironment) {
+    super.init(processingEnv)
+    generatedType = processingEnv.options[OPTION_GENERATED]?.let {
+      if (it !in POSSIBLE_GENERATED_NAMES) {
+        throw IllegalArgumentException("Invalid option value for $OPTION_GENERATED. Found $it, allowable values are $POSSIBLE_GENERATED_NAMES.")
+      }
+      processingEnv.elementUtils.getTypeElement(it)
+    }
+  }
 
   override fun process(annotations: Set<TypeElement>, roundEnv: RoundEnvironment): Boolean {
     for (type in roundEnv.getElementsAnnotatedWith(annotation)) {
       val jsonClass = type.getAnnotation(annotation)
       if (jsonClass.generateAdapter) {
         val adapterGenerator = processElement(type) ?: continue
-        adapterGenerator.generateAndWrite()
+        adapterGenerator.generateAndWrite(generatedType)
       }
     }
 
@@ -242,8 +273,8 @@ class JsonClassCodeGenProcessor : KotlinAbstractProcessor(), KotlinMetadataUtils
         element)
   }
 
-  private fun AdapterGenerator.generateAndWrite() {
-    val fileSpec = generateFile()
+  private fun AdapterGenerator.generateAndWrite(generatedOption: TypeElement?) {
+    val fileSpec = generateFile(generatedOption)
     val adapterName = fileSpec.members.filterIsInstance<TypeSpec>().first().name!!
     val outputDir = generatedDir ?: mavenGeneratedDir(adapterName)
     fileSpec.writeTo(outputDir)

--- a/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/JsonClassCodeGenProcessor.kt
+++ b/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/JsonClassCodeGenProcessor.kt
@@ -92,7 +92,8 @@ class JsonClassCodeGenProcessor : KotlinAbstractProcessor(), KotlinMetadataUtils
     super.init(processingEnv)
     generatedType = processingEnv.options[OPTION_GENERATED]?.let {
       if (it !in POSSIBLE_GENERATED_NAMES) {
-        throw IllegalArgumentException("Invalid option value for $OPTION_GENERATED. Found $it, allowable values are $POSSIBLE_GENERATED_NAMES.")
+        throw IllegalArgumentException(
+            "Invalid option value for $OPTION_GENERATED. Found $it, allowable values are $POSSIBLE_GENERATED_NAMES.")
       }
       processingEnv.elementUtils.getTypeElement(it)
     }

--- a/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/PropertyGenerator.kt
+++ b/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/PropertyGenerator.kt
@@ -79,7 +79,7 @@ internal class PropertyGenerator(
           CodeBlock.of("<%T>", unaliasedName)
         },
         unaliasedName.makeType(
-            enclosing.env.elementUtils, enclosing.typesParam, enclosing.genericTypeNames ?: emptyList()))
+            enclosing.elements, enclosing.typesParam, enclosing.genericTypeNames ?: emptyList()))
     val standardArgsSize = standardArgs.size + 1
     val (initializerString, args) = when {
       qualifiers.isEmpty() -> "" to emptyArray()

--- a/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/PropertyGenerator.kt
+++ b/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/PropertyGenerator.kt
@@ -79,7 +79,7 @@ internal class PropertyGenerator(
           CodeBlock.of("<%T>", unaliasedName)
         },
         unaliasedName.makeType(
-            enclosing.elements, enclosing.typesParam, enclosing.genericTypeNames ?: emptyList()))
+            enclosing.env.elementUtils, enclosing.typesParam, enclosing.genericTypeNames ?: emptyList()))
     val standardArgsSize = standardArgs.size + 1
     val (initializerString, args) = when {
       qualifiers.isEmpty() -> "" to emptyArray()


### PR DESCRIPTION
Part of #461

This leverages AutoCommon's `GeneratedAnnotations#generatedAnnotation` API to generate a `@Generated` annotation where possible. This keeps with conventions in other code gen tools, and also allows for more fine grained proguard rules for keeping generated adapter names, like so:

```proguard
-keepnames @com.squareup.moshi.<wherever this ends up>.MoshiSerializable class *

# Java < 9
-keepnames @javax.annotation.Generated class **JsonAdapter

#  Java 9+
-keepnames @javax.annotation.processing.Generated class **JsonAdapter
```

Generated annotation looks like this:

```kotlin
@Generated(
        value = ["com.squareup.moshi.MoshiKotlinCodeGenProcessor"],
        comments = "https://github.com/square/moshi"
)
```

I think this should be able to replace the `”Generated code; do not edit“ header` item in the linked issue as well.

This doooooes also replace `elements` in `AdapterGenerator` with a `ProcessingEnv`, but I figured that was less evil than polluting it with both `elements` and plumbing down an `env` separately simultaneously. This does also hit a weird ambiguity case due to `KotlinMetadataUtils`' repeat declaration, so a good reason for removing that in the future. Figured it best to punt on a better final place for this to another time.