### PR TITLE
Full JsonQualifier support in kotlin codegen

### DIFF
--- a/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/AdapterGenerator.kt
+++ b/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/AdapterGenerator.kt
@@ -34,6 +34,7 @@ import me.eugeniomarletti.kotlin.metadata.isDataClass
 import me.eugeniomarletti.kotlin.metadata.shadow.metadata.ProtoBuf.Visibility
 import me.eugeniomarletti.kotlin.metadata.visibility
 import java.lang.reflect.Type
+import javax.annotation.processing.Messager
 import javax.lang.model.element.TypeElement
 
 /** Generates a JSON adapter for a target type. */
@@ -81,7 +82,7 @@ internal class AdapterGenerator(
           .joinToString(", ") { "\"$it\"" }})", JsonReader.Options::class.asTypeName())
       .build()
 
-  fun generateFile(generatedOption: TypeElement?): FileSpec {
+  fun generateFile(messager: Messager, generatedOption: TypeElement?): FileSpec {
     for (property in propertyList) {
       property.allocateNames(nameAllocator)
     }
@@ -91,11 +92,11 @@ internal class AdapterGenerator(
     if (hasCompanionObject) {
       result.addFunction(generateJsonAdapterFun())
     }
-    result.addType(generateType(generatedOption))
+    result.addType(generateType(messager, generatedOption))
     return result.build()
   }
 
-  private fun generateType(generatedOption: TypeElement?): TypeSpec {
+  private fun generateType(messager: Messager, generatedOption: TypeElement?): TypeSpec {
     val result = TypeSpec.classBuilder(adapterName)
 
     generatedOption?.let {
@@ -129,7 +130,7 @@ internal class AdapterGenerator(
     result.addProperty(optionsProperty)
     for (uniqueAdapter in propertyList.distinctBy { it.delegateKey }) {
       result.addProperty(uniqueAdapter.delegateKey.generateProperty(
-          nameAllocator, typeRenderer, moshiParam))
+          nameAllocator, typeRenderer, moshiParam, messager))
     }
 
     result.addFunction(generateToStringFun())

--- a/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/DelegateKey.kt
+++ b/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/DelegateKey.kt
@@ -83,26 +83,10 @@ internal data class DelegateKey(
     val standardArgsSize = standardArgs.size + 1
     val (initializerString, args) = when {
       qualifiers.isEmpty() -> "" to emptyArray()
-      qualifiers.size == 1 -> {
-        ", %${standardArgsSize}T.getFieldAnnotations(javaClass, %${standardArgsSize + 1}S, %${standardArgsSize + 2}T::class.java)" to arrayOf(
-            Types::class.asTypeName(),
-            adapterName,
-            qualifiers.first().annotationType.asTypeName())
-      }
       else -> {
-        val initStringArgs = qualifiers
-            .mapIndexed { index, _ ->
-              val annoClassIndex = standardArgsSize + index + 2
-              return@mapIndexed "%${annoClassIndex}T::class.java"
-            }
-            .joinToString()
-        val initString = "%${standardArgsSize}T.getFieldAnnotations(javaClass, %${standardArgsSize + 1}S, $initStringArgs)"
-        val initArgs = qualifiers
-            .map { it.annotationType.asTypeName() }
-            .toTypedArray()
-        ", $initString" to arrayOf(Types::class.asTypeName(),
-            adapterName,
-            *initArgs)
+        ", %${standardArgsSize}T.getFieldJsonQualifierAnnotations(javaClass, %${standardArgsSize + 1}S)" to arrayOf(
+            Types::class.asTypeName(),
+            adapterName)
       }
     }
     val finalArgs = arrayOf(*standardArgs, *args)

--- a/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/DelegateKey.kt
+++ b/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/DelegateKey.kt
@@ -50,12 +50,13 @@ internal data class DelegateKey(
     messager: Messager): PropertySpec {
     fun AnnotationMirror.validate(): AnnotationMirror {
       // Check java types since that covers both java and kotlin annotations
-      annotationType.getAnnotation(java.lang.annotation.Retention::class.java)?.let {
+      val annotationElement = MoreTypes.asTypeElement(annotationType)
+      annotationElement.getAnnotation(java.lang.annotation.Retention::class.java)?.let {
         if (it.value != RetentionPolicy.RUNTIME) {
           messager.printMessage(ERROR, "JsonQualifier @${MoreTypes.asTypeElement(annotationType).simpleName} must have RUNTIME retention")
         }
       }
-      annotationType.getAnnotation(java.lang.annotation.Target::class.java)?.let {
+      annotationElement.getAnnotation(java.lang.annotation.Target::class.java)?.let {
         if (ElementType.FIELD !in it.value) {
           messager.printMessage(ERROR, "JsonQualifier @${MoreTypes.asTypeElement(annotationType).simpleName} must support FIELD target")
         }

--- a/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/JsonClassCodeGenProcessor.kt
+++ b/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/JsonClassCodeGenProcessor.kt
@@ -124,7 +124,7 @@ class JsonClassCodeGenProcessor : KotlinAbstractProcessor(), KotlinMetadataUtils
   }
 
   private fun AdapterGenerator.generateAndWrite(generatedOption: TypeElement?) {
-    val fileSpec = generateFile(generatedOption)
+    val fileSpec = generateFile(messager, generatedOption)
     val adapterName = fileSpec.members.filterIsInstance<TypeSpec>().first().name!!
     val outputDir = generatedDir ?: mavenGeneratedDir(adapterName)
     fileSpec.writeTo(outputDir)

--- a/kotlin-codegen/compiler/src/test/java/com/squareup/moshi/CompilerTest.kt
+++ b/kotlin-codegen/compiler/src/test/java/com/squareup/moshi/CompilerTest.kt
@@ -244,4 +244,62 @@ class CompilerTest {
     assertThat(result.exitCode).isEqualTo(ExitCode.COMPILATION_ERROR)
     assertThat(result.systemErr).contains("supertype java.util.Date is not a Kotlin type")
   }
+
+  @Ignore("This test needs the stdlib on the classpath to work")
+  @Test
+  fun nonFieldApplicableQualifier() {
+    val call = KotlinCompilerCall(temporaryFolder.root)
+    call.inheritClasspath = true
+    call.addService(Processor::class, JsonClassCodeGenProcessor::class)
+    call.addKt("source.kt", """
+        |import com.squareup.moshi.JsonClass
+        |import com.squareup.moshi.JsonQualifier
+        |import kotlin.annotation.AnnotationRetention.RUNTIME
+        |import kotlin.annotation.AnnotationTarget.PROPERTY
+        |import kotlin.annotation.Retention
+        |import kotlin.annotation.Target
+        |
+        |@Retention(RUNTIME)
+        |@Target(PROPERTY)
+        |@JsonQualifier
+        |annotation class UpperCase
+        |
+        |@JsonClass(generateAdapter = true)
+        |class ClassWithQualifier(@UpperCase val a: Int)
+        |""".trimMargin())
+
+    val result = call.execute()
+    println(result.systemErr)
+    assertThat(result.exitCode).isEqualTo(ExitCode.COMPILATION_ERROR)
+    assertThat(result.systemErr).contains("JsonQualifier @UpperCase must support FIELD target")
+  }
+
+  @Ignore("This test needs the stdlib on the classpath to work")
+  @Test
+  fun nonRuntimeQualifier() {
+    val call = KotlinCompilerCall(temporaryFolder.root)
+    call.inheritClasspath = true
+    call.addService(Processor::class, JsonClassCodeGenProcessor::class)
+    call.addKt("source.kt", """
+        |import com.squareup.moshi.JsonClass
+        |import com.squareup.moshi.JsonQualifier
+        |import kotlin.annotation.AnnotationRetention.BINARY
+        |import kotlin.annotation.AnnotationTarget.FIELD
+        |import kotlin.annotation.AnnotationTarget.PROPERTY
+        |import kotlin.annotation.Retention
+        |import kotlin.annotation.Target
+        |
+        |@Retention(BINARY)
+        |@Target(PROPERTY, FIELD)
+        |@JsonQualifier
+        |annotation class UpperCase
+        |
+        |@JsonClass(generateAdapter = true)
+        |class ClassWithQualifier(@UpperCase val a: Int)
+        |""".trimMargin())
+
+    val result = call.execute()
+    assertThat(result.exitCode).isEqualTo(ExitCode.COMPILATION_ERROR)
+    assertThat(result.systemErr).contains("JsonQualifier @UpperCase must have RUNTIME retention")
+  }
 }

--- a/kotlin-codegen/compiler/src/test/java/com/squareup/moshi/CompilerTest.kt
+++ b/kotlin-codegen/compiler/src/test/java/com/squareup/moshi/CompilerTest.kt
@@ -245,7 +245,6 @@ class CompilerTest {
     assertThat(result.systemErr).contains("supertype java.util.Date is not a Kotlin type")
   }
 
-  @Ignore("This test needs the stdlib on the classpath to work")
   @Test
   fun nonFieldApplicableQualifier() {
     val call = KotlinCompilerCall(temporaryFolder.root)
@@ -274,7 +273,6 @@ class CompilerTest {
     assertThat(result.systemErr).contains("JsonQualifier @UpperCase must support FIELD target")
   }
 
-  @Ignore("This test needs the stdlib on the classpath to work")
   @Test
   fun nonRuntimeQualifier() {
     val call = KotlinCompilerCall(temporaryFolder.root)

--- a/kotlin-codegen/integration-test/src/test/kotlin/com/squareup/moshi/GeneratedAdaptersTest.kt
+++ b/kotlin-codegen/integration-test/src/test/kotlin/com/squareup/moshi/GeneratedAdaptersTest.kt
@@ -447,7 +447,7 @@ class GeneratedAdaptersTest {
   }
 
   @JsonClass(generateAdapter = true)
-  class ConstructorParameterWithQualifier(@Uppercase var a: String, var b: String)
+  class ConstructorParameterWithQualifier(@Uppercase(inFrench = true) var a: String, var b: String)
 
   @Test fun propertyWithQualifier() {
     val moshi = Moshi.Builder()
@@ -467,7 +467,7 @@ class GeneratedAdaptersTest {
 
   @JsonClass(generateAdapter = true)
   class PropertyWithQualifier {
-    @Uppercase var a: String = ""
+    @Uppercase(inFrench = true) var a: String = ""
     var b: String = ""
   }
 
@@ -762,15 +762,14 @@ class GeneratedAdaptersTest {
     var b: Int = -1
   }
 
-  @Retention(AnnotationRetention.RUNTIME)
   @JsonQualifier
-  annotation class Uppercase
+  annotation class Uppercase(val inFrench: Boolean, val onSundays: Boolean = false)
 
   class UppercaseJsonAdapter {
-    @ToJson fun toJson(@Uppercase s: String) : String {
+    @ToJson fun toJson(@Uppercase(inFrench = true) s: String) : String {
       return s.toUpperCase(Locale.US)
     }
-    @FromJson @Uppercase fun fromJson(s: String) : String {
+    @FromJson @Uppercase(inFrench = true) fun fromJson(s: String) : String {
       return s.toLowerCase(Locale.US)
     }
   }

--- a/moshi/src/main/java/com/squareup/moshi/Types.java
+++ b/moshi/src/main/java/com/squareup/moshi/Types.java
@@ -220,23 +220,20 @@ public final class Types {
   /**
    * @param clazz the target class to read the {@code fieldName} field annotations from.
    * @param fieldName the target field name on {@code clazz}.
-   * @param targetAnnotations the target annotation classes to retrieve on the field.
-   * @return a set of {@link Annotation} instances retrieved from the targeted field. Can be empty
-   *         if none are found.
+   * @return a set of {@link JsonQualifier}-annotated {@link Annotation} instances retrieved from
+   *         the targeted field. Can be empty if none are found.
    */
-  @SafeVarargs
-  public static Set<? extends Annotation> getFieldAnnotations(Class<?> clazz,
-      String fieldName,
-      Class<? extends Annotation>... targetAnnotations) {
+  public static Set<? extends Annotation> getFieldJsonQualifierAnnotations(Class<?> clazz,
+      String fieldName) {
     try {
       Field field = clazz.getDeclaredField(fieldName);
       if (!field.isAccessible()) {
         field.setAccessible(true);
       }
-      Set<Annotation> annotations = new LinkedHashSet<>(targetAnnotations.length);
-      for (Class<? extends Annotation> annotationClass : targetAnnotations) {
-        @Nullable Annotation annotation = field.getAnnotation(annotationClass);
-        if (annotation != null) {
+      Annotation[] fieldAnnotations = field.getDeclaredAnnotations();
+      Set<Annotation> annotations = new LinkedHashSet<>(fieldAnnotations.length);
+      for (Annotation annotation : fieldAnnotations) {
+        if (annotation.annotationType().isAnnotationPresent(JsonQualifier.class)) {
           annotations.add(annotation);
         }
       }

--- a/moshi/src/main/java/com/squareup/moshi/Types.java
+++ b/moshi/src/main/java/com/squareup/moshi/Types.java
@@ -242,7 +242,7 @@ public final class Types {
       }
       return Collections.unmodifiableSet(annotations);
     } catch (NoSuchFieldException e) {
-      throw new RuntimeException("Could not access field "
+      throw new IllegalArgumentException("Could not access field "
           + fieldName
           + " on class "
           + clazz.getCanonicalName(),

--- a/moshi/src/test/java/com/squareup/moshi/TypesTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/TypesTest.java
@@ -17,6 +17,7 @@ package com.squareup.moshi;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ import java.util.Set;
 import org.junit.Test;
 
 import static com.squareup.moshi.internal.Util.canonicalize;
+import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
@@ -260,5 +262,43 @@ public final class TypesTest {
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessage("Unexpected primitive boolean. Use the boxed type.");
     }
+  }
+
+  @Test public void getFieldAnnotations_privateFieldTest() {
+    Set<? extends Annotation> annotations = Types.getFieldAnnotations(ClassWithAnnotatedFields.class,
+        "privateField",
+        FieldAnnotation.class);
+
+    assertThat(annotations).hasSize(1);
+    assertThat(annotations.iterator().next()).isInstanceOf(FieldAnnotation.class);
+  }
+
+  @Test public void getFieldAnnotations_publicFieldTest() {
+    Set<? extends Annotation> annotations = Types.getFieldAnnotations(ClassWithAnnotatedFields.class,
+        "publicField",
+        FieldAnnotation.class);
+
+    assertThat(annotations).hasSize(1);
+    assertThat(annotations.iterator().next()).isInstanceOf(FieldAnnotation.class);
+  }
+
+  @Test public void getFieldAnnotations_unannotatedTest() {
+    Set<? extends Annotation> annotations = Types.getFieldAnnotations(ClassWithAnnotatedFields.class,
+        "unannotatedField",
+        FieldAnnotation.class);
+
+    assertThat(annotations).hasSize(0);
+  }
+
+  @Target(FIELD)
+  @Retention(RUNTIME)
+  @interface FieldAnnotation {
+
+  }
+
+  static class ClassWithAnnotatedFields {
+    @FieldAnnotation private final int privateField = 0;
+    @FieldAnnotation public final int publicField = 0;
+    private final int unannotatedField = 0;
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/TypesTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/TypesTest.java
@@ -264,41 +264,51 @@ public final class TypesTest {
     }
   }
 
-  @Test public void getFieldAnnotations_privateFieldTest() {
-    Set<? extends Annotation> annotations = Types.getFieldAnnotations(ClassWithAnnotatedFields.class,
-        "privateField",
-        FieldAnnotation.class);
+  @Test public void getFieldJsonQualifierAnnotations_privateFieldTest() {
+    Set<? extends Annotation> annotations = Types.getFieldJsonQualifierAnnotations(ClassWithAnnotatedFields.class,
+        "privateField");
 
     assertThat(annotations).hasSize(1);
     assertThat(annotations.iterator().next()).isInstanceOf(FieldAnnotation.class);
   }
 
-  @Test public void getFieldAnnotations_publicFieldTest() {
-    Set<? extends Annotation> annotations = Types.getFieldAnnotations(ClassWithAnnotatedFields.class,
-        "publicField",
-        FieldAnnotation.class);
+  @Test public void getFieldJsonQualifierAnnotations_publicFieldTest() {
+    Set<? extends Annotation> annotations = Types.getFieldJsonQualifierAnnotations(ClassWithAnnotatedFields.class,
+        "publicField");
 
     assertThat(annotations).hasSize(1);
     assertThat(annotations.iterator().next()).isInstanceOf(FieldAnnotation.class);
   }
 
-  @Test public void getFieldAnnotations_unannotatedTest() {
-    Set<? extends Annotation> annotations = Types.getFieldAnnotations(ClassWithAnnotatedFields.class,
-        "unannotatedField",
-        FieldAnnotation.class);
+  @Test public void getFieldJsonQualifierAnnotations_unannotatedTest() {
+    Set<? extends Annotation> annotations = Types.getFieldJsonQualifierAnnotations(ClassWithAnnotatedFields.class,
+        "unannotatedField");
 
     assertThat(annotations).hasSize(0);
   }
 
+  @JsonQualifier
   @Target(FIELD)
   @Retention(RUNTIME)
   @interface FieldAnnotation {
 
   }
 
+  @Target(FIELD)
+  @Retention(RUNTIME)
+  @interface NoQualifierAnnotation {
+
+  }
+
   static class ClassWithAnnotatedFields {
-    @FieldAnnotation private final int privateField = 0;
-    @FieldAnnotation public final int publicField = 0;
+    @FieldAnnotation
+    @NoQualifierAnnotation
+    private final int privateField = 0;
+
+    @FieldAnnotation
+    @NoQualifierAnnotation
+    public final int publicField = 0;
+
     private final int unannotatedField = 0;
   }
 }


### PR DESCRIPTION
This implements full `JsonQualifier` support in the kotlin codegen. This works via reflection, copying qualifier annotations directly onto the generated adapter and retrieving them reflectively from the adapter via new helper utility method in `Types`.

Note that this requires the given qualifiers to be applicable to `FIELD` site targets, as we use that to avoid generation of an unnecessary synthetic method in the kotlin compiler for it to store the annotations and also know exactly how to access the annotations, vs guessing where the kotlin compiler will put them or what the name of the synthetic method is. 

Resolves another part of #461