### PR TITLE
Allow user adapters to convert null to non-null in codegen.

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/DelegateKey.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/DelegateKey.kt
@@ -69,11 +69,9 @@ internal data class DelegateKey(
     }
     val finalArgs = arrayOf(*standardArgs, *args)
 
-    val nullModifier = if (nullable) ".nullSafe()" else ".nonNull()"
-
     return PropertySpec.builder(adapterName, adapterTypeName, KModifier.PRIVATE)
         .addAnnotations(jsonQualifiers)
-        .initializer("%1N.adapter%2L(%3L$initializerString)$nullModifier", *finalArgs)
+        .initializer("%1N.adapter%2L(%3L$initializerString)", *finalArgs)
         .build()
   }
 }


### PR DESCRIPTION
Delegate to installed adapters instead of checking for null.

Closes #586.