### PR TITLE
Update kotlin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.7</java.version>
-    <kotlin.version>1.2.21</kotlin.version>
-    <kotlin-metadata.version>1.3.0</kotlin-metadata.version>
+    <kotlin.version>1.2.41</kotlin.version>
+    <kotlin-metadata.version>1.4.0</kotlin-metadata.version>
 
     <!-- Dependencies -->
     <okio.version>1.14.0</okio.version>


### PR DESCRIPTION
I've been seeing a warning in Android Studio about having a version on kotlin-stdlib that doesn't match the kotlin plugin version, so I've updated it (and kotlin-metadata) to the latest versions available.