### PR TITLE
Make RuntimeJsonAdapterFactory public

### DIFF
--- a/adapters/src/main/java/com/squareup/moshi/adapters/RuntimeJsonAdapterFactory.java
+++ b/adapters/src/main/java/com/squareup/moshi/adapters/RuntimeJsonAdapterFactory.java
@@ -34,8 +34,8 @@ import javax.annotation.CheckReturnValue;
  * decoding the JSON. This factory's adapters expect JSON in the format of a JSON object with a
  * key whose value is a label that determines the type to which to map the JSON object.
  */
-// TODO(jwilson): make this class public in Moshi 1.8.
-final class RuntimeJsonAdapterFactory<T> implements JsonAdapter.Factory {
+
+public final class RuntimeJsonAdapterFactory<T> implements JsonAdapter.Factory {
   final Class<T> baseType;
   final String labelKey;
   final Map<String, Type> labelToType = new LinkedHashMap<>();


### PR DESCRIPTION
RuntimeJsonAdapterFactory was public in a previous 1.7-SNAPSHOT build.

After viewing the todo, I changed the visibility modifier ahead of the next 1.8 snapshot release.