### PR TITLE
Fall back to reflection when generated adapter is not found.

### DIFF
--- a/kotlin/reflect/src/main/test/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/kotlin/reflect/src/main/test/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -1,0 +1,21 @@
+package com.squareup.moshi.kotlin.reflect
+
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class KotlinJsonAdapterTest {
+  @JsonClass(generateAdapter = true)
+  class Data
+
+  @Test fun fallsBackToReflectiveAdapterWithoutCodegen() {
+    val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+    val adapter = moshi.adapter(Data::class.java)
+    assertThat(adapter.toString()).isEqualTo(
+        "KotlinJsonAdapter(com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest.Data).nullSafe()"
+    )
+  }
+}

--- a/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.java
+++ b/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.java
@@ -18,15 +18,15 @@ package com.squareup.moshi;
 import com.squareup.moshi.internal.Util;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
+
+import static com.squareup.moshi.internal.Util.generatedAdapter;
 
 final class StandardJsonAdapters {
   private StandardJsonAdapters() {
@@ -57,9 +57,9 @@ final class StandardJsonAdapters {
 
       Class<?> rawType = Types.getRawType(type);
 
-      JsonClass jsonClass = rawType.getAnnotation(JsonClass.class);
-      if (jsonClass != null && jsonClass.generateAdapter()) {
-        return generatedAdapter(moshi, type, rawType).nullSafe();
+      @Nullable JsonAdapter<?> generatedAdapter = generatedAdapter(moshi, type, rawType);
+      if (generatedAdapter != null) {
+        return generatedAdapter;
       }
 
       if (rawType.isEnum()) {
@@ -223,44 +223,6 @@ final class StandardJsonAdapters {
       return "JsonAdapter(String)";
     }
   };
-
-  /**
-   * Loads the generated JsonAdapter for classes annotated {@link JsonClass}. This works because it
-   * uses the same naming conventions as {@code JsonClassCodeGenProcessor}.
-   */
-  static JsonAdapter<?> generatedAdapter(Moshi moshi, Type type, Class<?> rawType) {
-    String adapterClassName = rawType.getName().replace("$", "_") + "JsonAdapter";
-    try {
-      @SuppressWarnings("unchecked") // We generate types to match.
-      Class<? extends JsonAdapter<?>> adapterClass = (Class<? extends JsonAdapter<?>>)
-          Class.forName(adapterClassName, true, rawType.getClassLoader());
-      if (type instanceof ParameterizedType) {
-        Constructor<? extends JsonAdapter<?>> constructor
-            = adapterClass.getDeclaredConstructor(Moshi.class, Type[].class);
-        constructor.setAccessible(true);
-        return constructor.newInstance(moshi, ((ParameterizedType) type).getActualTypeArguments());
-      } else {
-        Constructor<? extends JsonAdapter<?>> constructor
-            = adapterClass.getDeclaredConstructor(Moshi.class);
-        constructor.setAccessible(true);
-        return constructor.newInstance(moshi);
-      }
-    } catch (ClassNotFoundException e) {
-      throw new RuntimeException(
-          "Failed to find the generated JsonAdapter class for " + rawType, e);
-    } catch (NoSuchMethodException e) {
-      throw new RuntimeException(
-          "Failed to find the generated JsonAdapter constructor for " + rawType, e);
-    } catch (IllegalAccessException e) {
-      throw new RuntimeException(
-          "Failed to access the generated JsonAdapter for " + rawType, e);
-    } catch (InstantiationException e) {
-      throw new RuntimeException(
-          "Failed to instantiate the generated JsonAdapter for " + rawType, e);
-    } catch (InvocationTargetException e) {
-      throw Util.rethrowCause(e);
-    }
-  }
 
   static final class EnumJsonAdapter<T extends Enum<T>> extends JsonAdapter<T> {
     private final Class<T> enumType;


### PR DESCRIPTION
This is handy for development builds where kapt is disabled and models still have @JsonClass(generatedAdapter = true).

Closes #715 