### PR TITLE
(WIP Prototype) Switch to public kotlinx-metadata API

### DIFF
--- a/kotlin/codegen/pom.xml
+++ b/kotlin/codegen/pom.xml
@@ -12,6 +12,14 @@
 
   <artifactId>moshi-kotlin-codegen</artifactId>
 
+  <repositories>
+    <repository>
+      <id>bintray-kotlin-kotlinx</id>
+      <name>bintray</name>
+      <url>https://kotlin.bintray.com/kotlinx</url>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
       <groupId>com.squareup.moshi</groupId>
@@ -56,15 +64,17 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-compiler-embeddable</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-annotation-processing-embeddable</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>me.eugeniomarletti.kotlin.metadata</groupId>
-      <artifactId>kotlin-metadata</artifactId>
-      <version>1.4.0</version>
+      <groupId>org.jetbrains.kotlinx</groupId>
+      <artifactId>kotlinx-metadata-jvm</artifactId>
+      <version>0.0.2</version>
     </dependency>
     <!--
       Though we don't use compile-testing, including it is a convenient way to get tools.jar on the
@@ -175,6 +185,11 @@
                 <relocation>
                   <pattern>com.squareup.kotlinpoet</pattern>
                   <shadedPattern>com.squareup.moshi.kotlinpoet</shadedPattern>
+                </relocation>
+                <!-- Repackage Kotlinx-metadata until its API is stable. -->
+                <relocation>
+                  <pattern>kotlinx.metadata.jvm</pattern>
+                  <shadedPattern>com.squareup.moshi.kotlinx.metadata.jvm</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
@@ -35,9 +35,7 @@ import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
-import me.eugeniomarletti.kotlin.metadata.isDataClass
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.ProtoBuf.Visibility
-import me.eugeniomarletti.kotlin.metadata.visibility
+import kotlinx.metadata.Flag
 import java.lang.reflect.Type
 import javax.annotation.processing.Messager
 import javax.lang.model.element.TypeElement
