### PR TITLE
Make "no adapter" error message friendlier.

### DIFF
--- a/kotlin-codegen/integration-test/src/test/kotlin/com/squareup/moshi/KotlinCodeGenTest.kt
+++ b/kotlin-codegen/integration-test/src/test/kotlin/com/squareup/moshi/KotlinCodeGenTest.kt
@@ -159,7 +159,7 @@ class KotlinCodeGenTest {
       moshi.adapter(Triple::class.java)
       fail()
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessage("Platform class kotlin.Triple annotated [] "
+      assertThat(e).hasMessage("Platform class kotlin.Triple (with no annotations) "
           + "requires explicit JsonAdapter to be registered")
     }
   }
@@ -330,7 +330,7 @@ class KotlinCodeGenTest {
       fail()
     } catch (e: IllegalArgumentException) {
       assertThat(e).hasMessage("No JsonAdapter for interface " +
-          "com.squareup.moshi.KotlinJsonAdapterTest\$Interface annotated []")
+          "com.squareup.moshi.KotlinJsonAdapterTest\$Interface (with no annotations)")
     }
   }
 

--- a/kotlin/src/test/java/com/squareup/moshi/kotlin/KotlinJsonAdapterTest.kt
+++ b/kotlin/src/test/java/com/squareup/moshi/kotlin/KotlinJsonAdapterTest.kt
@@ -438,7 +438,7 @@ class KotlinJsonAdapterTest {
       moshi.adapter(Triple::class.java)
       fail()
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessage("Platform class kotlin.Triple annotated [] "
+      assertThat(e).hasMessage("Platform class kotlin.Triple (with no annotations) "
           + "requires explicit JsonAdapter to be registered")
     }
   }
@@ -609,7 +609,7 @@ class KotlinJsonAdapterTest {
       fail()
     } catch (e: IllegalArgumentException) {
       assertThat(e).hasMessage("No JsonAdapter for interface " +
-          "com.squareup.moshi.kotlin.KotlinJsonAdapterTest\$Interface annotated []")
+          "com.squareup.moshi.kotlin.KotlinJsonAdapterTest\$Interface (with no annotations)")
     }
   }
 

--- a/moshi/src/main/java/com/squareup/moshi/AdapterMethodsFactory.java
+++ b/moshi/src/main/java/com/squareup/moshi/AdapterMethodsFactory.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 
 import static com.squareup.moshi.internal.Util.canonicalize;
 import static com.squareup.moshi.internal.Util.jsonAnnotations;
+import static com.squareup.moshi.internal.Util.typeAnnotatedWithAnnotations;
 
 final class AdapterMethodsFactory implements JsonAdapter.Factory {
   private final List<AdapterMethod> toAdapters;
@@ -52,7 +53,7 @@ final class AdapterMethodsFactory implements JsonAdapter.Factory {
       } catch (IllegalArgumentException e) {
         String missingAnnotation = toAdapter == null ? "@ToJson" : "@FromJson";
         throw new IllegalArgumentException("No " + missingAnnotation + " adapter for "
-            + type + " annotated " + annotations);
+            + typeAnnotatedWithAnnotations(type, annotations));
       }
     } else {
       delegate = null;

--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -29,6 +29,7 @@ import java.util.TreeMap;
 import javax.annotation.Nullable;
 
 import static com.squareup.moshi.internal.Util.resolve;
+import static com.squareup.moshi.internal.Util.typeAnnotatedWithAnnotations;
 
 /**
  * Emits a regular class as a JSON object by mapping Java fields to JSON object properties.
@@ -56,9 +57,7 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
       if (rawType.isInterface() || rawType.isEnum()) return null;
       if (Util.isPlatformType(rawType) && !Types.isAllowedPlatformType(rawType)) {
         throw new IllegalArgumentException("Platform "
-            + type
-            + " annotated "
-            + annotations
+            + typeAnnotatedWithAnnotations(type, annotations)
             + " requires explicit JsonAdapter to be registered");
       }
       if (!annotations.isEmpty()) return null;

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -31,6 +31,7 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 
 import static com.squareup.moshi.internal.Util.canonicalize;
+import static com.squareup.moshi.internal.Util.typeAnnotatedWithAnnotations;
 
 /**
  * Coordinates binding between JSON values and Java objects.
@@ -139,7 +140,8 @@ public final class Moshi {
       }
     }
 
-    throw new IllegalArgumentException("No JsonAdapter for " + type + " annotated " + annotations);
+    throw new IllegalArgumentException(
+        "No JsonAdapter for " + typeAnnotatedWithAnnotations(type, annotations));
   }
 
   @CheckReturnValue
@@ -159,7 +161,7 @@ public final class Moshi {
       if (result != null) return result;
     }
     throw new IllegalArgumentException("No next JsonAdapter for "
-        + type + " annotated " + annotations);
+        + typeAnnotatedWithAnnotations(type, annotations));
   }
 
   /** Returns a new builder containing all custom factories used by the current instance. */

--- a/moshi/src/main/java/com/squareup/moshi/internal/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/Util.java
@@ -430,4 +430,9 @@ public final class Util {
       }
     }
   }
+
+  public static String typeAnnotatedWithAnnotations(Type type,
+      Set<? extends Annotation> annotations) {
+    return type + (annotations.isEmpty() ? " (with no annotations)" : " annotated " + annotations);
+  }
 }

--- a/moshi/src/test/java/com/squareup/moshi/AdapterMethodsTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/AdapterMethodsTest.java
@@ -462,7 +462,7 @@ public final class AdapterMethodsTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage("No @FromJson adapter for interface "
-          + "com.squareup.moshi.AdapterMethodsTest$Shape annotated []");
+          + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)");
     }
   }
 
@@ -481,7 +481,7 @@ public final class AdapterMethodsTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage("No @ToJson adapter for interface "
-          + "com.squareup.moshi.AdapterMethodsTest$Shape annotated []");
+          + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)");
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -541,7 +541,8 @@ public final class MoshiTest {
       moshi.adapter(Types.subtypeOf(String.class));
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("No JsonAdapter for ? extends java.lang.String annotated []");
+      assertThat(e).hasMessage(
+          "No JsonAdapter for ? extends java.lang.String (with no annotations)");
     }
   }
 
@@ -551,7 +552,7 @@ public final class MoshiTest {
       moshi.adapter(Types.supertypeOf(String.class));
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("No JsonAdapter for ? super java.lang.String annotated []");
+      assertThat(e).hasMessage("No JsonAdapter for ? super java.lang.String (with no annotations)");
     }
   }
 
@@ -908,22 +909,22 @@ public final class MoshiTest {
       moshi.adapter(File.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage(
-          "Platform class java.io.File annotated [] requires explicit JsonAdapter to be registered");
+      assertThat(e).hasMessage("Platform class java.io.File (with no annotations) "
+          + "requires explicit JsonAdapter to be registered");
     }
     try {
       moshi.adapter(KeyGenerator.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage(
-          "Platform class javax.crypto.KeyGenerator annotated [] requires explicit JsonAdapter to be registered");
+      assertThat(e).hasMessage("Platform class javax.crypto.KeyGenerator (with no annotations) "
+          + "requires explicit JsonAdapter to be registered");
     }
     try {
       moshi.adapter(Pair.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage(
-          "Platform class android.util.Pair annotated [] requires explicit JsonAdapter to be registered");
+      assertThat(e).hasMessage("Platform class android.util.Pair (with no annotations) "
+          + "requires explicit JsonAdapter to be registered");
     }
   }
 


### PR DESCRIPTION
In the very common case, there are no JsonQualifier annotations for the type.

Closes #456