### PR TITLE
Embed ProGuard rules in the jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,34 +578,14 @@ implementation 'com.squareup.moshi:moshi:1.6.0'
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].
 
 
-ProGuard
+R8 / ProGuard
 --------
 
-If you are using ProGuard you might need to add the following options:
-```
--dontwarn okio.**
--dontwarn javax.annotation.**
--keepclasseswithmembers class * {
-    @com.squareup.moshi.* <methods>;
-}
--keep @com.squareup.moshi.JsonQualifier interface *
-```
-Additional rules are needed if you are using Kotlin:
+If you are using R8 or ProGuard add the options from [this file](https://github.com/square/moshi/blob/master/moshi/src/main/resources/META-INF/proguard/moshi.pro).
 
-*...If you are using the reflect API (i.e. `KotlinJsonAdapterFactory`):*
-```
--keepclassmembers class kotlin.Metadata {
-    public <methods>;
-}
-```
-*...If you are using the codegen API (i.e. `JsonClass(generateAdapter = true)`):*
-```
--keep class **JsonAdapter {
-    <init>(...);
-    <fields>;
-}
--keepnames @com.squareup.moshi.JsonClass class *
-```
+The `moshi-kotlin` artifact additionally requires the options from [this file](https://github.com/square/moshi/blob/master/kotlin/reflect/src/main/resources/META-INF/proguard/moshi-kotlin.pro)
+
+You might also need rules for Okio which is a dependency of this library.
 
 License
 --------

--- a/kotlin/reflect/src/main/resources/META-INF/proguard/moshi-kotlin.pro
+++ b/kotlin/reflect/src/main/resources/META-INF/proguard/moshi-kotlin.pro
@@ -1,3 +1,5 @@
+-keep class kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoaderImpl
+
 -keepclassmembers class kotlin.Metadata {
     public <methods>;
 }

--- a/kotlin/reflect/src/main/resources/META-INF/proguard/moshi-kotlin.pro
+++ b/kotlin/reflect/src/main/resources/META-INF/proguard/moshi-kotlin.pro
@@ -1,0 +1,3 @@
+-keepclassmembers class kotlin.Metadata {
+    public <methods>;
+}

--- a/moshi/src/main/resources/META-INF/proguard/moshi.pro
+++ b/moshi/src/main/resources/META-INF/proguard/moshi.pro
@@ -7,10 +7,10 @@
 
 -keep @com.squareup.moshi.JsonQualifier interface *
 
-# The name of @JsonClass types is used to look up the generated adapter
+# The name of @JsonClass types is used to look up the generated adapter.
 -keepnames @com.squareup.moshi.JsonClass class *
 
-# Retain generated JsonAdapters if annotated type is retained
+# Retain generated JsonAdapters if annotated type is retained.
 -if @com.squareup.moshi.JsonClass class *
 -keep class <1>JsonAdapter {
     <init>(...);

--- a/moshi/src/main/resources/META-INF/proguard/moshi.pro
+++ b/moshi/src/main/resources/META-INF/proguard/moshi.pro
@@ -1,0 +1,18 @@
+# JSR 305 annotations are for embedding nullability information.
+-dontwarn javax.annotation.**
+
+-keepclasseswithmembers class * {
+    @com.squareup.moshi.* <methods>;
+}
+
+-keep @com.squareup.moshi.JsonQualifier interface *
+
+# The name of @JsonClass types is used to look up the generated adapter
+-keepnames @com.squareup.moshi.JsonClass class *
+
+# Retain generated JsonAdapters if annotated type is retained
+-if @com.squareup.moshi.JsonClass class *
+-keep class <1>JsonAdapter {
+    <init>(...);
+    <fields>;
+}


### PR DESCRIPTION
This should probably not be merged until AGP 3.2.0 is out, because the `-if` rule used for generated adapters is only supported in ProGuard 6.0.0+ (AGP 3.1.x uses ProGuard 5.x).