### PR TITLE
Allow private transient Kotlin properties.

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TargetProperty.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TargetProperty.kt
@@ -67,11 +67,6 @@ internal data class TargetProperty(
    * cannot be used with code gen, or if no codegen is necessary for this property.
    */
   fun generator(messager: Messager): PropertyGenerator? {
-    if (!isVisible) {
-      messager.printMessage(Diagnostic.Kind.ERROR, "property ${this} is not visible", element)
-      return null
-    }
-
     if (isTransient) {
       if (!hasDefault) {
         messager.printMessage(
@@ -79,6 +74,11 @@ internal data class TargetProperty(
         return null
       }
       return null // This property is transient and has a default value. Ignore it.
+    }
+
+    if (!isVisible) {
+      messager.printMessage(Diagnostic.Kind.ERROR, "property ${this} is not visible", element)
+      return null
     }
 
     if (!isSettable) {

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codgen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codgen/GeneratedAdaptersTest.kt
@@ -535,18 +535,27 @@ class GeneratedAdaptersTest {
 
     val encoded = TransientProperty()
     encoded.a = 3
-    encoded.b = 5
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
+    encoded.setB(4)
+    encoded.c = 5
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"c":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":5,"c":6}""")!!
     assertThat(decoded.a).isEqualTo(-1)
-    assertThat(decoded.b).isEqualTo(6)
+    assertThat(decoded.getB()).isEqualTo(-1)
+    assertThat(decoded.c).isEqualTo(6)
   }
 
   @JsonClass(generateAdapter = true)
   class TransientProperty {
     @Transient var a: Int = -1
-    var b: Int = -1
+    @Transient private var b: Int = -1
+    var c: Int = -1
+
+    fun getB() = b
+
+    fun setB(b: Int) {
+      this.b = b
+    }
   }
 
   @Test fun nonNullPropertySetToNullFailsWithJsonDataException() {

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -363,17 +363,26 @@ class KotlinJsonAdapterTest {
 
     val encoded = TransientProperty()
     encoded.a = 3
-    encoded.b = 5
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
+    encoded.setB(4)
+    encoded.c = 5
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"c":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":5,"c":6}""")!!
     assertThat(decoded.a).isEqualTo(-1)
-    assertThat(decoded.b).isEqualTo(6)
+    assertThat(decoded.getB()).isEqualTo(-1)
+    assertThat(decoded.c).isEqualTo(6)
   }
 
   class TransientProperty {
     @Transient var a: Int = -1
-    var b: Int = -1
+    @Transient private var b: Int = -1
+    var c: Int = -1
+
+    fun getB() = b
+
+    fun setB(b: Int) {
+      this.b = b
+    }
   }
 
   @Test fun constructorParametersAndPropertiesWithSameNamesMustHaveSameTypes() {


### PR DESCRIPTION
Closes #571.