### PR TITLE
Fix qualifiedAdaptersAreShared test.

### DIFF
--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codgen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codgen/GeneratedAdaptersTest.kt
@@ -869,7 +869,9 @@ class GeneratedAdaptersTest {
     val encoded = MultiplePropertiesShareAdapter("Android", "Banana")
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":"ANDROID","b":"BANANA"}""")
 
-    val delegateAdapters = jsonAdapter::class.memberProperties.filter {
+    val adapterClass = Class.forName(
+        GeneratedAdaptersTest::class.qualifiedName + "_MultiplePropertiesShareAdapterJsonAdapter")
+    val delegateAdapters = adapterClass.kotlin.memberProperties.filter {
       it.returnType.classifier == JsonAdapter::class
     }
     assertThat(delegateAdapters).hasSize(1)


### PR DESCRIPTION
The test needs to inspect the original codegen adapter, not the adapter from the lookup (which is now the null-safe adapter).