### PR TITLE
Fix incorrect path in enum adapter error message.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.java
+++ b/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.java
@@ -291,10 +291,10 @@ final class StandardJsonAdapters {
       if (index != -1) return constants[index];
 
       // We can consume the string safely, we are terminating anyway.
+      String path = reader.getPath();
       String name = reader.nextString();
       throw new JsonDataException("Expected one of "
-          + Arrays.asList(nameStrings) + " but was " + name + " at path "
-          + reader.getPath());
+          + Arrays.asList(nameStrings) + " but was " + name + " at path " + path);
     }
 
     @Override public void toJson(JsonWriter writer, T value) throws IOException {

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -878,7 +878,7 @@ public final class MoshiTest {
 
   @Test public void invalidEnum() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
-    JsonAdapter<Roshambo> adapter = moshi.adapter(Roshambo.class).lenient();
+    JsonAdapter<Roshambo> adapter = moshi.adapter(Roshambo.class);
     try {
       adapter.fromJson("\"SPOCK\"");
       fail();
@@ -886,6 +886,22 @@ public final class MoshiTest {
       assertThat(expected).hasMessage(
           "Expected one of [ROCK, PAPER, scr] but was SPOCK at path $");
     }
+  }
+
+  @Test public void invalidEnumHasCorrectPathInExceptionMessage() throws Exception {
+    Moshi moshi = new Moshi.Builder().build();
+    JsonAdapter<Roshambo> adapter = moshi.adapter(Roshambo.class);
+    JsonReader reader = JsonReader.of(new Buffer().writeUtf8("[\"SPOCK\"]"));
+    reader.beginArray();
+    try {
+      adapter.fromJson(reader);
+      fail();
+    } catch (JsonDataException expected) {
+      assertThat(expected).hasMessage(
+          "Expected one of [ROCK, PAPER, scr] but was SPOCK at path $[0]");
+    }
+    reader.endArray();
+    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
   }
 
   @Test public void nullEnum() throws Exception {


### PR DESCRIPTION
"at path $[1]" > "at path $[0]"