### PR TITLE
Fix generic typealiases

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TargetType.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TargetType.kt
@@ -182,7 +182,7 @@ internal data class TargetType(
       for (property in classProto.propertyList) {
         val name = nameResolver.getString(property.name)
         val type = typeResolver.resolve(property.returnType.asTypeName(
-            nameResolver, classProto::getTypeParameter, true))
+            nameResolver, classProto::getTypeParameter, false))
         result[name] = TargetProperty(name, type, property, constructor.parameters[name],
             annotationHolders[name], fields[name], setters[name], getters[name])
       }
@@ -207,7 +207,7 @@ internal data class TargetType(
         TypeVariableName(
             name = nameResolver.getString(it.name),
             bounds = *(it.upperBoundList
-                .map { it.asTypeName(nameResolver, proto::getTypeParameter) }
+                .map { it.asTypeName(nameResolver, proto::getTypeParameter, false) }
                 .toTypedArray()),
             variance = it.varianceModifier)
             .reified(it.reified)

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
@@ -61,30 +61,30 @@ internal fun TypeParameter.Variance.asKModifier(): KModifier? {
 internal fun Type.asTypeName(
   nameResolver: NameResolver,
   getTypeParameter: (index: Int) -> TypeParameter,
-  resolveAliases: Boolean = false
+  useAbbreviatedType: Boolean = true
 ): TypeName {
 
   val argumentList = when {
-    hasAbbreviatedType() && !resolveAliases -> abbreviatedType.argumentList
+    useAbbreviatedType && hasAbbreviatedType() -> abbreviatedType.argumentList
     else -> argumentList
   }
 
   if (hasFlexibleUpperBound()) {
     return WildcardTypeName.subtypeOf(
-        flexibleUpperBound.asTypeName(nameResolver, getTypeParameter, resolveAliases))
+        flexibleUpperBound.asTypeName(nameResolver, getTypeParameter, useAbbreviatedType))
         .asNullableIf(nullable)
   } else if (hasOuterType()) {
     return WildcardTypeName.supertypeOf(
-        outerType.asTypeName(nameResolver, getTypeParameter, resolveAliases))
+        outerType.asTypeName(nameResolver, getTypeParameter, useAbbreviatedType))
         .asNullableIf(nullable)
   }
 
   val realType = when {
     hasTypeParameter() -> return getTypeParameter(typeParameter)
-        .asTypeName(nameResolver, getTypeParameter, resolveAliases)
+        .asTypeName(nameResolver, getTypeParameter, useAbbreviatedType)
         .asNullableIf(nullable)
     hasTypeParameterName() -> typeParameterName
-    hasAbbreviatedType() && !resolveAliases -> abbreviatedType.typeAliasName
+    useAbbreviatedType && hasAbbreviatedType() -> abbreviatedType.typeAliasName
     else -> className
   }
 
@@ -98,7 +98,7 @@ internal fun Type.asTypeName(
         argumentType.projection
       } else null
       if (argumentType.hasType()) {
-        argumentType.type.asTypeName(nameResolver, getTypeParameter, resolveAliases)
+        argumentType.type.asTypeName(nameResolver, getTypeParameter, useAbbreviatedType)
             .let { argumentTypeName ->
               nullableProjection?.let { projection ->
                 when (projection) {

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
@@ -65,7 +65,7 @@ internal fun Type.asTypeName(
 ): TypeName {
 
   val argumentList = when {
-    hasAbbreviatedType() -> abbreviatedType.argumentList
+    hasAbbreviatedType() && !resolveAliases -> abbreviatedType.argumentList
     else -> argumentList
   }
 

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codgen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codgen/GeneratedAdaptersTest.kt
@@ -826,6 +826,7 @@ data class NullableTypeParams<T>(
 )
 
 typealias TypeAliasName = String
+typealias GenericTypeAlias = List<String>
 
 /**
  * This is here mostly just to ensure it still compiles. Covers variance, @Json, default values,
@@ -852,5 +853,6 @@ data class SmokeTestType(
     val favoriteArrayValues: Array<String>,
     val favoriteNullableArrayValues: Array<String?>,
     val nullableSetListMapArrayNullableIntWithDefault: Set<List<Map<String, Array<IntArray?>>>>? = null,
-    val aliasedName: TypeAliasName = "Woah"
+    val aliasedName: TypeAliasName = "Woah",
+    val genericAlias: GenericTypeAlias = listOf("Woah")
 )


### PR DESCRIPTION
We had a missing `resolveAliases` check when gathering argument lists 🙄 

This is important because the argument is on the backing type, not on the aliased one.

As part of it, I also reworded the API to be a bit more understandable. Now instead of the confusing `resolveAliases` and always being negated when used with `hasAbbreviatedType()`, it's called `useAbbreviatedType` (which matches how it's referred to in the kotlin compiler as well).

Resolves #547