### PR TITLE
Add new error message for fields missing type adapters.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -95,7 +95,13 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
         // Look up a type adapter for this type.
         Type fieldType = resolve(type, rawType, field.getGenericType());
         Set<? extends Annotation> annotations = Util.jsonAnnotations(field);
-        JsonAdapter<Object> adapter = moshi.adapter(fieldType, annotations);
+        JsonAdapter<Object> adapter;
+        try {
+          adapter = moshi.adapter(fieldType, annotations);
+        } catch (IllegalArgumentException e) {
+          throw new IllegalArgumentException("Error creating adapter for field '" + field.getName()
+              + "' in " + type, e);
+        }
 
         // Create the binding between field and JSON.
         field.setAccessible(true);

--- a/moshi/src/test/java/com/squareup/moshi/JsonQualifiersTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonQualifiersTest.java
@@ -243,6 +243,11 @@ public final class JsonQualifiersTest {
       moshi.adapter(StringAndFooString.class);
       fail();
     } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessage("Error creating adapter for field 'b' in class "
+          + "com.squareup.moshi.JsonQualifiersTest$StringAndFooString");
+      assertThat(expected).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(expected.getCause()).hasMessage("No JsonAdapter for class java.lang.String "
+          + "annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
     }
   }
 
@@ -332,8 +337,11 @@ public final class JsonQualifiersTest {
       moshi.adapter(StringAndFooString.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("No @FromJson adapter for class java.lang.String "
-          + "annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
+      assertThat(expected).hasMessage("Error creating adapter for field 'b' in class"
+          + " com.squareup.moshi.JsonQualifiersTest$StringAndFooString");
+      assertThat(expected).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(expected.getCause()).hasMessage("No @FromJson adapter for class java.lang.String"
+          + " annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
     }
   }
 
@@ -353,7 +361,10 @@ public final class JsonQualifiersTest {
       moshi.adapter(StringAndFooString.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("No @ToJson adapter for class java.lang.String "
+      assertThat(expected).hasMessage("Error creating adapter for field 'b' in class "
+          + "com.squareup.moshi.JsonQualifiersTest$StringAndFooString");
+      assertThat(expected).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(expected.getCause()).hasMessage("No @ToJson adapter for class java.lang.String "
           + "annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
     }
   }

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -955,6 +955,24 @@ public final class MoshiTest {
     }
   }
 
+  static final class HasPlatformType {
+    ArrayList<String> list;
+  }
+
+  @Test public void platformTypeClassFieldThrows() {
+    Moshi moshi = new Moshi.Builder().build();
+    try {
+      moshi.adapter(HasPlatformType.class);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("Error creating adapter for field 'list' in class "
+          + "com.squareup.moshi.MoshiTest$HasPlatformType");
+      assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(e.getCause()).hasMessage("Platform java.util.ArrayList<java.lang.String> "
+          + "(with no annotations) requires explicit JsonAdapter to be registered");
+    }
+  }
+
   @Test public void qualifierWithElementsMayNotBeDirectlyRegistered() throws IOException {
     try {
       new Moshi.Builder()


### PR DESCRIPTION
The error message says the field that is missing an adapter, so you don't need to use a debugger.
The previous error message is moved to the exception's cause.

Closes #557 and may help folks on [SO](https://stackoverflow.com/questions/51669838/moshi-for-parsing-youtube-search-api).

If this is a good idea, maybe the Kotlin adapters should do something similar.