### PR TITLE
Change DelegateKey to use AnnotationSpec instead of AnnotationMirror

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
@@ -135,7 +135,7 @@ internal class AdapterGenerator(
     result.addProperty(optionsProperty)
     for (uniqueAdapter in propertyList.distinctBy { it.delegateKey }) {
       result.addProperty(uniqueAdapter.delegateKey.generateProperty(
-          nameAllocator, typeRenderer, moshiParam, messager))
+          nameAllocator, typeRenderer, moshiParam))
     }
 
     result.addFunction(generateToStringFun())

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/PropertyGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/PropertyGenerator.kt
@@ -20,8 +20,10 @@ import com.squareup.kotlinpoet.NameAllocator
 import com.squareup.kotlinpoet.PropertySpec
 
 /** Generates functions to encode and decode a property as JSON. */
-internal class PropertyGenerator(val target: TargetProperty) {
-  val delegateKey = target.delegateKey()
+internal class PropertyGenerator(
+  val target: TargetProperty,
+  val delegateKey: DelegateKey
+) {
   val name = target.name
   val jsonName = target.jsonName()
   val hasDefault = target.hasDefault


### PR DESCRIPTION
AnnotationSpec implements equals() in the way we need, but
AnnotationMirror doesn't. As a consequence this fixes a problem
where we were generating redundant adapters.

Closes: https://github.com/square/moshi/issues/563