### PR TITLE
Disallow null Type from entering user code.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -92,6 +92,9 @@ public final class Moshi {
   @CheckReturnValue
   @SuppressWarnings("unchecked") // Factories are required to return only matching JsonAdapters.
   public <T> JsonAdapter<T> adapter(Type type, Set<? extends Annotation> annotations) {
+    if (type == null) {
+      throw new NullPointerException("type == null");
+    }
     if (annotations == null) {
       throw new NullPointerException("annotations == null");
     }

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -27,6 +27,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -723,6 +724,16 @@ public final class MoshiTest {
 
     assertThat(messageAdapter.toJson(message))
         .isEqualTo("{\"shout\":\"WHAT'S UP\",\"speak\":\"Yo dog\"}");
+  }
+
+  @Test public void adapterLookupDisallowsNullType() {
+    Moshi moshi = new Moshi.Builder().build();
+    try {
+      moshi.adapter(null, Collections.<Annotation>emptySet());
+      fail();
+    } catch (NullPointerException expected) {
+      assertThat(expected).hasMessage("type == null");
+    }
   }
 
   @Test public void adapterLookupDisallowsNullAnnotations() {


### PR DESCRIPTION
Otherwise, Moshi.adapter(null) will end up calling into user JsonAdapter factories with a null Type parameter.
Kotlin fails with java.lang.IllegalArgumentException: Parameter specified as non-null is null
That message ends up too far away from the real error.