### PR TITLE
Don't use @Language when the literal includes a dollar sign

### DIFF
--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codgen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codgen/GeneratedAdaptersTest.kt
@@ -65,14 +65,12 @@ class GeneratedAdaptersTest {
     val adapter = moshi.adapter(JsonAnnotationWithDollarSign::class.java)
 
     // Read
-    @Language("JSON")
     val json = "{\"\$foo\": \"bar\"}"
 
     val instance = adapter.fromJson(json)!!
     assertThat(instance.bar).isEqualTo("bar")
 
     // Write
-    @Language("JSON")
     val expectedJson = "{\"\$foo\":\"baz\"}"
 
     assertThat(adapter.toJson(JsonAnnotationWithDollarSign("baz"))).isEqualTo(expectedJson)


### PR DESCRIPTION
It makes IntelliJ grumpy.
https://youtrack.jetbrains.com/issue/KT-27224