### PR TITLE
Support properties that don't have a backing field.

### DIFF
--- a/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/PropertyGenerator.kt
+++ b/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/PropertyGenerator.kt
@@ -25,7 +25,7 @@ internal class PropertyGenerator(
   val delegateKey: DelegateKey,
   val name: String,
   val serializedName: String,
-  val hasConstructorParameter: Boolean,
+  val parameterIndex: Int,
   val hasDefault: Boolean,
   val typeName: TypeName
 ) {
@@ -34,6 +34,9 @@ internal class PropertyGenerator(
 
   val isRequired
     get() = !delegateKey.nullable && !hasDefault
+
+  val hasConstructorParameter
+    get() = parameterIndex != -1
 
   /** We prefer to use 'null' to mean absent, but for some properties those are distinct. */
   val differentiateAbsentFromNull


### PR DESCRIPTION
Currently our main loop to gather PropertyGenerators goes over the backing fields.
This needs to change to iterate over the properties themselves. That leads to a lot
of churn. The net result is slightly more compatibility with the reflective adapter.