### PR TITLE
Fix README link to jar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ License
     limitations under the License.
 
 
- [dl]: https://search.maven.org/remote_content?g=com.squareup.moshi&a=moshi&v=LATEST
+ [dl]: https://search.maven.org/search?q=g:com.squareup.moshi%20a:moshi%20v:LATEST%3D
  [snap]: https://oss.sonatype.org/content/repositories/snapshots/com/squareup/moshi/
  [okio]: https://github.com/square/okio/
  [okhttp]: https://github.com/square/okhttp/

--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ License
     limitations under the License.
 
 
- [dl]: https://search.maven.org/search?q=g:com.squareup.moshi%20a:moshi%20v:LATEST%3D
+ [dl]: https://search.maven.org/classic/remote_content?g=com.squareup.moshi&a=moshi&v=LATEST
  [snap]: https://oss.sonatype.org/content/repositories/snapshots/com/squareup/moshi/
  [okio]: https://github.com/square/okio/
  [okhttp]: https://github.com/square/okhttp/


### PR DESCRIPTION
Sonatype changed its site.

I'm not sure if there's a way to link directly to the latest jar now.