### PR TITLE
Fix nullability not being preserved and clean up from shadowed names

### DIFF
--- a/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/TypeResolver.kt
+++ b/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/TypeResolver.kt
@@ -35,15 +35,18 @@ open class TypeResolver {
       is ParameterizedTypeName -> {
         ParameterizedTypeName.get(
             typeName.rawType, *(typeName.typeArguments.map { resolve(it) }.toTypedArray()))
+            .asNullableIf(typeName.nullable)
       }
 
       is WildcardTypeName -> {
         when {
           typeName.lowerBounds.size == 1 -> {
             WildcardTypeName.supertypeOf(resolve(typeName.lowerBounds[0]))
+                .asNullableIf(typeName.nullable)
           }
           typeName.upperBounds.size == 1 -> {
             WildcardTypeName.subtypeOf(resolve(typeName.upperBounds[0]))
+                .asNullableIf(typeName.nullable)
           }
           else -> {
             throw IllegalArgumentException(

--- a/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/kotlintypes.kt
+++ b/kotlin-codegen/compiler/src/main/java/com/squareup/moshi/kotlintypes.kt
@@ -26,3 +26,7 @@ internal fun TypeName.rawType(): ClassName {
     else -> throw IllegalArgumentException("Cannot get raw type from $this")
   }
 }
+
+internal fun TypeName.asNullableIf(condition: Boolean): TypeName {
+  return if (condition) asNullable() else this
+}

--- a/kotlin-codegen/compiler/src/test/java/com/squareup/moshi/TypeResolverTest.kt
+++ b/kotlin-codegen/compiler/src/test/java/com/squareup/moshi/TypeResolverTest.kt
@@ -1,0 +1,36 @@
+package com.squareup.moshi
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.kotlinpoet.ParameterizedTypeName
+import com.squareup.kotlinpoet.WildcardTypeName
+import com.squareup.kotlinpoet.asClassName
+import org.junit.Test
+
+class TypeResolverTest {
+
+  private val resolver = TypeResolver()
+
+  @Test
+  fun ensureClassNameNullabilityIsPreserved() {
+    assertThat(resolver.resolve(Int::class.asClassName().asNullable()).nullable).isTrue()
+  }
+
+  @Test
+  fun ensureParameterizedNullabilityIsPreserved() {
+    val nullableTypeName = ParameterizedTypeName.get(
+        List::class.asClassName(),
+        String::class.asClassName())
+        .asNullable()
+
+    assertThat(resolver.resolve(nullableTypeName).nullable).isTrue()
+  }
+
+  @Test
+  fun ensureWildcardNullabilityIsPreserved() {
+    val nullableTypeName = WildcardTypeName.subtypeOf(List::class.asClassName())
+        .asNullable()
+
+    assertThat(resolver.resolve(nullableTypeName).nullable).isTrue()
+  }
+
+}


### PR DESCRIPTION
This fixes #526 and also cleans up some `typeVariable` name shadowing in `metadata.kt` that was causing some confusing behavior before.