@@ -48,9 +46,9 @@ internal class AdapterGenerator(
   private val propertyList: List<PropertyGenerator>
 ) {
   private val className = target.name
-  private val isDataClass = target.proto.isDataClass
+  private val isDataClass = Flag.Class.IS_DATA(target.data.flags)
   private val companionObjectName = target.companionObjectName
-  private val visibility = target.proto.visibility!!
+  private val isInternal = Flag.IS_INTERNAL(target.data.flags)
   private val typeVariables = target.typeVariables
 
   private val nameAllocator = NameAllocator()
@@ -118,7 +116,7 @@ internal class AdapterGenerator(
     }
 
     // TODO make this configurable. Right now it just matches the source model
-    if (visibility == Visibility.INTERNAL) {
+    if (isInternal) {
       result.addModifiers(KModifier.INTERNAL)
     }
 
@@ -324,7 +322,7 @@ internal class AdapterGenerator(
         .returns(jsonAdapterTypeName)
         .addParameter(moshiParam)
 
-    if (visibility == Visibility.INTERNAL) {
+    if (isInternal) {
       result.addModifiers(KModifier.INTERNAL)
     }
 

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessor.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessor.kt
@@ -18,16 +18,18 @@ package com.squareup.moshi.kotlin.codegen
 import com.google.auto.service.AutoService
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.moshi.JsonClass
-import me.eugeniomarletti.kotlin.metadata.KotlinMetadataUtils
-import me.eugeniomarletti.kotlin.metadata.declaresDefaultValue
-import me.eugeniomarletti.kotlin.processing.KotlinAbstractProcessor
 import java.io.File
+import javax.annotation.processing.AbstractProcessor
+import javax.annotation.processing.Filer
+import javax.annotation.processing.Messager
 import javax.annotation.processing.ProcessingEnvironment
 import javax.annotation.processing.Processor
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.Element
 import javax.lang.model.element.TypeElement
+import javax.lang.model.util.Elements
+import javax.lang.model.util.Types
 import javax.tools.Diagnostic.Kind.ERROR
 
 /**
@@ -42,9 +44,13 @@ import javax.tools.Diagnostic.Kind.ERROR
  * If you don't want this though, you can use the runtime [JsonClass] factory implementation.
  */
 @AutoService(Processor::class)
-class JsonClassCodegenProcessor : KotlinAbstractProcessor(), KotlinMetadataUtils {
+class JsonClassCodegenProcessor : AbstractProcessor() {
 
   companion object {
+    /**
+     * Name of the processor option containing the path to the Kotlin generated src dir.
+     */
+    private const val OPTION_KAPT_GENERATED = "kapt.kotlin.generated"
     /**
      * This annotation processing argument can be specified to have a `@Generated` annotation
      * included in the generated code. It is not encouraged unless you need it for static analysis
@@ -63,6 +69,11 @@ class JsonClassCodegenProcessor : KotlinAbstractProcessor(), KotlinMetadataUtils
 
   private val annotation = JsonClass::class.java
   private var generatedType: TypeElement? = null
+  private lateinit var messager: Messager
+  private lateinit var elementUtils: Elements
+  private lateinit var typeUtils: Types
+  private lateinit var filer: Filer
+  private var generatedDir: File? = null
 
   override fun getSupportedAnnotationTypes() = setOf(annotation.canonicalName)
 
@@ -72,6 +83,11 @@ class JsonClassCodegenProcessor : KotlinAbstractProcessor(), KotlinMetadataUtils
 
   override fun init(processingEnv: ProcessingEnvironment) {
     super.init(processingEnv)
+    messager = processingEnv.messager
+    elementUtils = processingEnv.elementUtils
+    typeUtils = processingEnv.typeUtils
+    filer = processingEnv.filer
+    generatedDir = processingEnv.options[OPTION_KAPT_GENERATED]?.let(::File)
     generatedType = processingEnv.options[OPTION_GENERATED]?.let {
       if (it !in POSSIBLE_GENERATED_NAMES) {
         throw IllegalArgumentException("Invalid option value for $OPTION_GENERATED. Found $it, " +

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessor.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessor.kt
@@ -121,7 +121,7 @@ class JsonClassCodegenProcessor : AbstractProcessor() {
     }
 
     for ((name, parameter) in type.constructor.parameters) {
-      if (type.properties[parameter.name] == null && !parameter.proto.declaresDefaultValue) {
+      if (type.properties[parameter.name] == null && !parameter.data.declaresDefaultValue) {
         messager.printMessage(
             ERROR, "No property for required constructor parameter $name", parameter.element)
         return null

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TargetConstructor.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TargetConstructor.kt
@@ -15,49 +15,32 @@
  */
 package com.squareup.moshi.kotlin.codegen
 
-import me.eugeniomarletti.kotlin.metadata.KotlinClassMetadata
-import me.eugeniomarletti.kotlin.metadata.isPrimary
-import me.eugeniomarletti.kotlin.metadata.jvm.getJvmConstructorSignature
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.ProtoBuf.Constructor
 import javax.lang.model.element.ElementKind
 import javax.lang.model.element.ExecutableElement
-import javax.lang.model.util.Elements
+import javax.lang.model.element.TypeElement
 
 /** A constructor in user code that should be called by generated code. */
 internal data class TargetConstructor(
-  val element: ExecutableElement,
-  val proto: Constructor,
-  val parameters: Map<String, TargetParameter>
+    val element: ExecutableElement,
+    val data: ConstructorData,
+    val parameters: Map<String, TargetParameter>
 ) {
   companion object {
-    fun primary(metadata: KotlinClassMetadata, elements: Elements): TargetConstructor {
-      val (nameResolver, classProto) = metadata.data
-
-      // todo allow custom constructor
-      val proto = classProto.constructorList
-          .single { it.isPrimary }
-      val constructorJvmSignature = proto.getJvmConstructorSignature(
-          nameResolver, classProto.typeTable)
-      val element = classProto.fqName
-          .let(nameResolver::getString)
-          .replace('/', '.')
-          .let(elements::getTypeElement)
+    fun primary(constructorData: ConstructorData, typeElement: TypeElement): TargetConstructor {
+      val element = typeElement
           .enclosedElements
           .mapNotNull {
             it.takeIf { it.kind == ElementKind.CONSTRUCTOR }?.let { it as ExecutableElement }
           }
           .first()
-      // TODO Temporary until JVM method signature matching is better
-      //  .single { it.jvmMethodSignature == constructorJvmSignature }
 
       val parameters = mutableMapOf<String, TargetParameter>()
-      for (parameter in proto.valueParameterList) {
-        val name = nameResolver.getString(parameter.name)
-        val index = proto.valueParameterList.indexOf(parameter)
+      for ((index, parameter) in constructorData.parameters.withIndex()) {
+        val name = parameter.name
         parameters[name] = TargetParameter(name, parameter, index, element.parameters[index])
       }
 
-      return TargetConstructor(element, proto, parameters)
+      return TargetConstructor(element, constructorData, parameters)
     }
   }
 }

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TargetParameter.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TargetParameter.kt
@@ -15,13 +15,12 @@
  */
 package com.squareup.moshi.kotlin.codegen
 
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.ProtoBuf.ValueParameter
 import javax.lang.model.element.VariableElement
 
 /** A parameter in user code that should be populated by generated code. */
 internal data class TargetParameter(
   val name: String,
-  val proto: ValueParameter,
+  val data: ParameterData,
   val index: Int,
   val element: VariableElement
 )

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TargetProperty.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TargetProperty.kt
@@ -19,13 +19,7 @@ import com.google.auto.common.AnnotationMirrors
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonQualifier
-import me.eugeniomarletti.kotlin.metadata.declaresDefaultValue
-import me.eugeniomarletti.kotlin.metadata.hasSetter
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.ProtoBuf.Property
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.ProtoBuf.Visibility.INTERNAL
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.ProtoBuf.Visibility.PROTECTED
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.ProtoBuf.Visibility.PUBLIC
-import me.eugeniomarletti.kotlin.metadata.visibility
+import kotlinx.metadata.Flag
 import javax.annotation.processing.Messager
 import javax.lang.model.element.AnnotationMirror
 import javax.lang.model.element.Element
@@ -38,7 +32,7 @@ import javax.tools.Diagnostic
 internal data class TargetProperty(
   val name: String,
   val type: TypeName,
-  private val proto: Property,
+  private val data: PropertyData,
   private val parameter: TargetParameter?,
   private val annotationHolder: ExecutableElement?,
   private val field: VariableElement?,
@@ -47,19 +41,19 @@ internal data class TargetProperty(
 ) {
   val parameterIndex get() = parameter?.index ?: -1
 
-  val hasDefault get() = parameter?.proto?.declaresDefaultValue ?: true
+  val hasDefault get() = parameter?.data?.declaresDefaultValue ?: true
 
   private val isTransient get() = field != null && Modifier.TRANSIENT in field.modifiers
 
   private val element get() = field ?: setter ?: getter!!
 
-  private val isSettable get() = proto.hasSetter || parameter != null
+  private val isSettable get() = data.hasSetter || parameter != null
 
   private val isVisible: Boolean
     get() {
-      return proto.visibility == INTERNAL
-          || proto.visibility == PROTECTED
-          || proto.visibility == PUBLIC
+      return Flag.IS_INTERNAL(data.flags)
+          || Flag.IS_PROTECTED(data.flags)
+          || Flag.IS_PUBLIC(data.flags)
     }
 
   /**

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TargetType.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TargetType.kt
@@ -16,27 +16,12 @@
 package com.squareup.moshi.kotlin.codegen
 
 import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
-import me.eugeniomarletti.kotlin.metadata.KotlinClassMetadata
-import me.eugeniomarletti.kotlin.metadata.KotlinMetadata
-import me.eugeniomarletti.kotlin.metadata.classKind
-import me.eugeniomarletti.kotlin.metadata.getPropertyOrNull
-import me.eugeniomarletti.kotlin.metadata.isInnerClass
-import me.eugeniomarletti.kotlin.metadata.kotlinMetadata
-import me.eugeniomarletti.kotlin.metadata.modality
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.ProtoBuf.Class
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.ProtoBuf.Modality.ABSTRACT
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.ProtoBuf.TypeParameter
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.ProtoBuf.Visibility.INTERNAL
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.ProtoBuf.Visibility.LOCAL
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.ProtoBuf.Visibility.PUBLIC
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.deserialization.NameResolver
-import me.eugeniomarletti.kotlin.metadata.shadow.util.capitalizeDecapitalize.decapitalizeAsciiOnly
-import me.eugeniomarletti.kotlin.metadata.visibility
+import kotlinx.metadata.Flag
+import kotlinx.metadata.jvm.KotlinClassMetadata
 import javax.annotation.processing.Messager
 import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
@@ -49,12 +34,12 @@ import javax.tools.Diagnostic.Kind.ERROR
 
 /** A user type that should be decoded and encoded by generated code. */
 internal data class TargetType(
-  val proto: Class,
-  val element: TypeElement,
-  val constructor: TargetConstructor,
-  val properties: Map<String, TargetProperty>,
-  val typeVariables: List<TypeVariableName>,
-  val companionObjectName: String?
+    val data: ClassData,
+    val element: TypeElement,
+    val constructor: TargetConstructor,
+    val properties: Map<String, TargetProperty>,
+    val typeVariables: List<TypeVariableName>,
+    val companionObjectName: String?
 ) {
   val name = element.className
 
@@ -63,47 +48,43 @@ internal data class TargetType(
 
     /** Returns a target type for `element`, or null if it cannot be used with code gen. */
     fun get(messager: Messager, elements: Elements, types: Types, element: Element): TargetType? {
-      val typeMetadata: KotlinMetadata? = element.kotlinMetadata
-      if (element !is TypeElement || typeMetadata !is KotlinClassMetadata) {
+      val classMetadata = element.readMetadata()?.readKotlinClassMetadata()
+      if (element !is TypeElement || classMetadata !is KotlinClassMetadata) {
         messager.printMessage(
             ERROR, "@JsonClass can't be applied to $element: must be a Kotlin class", element)
         return null
       }
 
-      val proto = typeMetadata.data.classProto
-      when {
-        proto.classKind == Class.Kind.ENUM_CLASS -> {
-          messager.printMessage(
-              ERROR, "@JsonClass can't be applied to $element: must not be an enum class", element)
-          return null
-        }
-        proto.classKind != Class.Kind.CLASS -> {
-          messager.printMessage(
-              ERROR, "@JsonClass can't be applied to $element: must be a Kotlin class", element)
-          return null
-        }
-        proto.isInnerClass -> {
-          messager.printMessage(
-              ERROR, "@JsonClass can't be applied to $element: must not be an inner class", element)
-          return null
-        }
-        proto.modality == ABSTRACT -> {
-          messager.printMessage(
-              ERROR, "@JsonClass can't be applied to $element: must not be abstract", element)
-          return null
-        }
-        proto.visibility == LOCAL -> {
-          messager.printMessage(
-              ERROR, "@JsonClass can't be applied to $element: must not be local", element)
-          return null
-        }
+      val typeMetadata = classMetadata as KotlinClassMetadata.Class
+      val classData = typeMetadata.readClassData()
+      if (Flag.Class.IS_ENUM_CLASS(classData.flags)) {
+        messager.printMessage(
+            ERROR, "@JsonClass can't be applied to $element: must not be an enum class", element)
+        return null
+      } else if (!Flag.Class.IS_CLASS(classData.flags)) {
+        messager.printMessage(
+            ERROR, "@JsonClass can't be applied to $element: must be a Kotlin class", element)
+        return null
+      } else if (Flag.IS_ABSTRACT(classData.flags)) {
+        messager.printMessage(
+            ERROR, "@JsonClass can't be applied to $element: must not be abstract", element)
+        return null
+      } else if (Flag.IS_LOCAL(classData.flags)) {
+        messager.printMessage(
+            ERROR, "@JsonClass can't be applied to $element: must not be local", element)
+        return null
+      } else if (Flag.Class.IS_INNER(classData.flags)) {
+        messager.printMessage(
+            ERROR, "@JsonClass can't be applied to $element: must not be an inner class", element)
+        return null
       }
 
-      val typeVariables = genericTypeNames(proto, typeMetadata.data.nameResolver)
+      val typeVariables = classData.typeVariables
       val appliedType = AppliedType.get(element)
 
-      val constructor = TargetConstructor.primary(typeMetadata, elements)
-      if (constructor.proto.visibility != INTERNAL && constructor.proto.visibility != PUBLIC) {
+      val constructor = TargetConstructor.primary(classData.constructorData!!,
+          elements.getTypeElement(classData.name))
+      if (!Flag.IS_INTERNAL(constructor.data.flags) && !Flag.IS_PUBLIC(constructor.data.flags)) {
         messager.printMessage(ERROR, "@JsonClass can't be applied to $element: " +
             "primary constructor is not internal or public", element)
         return null
@@ -117,7 +98,7 @@ internal data class TargetType(
         if (supertype.element.kind != ElementKind.CLASS) {
           continue // Don't load properties for interface types.
         }
-        if (supertype.element.kotlinMetadata == null) {
+        if (supertype.element.readMetadata() == null) {
           messager.printMessage(ERROR,
               "@JsonClass can't be applied to $element: supertype $supertype is not a Kotlin type",
               element)
@@ -129,23 +110,19 @@ internal data class TargetType(
           properties.putIfAbsent(name, property)
         }
       }
-      val companionObjectName = if (proto.hasCompanionObjectName()) {
-        typeMetadata.data.nameResolver.getQualifiedClassName(proto.companionObjectName)
-      } else {
-        null
-      }
-      return TargetType(proto, element, constructor, properties, typeVariables, companionObjectName)
+      return TargetType(classData, element, constructor, properties, typeVariables,
+          classData.companionObjectName)
     }
 
     /** Returns the properties declared by `typeElement`. */
     private fun declaredProperties(
-      typeElement: TypeElement,
-      typeResolver: TypeResolver,
-      constructor: TargetConstructor
+        typeElement: TypeElement,
+        typeResolver: TypeResolver,
+        constructor: TargetConstructor
     ): Map<String, TargetProperty> {
-      val typeMetadata: KotlinClassMetadata = typeElement.kotlinMetadata as KotlinClassMetadata
-      val nameResolver = typeMetadata.data.nameResolver
-      val classProto = typeMetadata.data.classProto
+      val classMetadata = typeElement.readMetadata()?.readKotlinClassMetadata()
+      val typeMetadata = classMetadata as KotlinClassMetadata.Class
+      val classData = typeMetadata.readClassData()
 
       val annotationHolders = mutableMapOf<String, ExecutableElement>()
       val fields = mutableMapOf<String, VariableElement>()
@@ -170,19 +147,17 @@ internal data class TargetType(
             }
           }
 
-          val propertyProto = typeMetadata.data.getPropertyOrNull(element)
-          if (propertyProto != null) {
-            val name = nameResolver.getString(propertyProto.name)
-            annotationHolders[name] = element
+          val propertyData = classData.getPropertyOrNull(element)
+          if (propertyData != null) {
+            annotationHolders[propertyData.name] = element
           }
         }
       }
 
       val result = mutableMapOf<String, TargetProperty>()
-      for (property in classProto.propertyList) {
-        val name = nameResolver.getString(property.name)
-        val type = typeResolver.resolve(property.returnType.asTypeName(
-            nameResolver, classProto::getTypeParameter, false))
+      for (property in classData.properties) {
+        val name = property.name
+        val type = typeResolver.resolve(property.type)
         result[name] = TargetProperty(name, type, property, constructor.parameters[name],
             annotationHolders[name], fields[name], setters[name], getters[name])
       }
@@ -202,28 +177,15 @@ internal data class TargetType(
 
     private val Element.name get() = simpleName.toString()
 
-    private fun genericTypeNames(proto: Class, nameResolver: NameResolver): List<TypeVariableName> {
-      return proto.typeParameterList.map {
-        TypeVariableName(
-            name = nameResolver.getString(it.name),
-            bounds = *(it.upperBoundList
-                .map { it.asTypeName(nameResolver, proto::getTypeParameter, false) }
-                .toTypedArray()),
-            variance = it.varianceModifier)
-            .reified(it.reified)
-      }
-    }
 
-    private val TypeParameter.varianceModifier: KModifier?
-      get() {
-        return variance.asKModifier().let {
-          // We don't redeclare out variance here
-          if (it == KModifier.OUT) {
-            null
-          } else {
-            it
-          }
-        }
-      }
   }
+}
+
+private fun String.decapitalizeAsciiOnly(): String {
+  if (isEmpty()) return this
+  val c = this[0]
+  return if (c in 'A'..'Z')
+    c.toLowerCase() + substring(1)
+  else
+    this
 }

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
@@ -18,111 +18,294 @@ package com.squareup.moshi.kotlin.codegen
 import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.KModifier
-import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.WildcardTypeName
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.ProtoBuf.Type
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.ProtoBuf.TypeParameter
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.ProtoBuf.TypeParameter.Variance
-import me.eugeniomarletti.kotlin.metadata.shadow.metadata.deserialization.NameResolver
+import kotlinx.metadata.Flag
+import kotlinx.metadata.Flags
+import kotlinx.metadata.KmClassVisitor
+import kotlinx.metadata.KmConstructorVisitor
+import kotlinx.metadata.KmPropertyVisitor
+import kotlinx.metadata.KmTypeParameterVisitor
+import kotlinx.metadata.KmTypeVisitor
+import kotlinx.metadata.KmValueParameterVisitor
+import kotlinx.metadata.KmVariance
+import kotlinx.metadata.jvm.KotlinClassHeader
+import kotlinx.metadata.jvm.KotlinClassMetadata
+import javax.lang.model.element.Element
+import javax.lang.model.element.ExecutableElement
 
-internal fun TypeParameter.asTypeName(
-  nameResolver: NameResolver,
-  getTypeParameter: (index: Int) -> TypeParameter,
-  resolveAliases: Boolean = false
-): TypeName {
-  return TypeVariableName(
-      name = nameResolver.getString(name),
-      bounds = *(upperBoundList.map {
-        it.asTypeName(nameResolver, getTypeParameter, resolveAliases)
-      }
-          .toTypedArray()),
-      variance = variance.asKModifier()
-  )
+@Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+internal fun Element.readMetadata(): KotlinClassHeader? {
+  return getAnnotation(Metadata::class.java)?.run {
+    KotlinClassHeader(k, mv, bv, d1, d2, xs, pn, xi)
+  }
 }
 
-internal fun TypeParameter.Variance.asKModifier(): KModifier? {
+internal fun KotlinClassHeader.readKotlinClassMetadata(): KotlinClassMetadata? {
+  return KotlinClassMetadata.read(this)
+}
+
+internal fun KmVariance.asKModifier(): KModifier? {
   return when (this) {
-    Variance.IN -> KModifier.IN
-    Variance.OUT -> KModifier.OUT
-    Variance.INV -> null
+    KmVariance.IN -> KModifier.IN
+    KmVariance.OUT -> KModifier.OUT
+    KmVariance.INVARIANT -> null
   }
 }
 
 /**
- * Returns the TypeName of this type as it would be seen in the source code, including nullability
+ * Resolves the TypeName of this type as it would be seen in the source code, including nullability
  * and generic type parameters.
  *
- * @param [nameResolver] a [NameResolver] instance from the source proto
+ * @param flags the [Flags] associated with this type
  * @param [getTypeParameter] a function that returns the type parameter for the given index. **Only
- *     called if [ProtoBuf.Type.hasTypeParameter] is true!**
+ *     called if [TypeNameKmTypeVisitor.visitTypeParameter] is called**
+ * @param useTypeAlias indicates whether or not to use type aliases or resolve their underlying
+ *     types
  */
-internal fun Type.asTypeName(
-  nameResolver: NameResolver,
-  getTypeParameter: (index: Int) -> TypeParameter,
-  useAbbreviatedType: Boolean = true
-): TypeName {
+internal class TypeNameKmTypeVisitor(flags: Flags,
+    private val getTypeParameter: ((index: Int) -> TypeName)? = null,
+    private val useTypeAlias: Boolean = true,
+    private val receiver: (TypeName) -> Unit) : KmTypeVisitor() {
 
-  val argumentList = when {
-    useAbbreviatedType && hasAbbreviatedType() -> abbreviatedType.argumentList
-    else -> argumentList
+  private val nullable = Flag.Type.IS_NULLABLE(flags)
+  private var className: String? = null
+  private var typeAliasName: String? = null
+  private var typeAliasType: TypeName? = null
+  private var flexibleTypeUpperBound: TypeName? = null
+  private var outerType: TypeName? = null
+  private var typeParameter: TypeName? = null
+  private val argumentList = mutableListOf<TypeName>()
+
+  override fun visitAbbreviatedType(flags: Flags): KmTypeVisitor? {
+    if (!useTypeAlias) {
+      return null
+    }
+    return TypeNameKmTypeVisitor(flags, getTypeParameter, useTypeAlias) {
+      typeAliasType = it
+    }
   }
 
-  if (hasFlexibleUpperBound()) {
-    return WildcardTypeName.subtypeOf(
-        flexibleUpperBound.asTypeName(nameResolver, getTypeParameter, useAbbreviatedType))
-        .asNullableIf(nullable)
-  } else if (hasOuterType()) {
-    return WildcardTypeName.supertypeOf(
-        outerType.asTypeName(nameResolver, getTypeParameter, useAbbreviatedType))
-        .asNullableIf(nullable)
+  override fun visitArgument(flags: Flags, variance: KmVariance): KmTypeVisitor? {
+    return TypeNameKmTypeVisitor(flags, getTypeParameter, useTypeAlias) {
+      argumentList.add(
+          when (variance) {
+            KmVariance.IN -> WildcardTypeName.supertypeOf(it)
+            KmVariance.OUT -> WildcardTypeName.subtypeOf(it)
+            KmVariance.INVARIANT -> it
+          }
+      )
+    }
   }
 
-  val realType = when {
-    hasTypeParameter() -> return getTypeParameter(typeParameter)
-        .asTypeName(nameResolver, getTypeParameter, useAbbreviatedType)
-        .asNullableIf(nullable)
-    hasTypeParameterName() -> typeParameterName
-    useAbbreviatedType && hasAbbreviatedType() -> abbreviatedType.typeAliasName
-    else -> className
+  override fun visitClass(name: kotlinx.metadata.ClassName) {
+    className = name
   }
 
-  var typeName: TypeName =
-      ClassName.bestGuess(nameResolver.getString(realType)
-          .replace("/", "."))
+  override fun visitFlexibleTypeUpperBound(flags: Flags,
+      typeFlexibilityId: String?): KmTypeVisitor? {
+    return TypeNameKmTypeVisitor(flags, getTypeParameter, useTypeAlias) {
+      flexibleTypeUpperBound = WildcardTypeName.subtypeOf(it)
+    }
+  }
 
-  if (argumentList.isNotEmpty()) {
-    val remappedArgs: Array<TypeName> = argumentList.map { argumentType ->
-      val nullableProjection = if (argumentType.hasProjection()) {
-        argumentType.projection
-      } else null
-      if (argumentType.hasType()) {
-        argumentType.type.asTypeName(nameResolver, getTypeParameter, useAbbreviatedType)
-            .let { argumentTypeName ->
-              nullableProjection?.let { projection ->
-                when (projection) {
-                  Type.Argument.Projection.IN -> WildcardTypeName.supertypeOf(argumentTypeName)
-                  Type.Argument.Projection.OUT -> {
-                    if (argumentTypeName == ANY) {
-                      // This becomes a *, which we actually don't want here.
-                      // List<Any> works with List<*>, but List<*> doesn't work with List<Any>
-                      argumentTypeName
-                    } else {
-                      WildcardTypeName.subtypeOf(argumentTypeName)
-                    }
-                  }
-                  Type.Argument.Projection.STAR -> WildcardTypeName.subtypeOf(ANY)
-                  Type.Argument.Projection.INV -> TODO("INV projection is unsupported")
-                }
-              } ?: argumentTypeName
-            }
-      } else {
-        WildcardTypeName.subtypeOf(ANY)
+  override fun visitOuterType(flags: Flags): KmTypeVisitor? {
+    return TypeNameKmTypeVisitor(flags, getTypeParameter, useTypeAlias) {
+      outerType = WildcardTypeName.supertypeOf(it)
+    }
+  }
+
+  override fun visitStarProjection() {
+    argumentList.add(WildcardTypeName.subtypeOf(ANY))
+  }
+
+  override fun visitTypeAlias(name: kotlinx.metadata.ClassName) {
+    if (!useTypeAlias) {
+      return
+    }
+    typeAliasName = name
+  }
+
+  override fun visitTypeParameter(id: Int) {
+    typeParameter = getTypeParameter?.invoke(id) ?: throw IllegalStateException(
+        "Visiting TypeParameter when there are no type parameters!")
+  }
+
+  override fun visitEnd() {
+    var finalType = flexibleTypeUpperBound ?: outerType ?: typeParameter
+    if (finalType == null) {
+      if (useTypeAlias) {
+        finalType = typeAliasName?.let { ClassName.bestGuess(it.replace("/", ".")) }
       }
-    }.toTypedArray()
-    typeName = ParameterizedTypeName.get(typeName as ClassName, *remappedArgs)
+      if (finalType == null) {
+        finalType = typeAliasType ?: className?.let { ClassName.bestGuess(it.replace("/", ".")) }
+            ?: throw IllegalStateException("No valid typename found!")
+      }
+    }
+
+    finalType = finalType.asNullableIf(nullable)
+    receiver(finalType)
+  }
+}
+
+internal fun KotlinClassMetadata.Class.readClassData(): ClassData {
+  @Suppress("RedundantExplicitType")
+  var classFlags: Flags = 0
+  lateinit var className: String
+  var constructorData: ConstructorData? = null
+  var companionObjectName: String? = null
+  val typeParameters = LinkedHashMap<Int, TypeVariableName>()
+  val typeParamResolver = { id: Int -> typeParameters[id]!! }
+  val superTypes = mutableListOf<TypeName>()
+  val properties = mutableListOf<PropertyData>()
+  accept(object : KmClassVisitor() {
+    override fun visit(flags: Flags, name: kotlinx.metadata.ClassName) {
+      super.visit(flags, name)
+      className = name
+      classFlags = flags
+    }
+
+    override fun visitTypeParameter(flags: Flags,
+        name: String,
+        id: Int,
+        variance: KmVariance): KmTypeParameterVisitor? {
+      return object : KmTypeParameterVisitor() {
+        val upperBoundList = mutableListOf<TypeName>()
+        override fun visitUpperBound(flags: Flags): KmTypeVisitor? {
+          return TypeNameKmTypeVisitor(flags) {
+            upperBoundList += it
+          }
+        }
+
+        override fun visitEnd() {
+          typeParameters[id] = TypeVariableName(
+              name = name,
+              bounds = *(upperBoundList.toTypedArray()),
+              variance = variance.asKModifier().let {
+                if (it == KModifier.OUT) {
+                  // We don't redeclare out variance here
+                  null
+                } else {
+                  it
+                }
+              }
+          )
+              .reified(Flag.TypeParameter.IS_REIFIED(flags))
+        }
+      }
+    }
+
+    override fun visitCompanionObject(name: String) {
+      companionObjectName = name
+    }
+
+    override fun visitConstructor(flags: Flags): KmConstructorVisitor? {
+      return if (Flag.Constructor.IS_PRIMARY(flags)) {
+        object : KmConstructorVisitor() {
+          val params = mutableListOf<ParameterData>()
+          override fun visitValueParameter(flags: Flags, name: String): KmValueParameterVisitor? {
+            return object : KmValueParameterVisitor() {
+              override fun visitType(flags: Flags): KmTypeVisitor? {
+                return TypeNameKmTypeVisitor(flags, typeParamResolver) {
+                  params += ParameterData(flags, name, it)
+                }
+              }
+
+              override fun visitVarargElementType(flags: Flags): KmTypeVisitor? {
+                return TypeNameKmTypeVisitor(flags, typeParamResolver) {
+                  params += ParameterData(flags, name, it, true)
+                }
+              }
+            }
+          }
+
+          override fun visitEnd() {
+            constructorData = ConstructorData(flags, params)
+          }
+        }
+      } else {
+        null
+      }
+    }
+
+    override fun visitSupertype(flags: Flags): KmTypeVisitor? {
+      return TypeNameKmTypeVisitor(flags, typeParamResolver) {
+        superTypes += it
+      }
+    }
+
+    override fun visitProperty(flags: Flags,
+        name: String,
+        getterFlags: Flags,
+        setterFlags: Flags): KmPropertyVisitor? {
+      return object : KmPropertyVisitor() {
+        lateinit var type: TypeName
+        override fun visitEnd() {
+          properties += PropertyData(flags, name, type)
+        }
+
+        override fun visitReturnType(flags: Flags): KmTypeVisitor? {
+          return TypeNameKmTypeVisitor(flags, typeParamResolver) {
+            type = it
+          }
+        }
+      }
+    }
+  })
+
+  return ClassData(className.replace("/", "."),
+      classFlags,
+      companionObjectName,
+      constructorData,
+      superTypes,
+      typeParameters.values.toList(),
+      properties)
+}
+
+internal data class ClassData(
+    val name: String,
+    val flags: Flags,
+    val companionObjectName: String?,
+    val constructorData: ConstructorData?,
+    val superTypes: MutableList<TypeName>,
+    val typeVariables: List<TypeVariableName>,
+    val properties: List<PropertyData>
+) {
+  fun getPropertyOrNull(methodElement: ExecutableElement): PropertyData? {
+    return methodElement.simpleName.toString()
+        .takeIf { it.endsWith(kotlinPropertyAnnotationsFunPostfix) }
+        ?.substringBefore(kotlinPropertyAnnotationsFunPostfix)
+        ?.let { propertyName -> properties.firstOrNull { propertyName == it.name } }
   }
 
-  return typeName.asNullableIf(nullable)
+  companion object {
+    /**
+     * Postfix of the method name containing the [kotlin.Metadata] annotation for the relative property.
+     * @see [getPropertyOrNull]
+     */
+    const val kotlinPropertyAnnotationsFunPostfix = "\$annotations"
+  }
+}
+
+internal data class ConstructorData(
+    val flags: Flags,
+    val parameters: List<ParameterData>
+)
+
+internal data class ParameterData(
+    val flags: Flags,
+    val name: String,
+    val type: TypeName,
+    val isVarArg: Boolean = false
+) {
+  val declaresDefaultValue = Flag.ValueParameter.DECLARES_DEFAULT_VALUE(flags)
+}
+
+internal data class PropertyData(
+    val flags: Flags,
+    val name: String,
+    val type: TypeName
+) {
+  val hasSetter = Flag.Property.HAS_SETTER(flags)
 }


### PR DESCRIPTION
This swaps out kotlin-metadata for the new [kotlinx-metadata](https://github.com/JetBrains/kotlin/tree/master/libraries/kotlinx-metadata/jvm) API

I _think_ this is actually done, but I'm unable to get the build working in the `kotlin/tests` project due to `MetadataExtensions` services not being visible for some reason. They work in the `codegen/src/test` tests though.

The high level architecture:
  - Switch to new `Data` class representations of specific types, replacing the raw protos they were reading before.
  - The `metadata.kt` class has been switched to provide APIs for resolving `TypeName`s from the library's `KmVisitor` APIs. This is a significant departure from before since it's a visitor pattern, but ended up working nicely once I wrote `TypeNameKmTypeVisitor`.
  - Shade the kotlinx-metadata library since it's not stable yet, and also avoid dependence on the kotlinx bintray repo

The other changes were pretty lightweight after migrating `metadata.kt`. Overall pretty happy with how this turned out, and definitely cleaner than reading the raw protos from before.