### PR TITLE
Parsing String to Map -> Map to String fails in Kotlin

### DIFF
--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -849,6 +849,14 @@ class KotlinJsonAdapterTest {
     assertThat(adapter.fromJson(json)).isEqualTo(value)
     assertThat(adapter.toJson(value)).isEqualTo(json)
   }
+  
+  @Test fun backAndForthMap() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    val json = """{"map-key1":"map-value","map-key2":"map-value"}"""
+    val map = moshi.adapter(Map::class.java).fromJson(json)!!
+    val value = moshi.adapter(map.javaClass).toJson(map)
+    assertThat(value).isEqualTo(json)
+  }
 
   @Test fun mixingReflectionAndCodegen() {
     val moshi = Moshi.Builder()


### PR DESCRIPTION
This is a small Bug which appears to happen only in kotlin.