### PR TITLE
Fix type checks with custom adapters.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/internal/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/Util.java
@@ -45,7 +45,7 @@ public final class Util {
 
   public static boolean typesMatch(Type pattern, Type candidate) {
     // TODO: permit raw types (like Set.class) to match non-raw candidates (like Set<Long>).
-    return pattern.equals(candidate);
+    return Types.equals(pattern, candidate);
   }
 
   public static Set<? extends Annotation> jsonAnnotations(AnnotatedElement annotatedElement) {


### PR DESCRIPTION
Moshi.Builder.add(Type, ...) adds a factory that had a broken type equality check.
Closes #128 

Could also canonicalize the input of the add methods instead, but I like getting rid of j.l.r.Type.equals.

Confirmed broken and fixed states on an Android SDK 22 emulator.