### PR TITLE
Remove duplicate kotlin-metadata version declaration.

### DIFF
--- a/kotlin/codegen/pom.xml
+++ b/kotlin/codegen/pom.xml
@@ -64,7 +64,6 @@
     <dependency>
       <groupId>me.eugeniomarletti.kotlin.metadata</groupId>
       <artifactId>kotlin-metadata</artifactId>
-      <version>1.4.0</version>
     </dependency>
     <!--
       Though we don't use compile-testing, including it is a convenient way to get tools.jar on the


### PR DESCRIPTION
The version is already defined in the root.