### PR TITLE
Always keep fields of annotated enums

### DIFF
--- a/moshi/src/main/resources/META-INF/proguard/moshi.pro
+++ b/moshi/src/main/resources/META-INF/proguard/moshi.pro
@@ -9,7 +9,7 @@
 
 # Enum field names are used by the integrated EnumJsonAdapter.
 # Annotate enums with @JsonClass(generateAdapter = false) to use them with Moshi.
--keepclassmembernames @com.squareup.moshi.JsonClass class * extends java.lang.Enum {
+-keepclassmembers @com.squareup.moshi.JsonClass class * extends java.lang.Enum {
     <fields>;
 }
 


### PR DESCRIPTION
We need to keep enum fields for `EnumJsonAdapter` even if they are not used elsewhere.

```kotlin
@JsonClass(generateAdapter = false)
enum class StatusCode {
    @Json(name = "success")
    Success,
    @Json(name = "error")
    Error
}

if (status == StatusCode.Success) {
    ...
}
```

`-keepclassmembernames` won't prevent `StatusCode.Error` from being removed that's why `-keepclassmembers` should be used instead.
@gabrielittner 