### PR TITLE
Make generated adapters null-safe.

### DIFF
--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codgen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codgen/GeneratedAdaptersTest.kt
@@ -1075,6 +1075,13 @@ class GeneratedAdaptersTest {
         .isEqualTo(HasNullableBoolean(null))
     assertThat(adapter.toJson(HasNullableBoolean(null))).isEqualTo("""{"boolean":null}""")
   }
+
+  @Test fun adaptersAreNullSafe() {
+    val moshi = Moshi.Builder().build()
+    val adapter = moshi.adapter(HasNonNullConstructorParameter::class.java)
+    assertThat(adapter.fromJson("null")).isNull()
+    assertThat(adapter.toJson(null)).isEqualTo("null")
+  }
 }
 
 // Has to be outside to avoid Types seeing an owning class

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -860,10 +860,11 @@ class KotlinJsonAdapterTest {
     val generatedAdapter = moshi.adapter(UsesGeneratedAdapter::class.java)
     val reflectionAdapter = moshi.adapter(UsesReflectionAdapter::class.java)
 
-    assertThat(generatedAdapter.javaClass.name)
-        .contains("KotlinJsonAdapterTest_UsesGeneratedAdapterJsonAdapter")
-    assertThat(reflectionAdapter.javaClass.name)
-        .doesNotContain("KotlinJsonAdapterTest_UsesReflectionAdapterJsonAdapter")
+    assertThat(generatedAdapter.toString())
+        .isEqualTo("GeneratedJsonAdapter(KotlinJsonAdapterTest.UsesGeneratedAdapter).nullSafe()")
+    assertThat(reflectionAdapter.toString())
+        .isEqualTo("KotlinJsonAdapter(com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest" +
+            ".UsesReflectionAdapter).nullSafe()")
   }
 
   @JsonClass(generateAdapter = true)
@@ -912,5 +913,12 @@ class KotlinJsonAdapterTest {
     assertThat(adapter.fromJson("""{"boolean":"not a boolean"}"""))
         .isEqualTo(HasNullableBoolean(null))
     assertThat(adapter.toJson(HasNullableBoolean(null))).isEqualTo("""{"boolean":null}""")
+  }
+
+  @Test fun adaptersAreNullSafe() {
+    val moshi = Moshi.Builder().build()
+    val adapter = moshi.adapter(HasNonNullConstructorParameter::class.java)
+    assertThat(adapter.fromJson("null")).isNull()
+    assertThat(adapter.toJson(null)).isEqualTo("null")
   }
 }

--- a/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.java
+++ b/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.java
@@ -59,7 +59,7 @@ final class StandardJsonAdapters {
 
       JsonClass jsonClass = rawType.getAnnotation(JsonClass.class);
       if (jsonClass != null && jsonClass.generateAdapter()) {
-        return generatedAdapter(moshi, type, rawType);
+        return generatedAdapter(moshi, type, rawType).nullSafe();
       }
 
       if (rawType.isEnum()) {


### PR DESCRIPTION
This is in alignment with the lookup for Java and Kotlin reflective adapters.

This also makes https://github.com/square/moshi/issues/586 easy to support, as long as adapter factories don't know about type nullability.