### PR TITLE
Include labels when encoding with RuntimeJsonAdapterFactory.

### DIFF
--- a/adapters/src/main/java/com/squareup/moshi/adapters/EnumJsonAdapter.java
+++ b/adapters/src/main/java/com/squareup/moshi/adapters/EnumJsonAdapter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.moshi.adapters;
 
 import com.squareup.moshi.Json;
@@ -7,7 +22,6 @@ import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -55,7 +69,7 @@ public final class EnumJsonAdapter<T extends Enum<T>> extends JsonAdapter<T> {
     }
   }
 
-  @Override public @Nonnull T fromJson(JsonReader reader) throws IOException {
+  @Override public @Nullable T fromJson(JsonReader reader) throws IOException {
     int index = reader.selectString(options);
     if (index != -1) return constants[index];
 

--- a/adapters/src/test/java/com/squareup/moshi/adapters/RuntimeJsonAdapterFactoryTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/RuntimeJsonAdapterFactoryTest.java
@@ -53,9 +53,9 @@ public final class RuntimeJsonAdapterFactoryTest {
     JsonAdapter<Message> adapter = moshi.adapter(Message.class);
 
     assertThat(adapter.toJson(new Success("Okay!")))
-        .isEqualTo("{\"value\":\"Okay!\"}");
+        .isEqualTo("{\"type\":\"success\",\"value\":\"Okay!\"}");
     assertThat(adapter.toJson(new Error(Collections.<String, Object>singletonMap("order", 66))))
-        .isEqualTo("{\"error_logs\":{\"order\":66}}");
+        .isEqualTo("{\"type\":\"error\",\"error_logs\":{\"order\":66}}");
   }
 
   @Test public void unregisteredLabelValue() throws IOException {


### PR DESCRIPTION
Otherwise the adapter is not symmetric.