### PR TITLE
Generate nicer stacktraces when creating a generated adapter fails.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.moshi;
 
+import com.squareup.moshi.internal.Util;
 import java.io.ObjectInputStream;
 import java.io.ObjectStreamClass;
 import java.lang.reflect.Constructor;
@@ -103,7 +104,7 @@ abstract class ClassFactory<T> {
     } catch (IllegalAccessException e) {
       throw new AssertionError();
     } catch (InvocationTargetException e) {
-      throw new RuntimeException(e);
+      throw Util.rethrowCause(e);
     } catch (NoSuchMethodException ignored) {
       // Not the expected version of Dalvik/libcore!
     }

--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -138,10 +138,7 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
     } catch (InstantiationException e) {
       throw new RuntimeException(e);
     } catch (InvocationTargetException e) {
-      Throwable targetException = e.getTargetException();
-      if (targetException instanceof RuntimeException) throw (RuntimeException) targetException;
-      if (targetException instanceof Error) throw (Error) targetException;
-      throw new RuntimeException(targetException);
+      throw Util.rethrowCause(e);
     } catch (IllegalAccessException e) {
       throw new AssertionError();
     }

--- a/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.java
+++ b/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.java
@@ -254,12 +254,11 @@ final class StandardJsonAdapters {
     } catch (IllegalAccessException e) {
       throw new RuntimeException(
           "Failed to access the generated JsonAdapter for " + rawType, e);
-    } catch (InvocationTargetException e) {
-      throw new RuntimeException(
-          "Failed to construct the generated JsonAdapter for " + rawType, e);
     } catch (InstantiationException e) {
       throw new RuntimeException(
           "Failed to instantiate the generated JsonAdapter for " + rawType, e);
+    } catch (InvocationTargetException e) {
+      throw Util.rethrowCause(e);
     }
   }
 

--- a/moshi/src/main/java/com/squareup/moshi/internal/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/Util.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.GenericDeclaration;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
@@ -93,6 +94,14 @@ public final class Util {
         || name.startsWith("javax.")
         || name.startsWith("kotlin.")
         || name.startsWith("scala.");
+  }
+
+  /** Throws the cause of {@code e}, wrapping it if it is checked. */
+  public static RuntimeException rethrowCause(InvocationTargetException e) {
+    Throwable cause = e.getTargetException();
+    if (cause instanceof RuntimeException) throw (RuntimeException) cause;
+    if (cause instanceof Error) throw (Error) cause;
+    throw new RuntimeException(cause);
   }
 
   /**


### PR DESCRIPTION
Otherwise we end up with many InvocationTargetExceptions layered in, which makes
it difficult to identify what actually failed.