### PR TITLE
Track field names in the adapter lookup stack.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -95,14 +95,15 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
         // Look up a type adapter for this type.
         Type fieldType = resolve(type, rawType, field.getGenericType());
         Set<? extends Annotation> annotations = Util.jsonAnnotations(field);
-        JsonAdapter<Object> adapter = moshi.adapter(fieldType, annotations);
+        String fieldName = field.getName();
+        JsonAdapter<Object> adapter = moshi.adapter(fieldType, annotations, fieldName);
 
         // Create the binding between field and JSON.
         field.setAccessible(true);
 
         // Store it using the field's name. If there was already a field with this name, fail!
         Json jsonAnnotation = field.getAnnotation(Json.class);
-        String name = jsonAnnotation != null ? jsonAnnotation.name() : field.getName();
+        String name = jsonAnnotation != null ? jsonAnnotation.name() : fieldName;
         FieldBinding<Object> fieldBinding = new FieldBinding<>(name, field, adapter);
         FieldBinding<?> replaced = fieldBindings.put(name, fieldBinding);
         if (replaced != null) {

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -94,9 +94,13 @@ public final class Moshi {
     return adapter(type, annotations, null);
   }
 
+  /**
+   * @param fieldName An optional field name associated with this type. The field name is used as a
+   * hint for better adapter lookup error messages for nested structures.
+   */
   @CheckReturnValue
   @SuppressWarnings("unchecked") // Factories are required to return only matching JsonAdapters.
-  <T> JsonAdapter<T> adapter(Type type, Set<? extends Annotation> annotations,
+  public <T> JsonAdapter<T> adapter(Type type, Set<? extends Annotation> annotations,
       @Nullable String fieldName) {
     if (type == null) {
       throw new NullPointerException("type == null");

--- a/moshi/src/test/java/com/squareup/moshi/JsonQualifiersTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonQualifiersTest.java
@@ -332,8 +332,10 @@ public final class JsonQualifiersTest {
       moshi.adapter(StringAndFooString.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("Error creating adapter for field "
-          + "\'com.squareup.moshi.JsonQualifiersTest$StringAndFooString.b\'");
+      assertThat(expected).hasMessage("No @FromJson adapter for class java.lang.String annotated "
+          + "[@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]"
+          + "\nfor class java.lang.String b"
+          + "\nfor class com.squareup.moshi.JsonQualifiersTest$StringAndFooString");
       assertThat(expected).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
       assertThat(expected.getCause()).hasMessage("No @FromJson adapter for class java.lang.String "
           + "annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
@@ -356,8 +358,10 @@ public final class JsonQualifiersTest {
       moshi.adapter(StringAndFooString.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("Error creating adapter for field "
-          + "\'com.squareup.moshi.JsonQualifiersTest$StringAndFooString.b\'");
+      assertThat(expected).hasMessage("No @ToJson adapter for class java.lang.String annotated "
+          + "[@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]"
+          + "\nfor class java.lang.String b"
+          + "\nfor class com.squareup.moshi.JsonQualifiersTest$StringAndFooString");
       assertThat(expected).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
       assertThat(expected.getCause()).hasMessage("No @ToJson adapter for class java.lang.String "
           + "annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");

--- a/moshi/src/test/java/com/squareup/moshi/JsonQualifiersTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonQualifiersTest.java
@@ -332,7 +332,10 @@ public final class JsonQualifiersTest {
       moshi.adapter(StringAndFooString.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("No @FromJson adapter for class java.lang.String "
+      assertThat(expected).hasMessage("Error creating adapter for field "
+          + "\'com.squareup.moshi.JsonQualifiersTest$StringAndFooString.b\'");
+      assertThat(expected).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(expected.getCause()).hasMessage("No @FromJson adapter for class java.lang.String "
           + "annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
     }
   }
@@ -353,7 +356,10 @@ public final class JsonQualifiersTest {
       moshi.adapter(StringAndFooString.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("No @ToJson adapter for class java.lang.String "
+      assertThat(expected).hasMessage("Error creating adapter for field "
+          + "\'com.squareup.moshi.JsonQualifiersTest$StringAndFooString.b\'");
+      assertThat(expected).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(expected.getCause()).hasMessage("No @ToJson adapter for class java.lang.String "
           + "annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
     }
   }

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -45,6 +45,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
+@SuppressWarnings("CheckReturnValue")
 public final class MoshiTest {
   @Test public void booleanAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
@@ -952,6 +953,61 @@ public final class MoshiTest {
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage("Platform class android.util.Pair (with no annotations) "
           + "requires explicit JsonAdapter to be registered");
+    }
+  }
+
+  static final class HasPlatformType {
+    ArrayList<String> strings;
+
+    static final class Wrapper {
+      HasPlatformType hasPlatformType;
+    }
+
+    static final class ListWrapper {
+      List<HasPlatformType> platformTypes;
+    }
+  }
+
+  @Test public void reentrantFieldErrorMessagesTopLevelMap() {
+    Moshi moshi = new Moshi.Builder().build();
+    try {
+      moshi.adapter(Types.newParameterizedType(Map.class, String.class, HasPlatformType.class));
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("Error creating adapter for field "
+          + "'com.squareup.moshi.MoshiTest$HasPlatformType.strings' in java.util.Map");
+      assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(e.getCause()).hasMessage("Platform java.util.ArrayList<java.lang.String> "
+          + "(with no annotations) requires explicit JsonAdapter to be registered");
+    }
+  }
+
+  @Test public void reentrantFieldErrorMessagesWrapper() {
+    Moshi moshi = new Moshi.Builder().build();
+    try {
+      moshi.adapter(HasPlatformType.Wrapper.class);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("Error creating adapter for field "
+          + "\'com.squareup.moshi.MoshiTest$HasPlatformType$Wrapper.hasPlatformType.strings\'");
+      assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(e.getCause()).hasMessage("Platform java.util.ArrayList<java.lang.String> "
+          + "(with no annotations) requires explicit JsonAdapter to be registered");
+    }
+  }
+
+  @Test public void reentrantFieldErrorMessagesListWrapper() {
+    Moshi moshi = new Moshi.Builder().build();
+    try {
+      moshi.adapter(HasPlatformType.ListWrapper.class);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("Error creating adapter for field "
+          + "'com.squareup.moshi.MoshiTest$HasPlatformType.strings' in field "
+          + "'com.squareup.moshi.MoshiTest$HasPlatformType$ListWrapper.platformTypes'");
+      assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(e.getCause()).hasMessage("Platform java.util.ArrayList<java.lang.String> "
+          + "(with no annotations) requires explicit JsonAdapter to be registered");
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -974,8 +974,13 @@ public final class MoshiTest {
       moshi.adapter(Types.newParameterizedType(Map.class, String.class, HasPlatformType.class));
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Error creating adapter for field "
-          + "'com.squareup.moshi.MoshiTest$HasPlatformType.strings' in java.util.Map");
+      assertThat(e).hasMessage(
+          "Platform java.util.ArrayList<java.lang.String> (with no annotations) requires explicit "
+              + "JsonAdapter to be registered"
+              + "\nfor java.util.ArrayList<java.lang.String> strings"
+              + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType"
+              + "\nfor java.util.Map<java.lang.String, "
+              + "com.squareup.moshi.MoshiTest$HasPlatformType>");
       assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause()).hasMessage("Platform java.util.ArrayList<java.lang.String> "
           + "(with no annotations) requires explicit JsonAdapter to be registered");
@@ -988,8 +993,12 @@ public final class MoshiTest {
       moshi.adapter(HasPlatformType.Wrapper.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Error creating adapter for field "
-          + "\'com.squareup.moshi.MoshiTest$HasPlatformType$Wrapper.hasPlatformType.strings\'");
+      assertThat(e).hasMessage(
+          "Platform java.util.ArrayList<java.lang.String> (with no annotations) requires explicit "
+              + "JsonAdapter to be registered"
+              + "\nfor java.util.ArrayList<java.lang.String> strings"
+              + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType hasPlatformType"
+              + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType$Wrapper");
       assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause()).hasMessage("Platform java.util.ArrayList<java.lang.String> "
           + "(with no annotations) requires explicit JsonAdapter to be registered");
@@ -1002,9 +1011,13 @@ public final class MoshiTest {
       moshi.adapter(HasPlatformType.ListWrapper.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Error creating adapter for field "
-          + "'com.squareup.moshi.MoshiTest$HasPlatformType.strings' in field "
-          + "'com.squareup.moshi.MoshiTest$HasPlatformType$ListWrapper.platformTypes'");
+      assertThat(e).hasMessage(
+          "Platform java.util.ArrayList<java.lang.String> (with no annotations) requires explicit "
+              + "JsonAdapter to be registered"
+              + "\nfor java.util.ArrayList<java.lang.String> strings"
+              + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType"
+              + "\nfor java.util.List<com.squareup.moshi.MoshiTest$HasPlatformType> platformTypes"
+              + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType$ListWrapper");
       assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause()).hasMessage("Platform java.util.ArrayList<java.lang.String> "
           + "(with no annotations) requires explicit JsonAdapter to be registered");


### PR DESCRIPTION
This allows for an error message that includes field names to track down the cause of adapter creation failure for deeply nested structures.


This got complicated, so I am not sure I have a good solution yet.