### PR TITLE
Trailing comma

### DIFF
--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
@@ -165,6 +165,20 @@ public final class JsonReaderTest {
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
   }
 
+  @Test public void failOnTrailingComma() throws IOException {
+    JsonReader reader = newReader("{\"a\": \"android\", }");
+    reader.beginObject();
+    assertThat(reader.nextName()).isEqualTo("a");
+    assertThat(reader.nextString()).isEqualTo("android");
+    try {
+      //noinspection ResultOfMethodCallIgnored
+      reader.nextName();
+      fail();
+    } catch (JsonEncodingException expected) {
+      assertThat(expected).hasMessage("Expected name at path $.a");
+    }
+  }
+
   @Test public void failOnUnknownFailsOnUnknownObjectValue() throws IOException {
     JsonReader reader = newReader("{\"a\": 123}");
     reader.setFailOnUnknown(true);


### PR DESCRIPTION
# Description
- I like to add a test for a **trailing comma** since this is a common mistake which is hard to find. I hope that the issue will be easier to discover by others by adding the test and the exception message to the sources.

# Not ready to merge :x: 
- Currently, the `[Utf8]` test succeeds while the `[Value`] test **fails**. I could not yet figure out why. Maybe you can help with that.

# Future improvements
- You might want to discuss whether it would be possible to throw a more precise exception such as `TrailingCommaException: Trailing comma detected at path $.a` instead of `JsonEncodingException: Expected name at path $.`