### PR TITLE
Make nullable primitives in codegen use boxed type adapters.

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TypeRenderer.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TypeRenderer.kt
@@ -43,6 +43,16 @@ abstract class TypeRenderer {
 
   fun render(typeName: TypeName): CodeBlock {
     if (typeName.nullable) {
+      if (typeName == BOOLEAN.asNullable()
+          || typeName == BYTE.asNullable()
+          || typeName == CHAR.asNullable()
+          || typeName == DOUBLE.asNullable()
+          || typeName == FLOAT.asNullable()
+          || typeName == INT.asNullable()
+          || typeName == LONG.asNullable()
+          || typeName == SHORT.asNullable()) {
+        return CodeBlock.of("%T::class.javaObjectType", typeName.asNonNullable())
+      }
       return render(typeName.asNonNullable())
     }
 

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -17,9 +17,12 @@ package com.squareup.moshi.kotlin.reflect
 
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.JsonQualifier
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.ToJson
 import com.squareup.moshi.Types
@@ -880,5 +883,34 @@ class KotlinJsonAdapterTest {
     @FromJson @Uppercase fun fromJson(s: String) : String {
       return s.toLowerCase(Locale.US)
     }
+  }
+
+  data class HasNullableBoolean(val boolean: Boolean?)
+
+  @Test fun nullablePrimitivesUseBoxedPrimitiveAdapters() {
+    val moshi = Moshi.Builder()
+        .add(JsonAdapter.Factory { type, annotations, moshi ->
+          if (Boolean::class.javaObjectType == type) {
+            return@Factory object: JsonAdapter<Boolean?>() {
+              override fun fromJson(reader: JsonReader): Boolean? {
+                if (reader.peek() != JsonReader.Token.BOOLEAN) {
+                  reader.skipValue()
+                  return null
+                }
+                return reader.nextBoolean()
+              }
+
+              override fun toJson(writer: JsonWriter, value: Boolean?) {
+                writer.value(value)
+              }
+            }
+          }
+          null
+        })
+        .build()
+    val adapter = moshi.adapter(HasNullableBoolean::class.java).serializeNulls()
+    assertThat(adapter.fromJson("""{"boolean":"not a boolean"}"""))
+        .isEqualTo(HasNullableBoolean(null))
+    assertThat(adapter.toJson(HasNullableBoolean(null))).isEqualTo("""{"boolean":null}""")
   }
 }


### PR DESCRIPTION
```kotlin
private val nullableBooleanAdapter: JsonAdapter<Boolean?> =
        moshi.adapter(Boolean::class.javaObjectType).nullSafe()
```
instead of
```kotlin
private val nullableBooleanAdapter: JsonAdapter<Boolean> = moshi.adapter(Boolean::class).nullSafe()
```