### PR TITLE
Allow other processors to process JsonClass

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessor.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessor.kt
@@ -90,7 +90,7 @@ class JsonClassCodegenProcessor : KotlinAbstractProcessor(), KotlinMetadataUtils
       }
     }
 
-    return true
+    return false
   }
 
   private fun adapterGenerator(element: Element): AdapterGenerator? {


### PR DESCRIPTION
Someone at KotlinConf brought this to my attention, as they're trying to generate their own adapter factory that delegates to the other ones (to skip the reflective lookup) but can't since moshi consumes the annotation and doesn't allow others.