### PR TITLE
Demo automatic sealed class <-> polymorphic adapter support in moshi-kotlin 

### DIFF
--- a/adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.java
+++ b/adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.java
@@ -243,12 +243,8 @@ public final class PolymorphicJsonAdapterFactory<T> implements JsonAdapter.Facto
     @Override public Object fromJson(JsonReader reader) throws IOException {
       int labelIndex = labelIndex(reader.peekJson());
       if (labelIndex == -1) {
-        if (defaultValueSet) {
-          reader.skipValue();
-          return defaultValue;
-        } else {
-          throw new JsonDataException("Missing label for " + labelKey);
-        }
+        reader.skipValue();
+        return defaultValue;
       }
       return jsonAdapters.get(labelIndex).fromJson(reader);
     }
@@ -276,7 +272,7 @@ public final class PolymorphicJsonAdapterFactory<T> implements JsonAdapter.Facto
         return labelIndex;
       }
 
-      return -1;
+      throw new JsonDataException("Missing label for " + labelKey);
     }
 
     @Override public void toJson(JsonWriter writer, Object value) throws IOException {

--- a/adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicType.java
+++ b/adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicType.java
@@ -1,0 +1,31 @@
+package com.squareup.moshi.adapters;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Indicates that a given type is a Polymorphic type. This annotation should be applied on to the
+ * base type. Moshi's Kotlin support (reflective or code gen) can read this annotation and
+ * automatically infer/manage these polymorphic types without any custom wiring.
+ */
+@Target(TYPE)
+@Retention(RUNTIME)
+@Documented
+public @interface PolymorphicType {
+  /**
+   * The key in the JSON object whose value determines the type to which to map the * JSON object.
+   */
+  String typeLabel();
+
+  /**
+   * If you want to have a fallback type for when decoding encounters an unknown label, you can
+   * specify it here. Note that the expectation of the Kotlin support for this is that the default
+   * type is a Kotlin {@code object} class. If you require a dynamically instantiated class, you
+   * must manually wire this up via {@link PolymorphicJsonAdapterFactory}.
+   */
+  Class<?> fallbackType() default void.class;
+}

--- a/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
@@ -78,6 +78,33 @@ public final class PolymorphicJsonAdapterFactoryTest {
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.BEGIN_OBJECT);
   }
 
+  @Test public void specifiedFallbackSubtype() throws IOException {
+    Error fallbackError = new Error(Collections.<String, Object>emptyMap());
+    Moshi moshi = new Moshi.Builder()
+        .add(PolymorphicJsonAdapterFactory.of(Message.class, "type")
+            .withSubtype(Success.class, "success")
+            .withSubtype(Error.class, "error")
+            .withDefaultValue(fallbackError))
+        .build();
+    JsonAdapter<Message> adapter = moshi.adapter(Message.class);
+
+    Message message = adapter.fromJson("{\"type\":\"data\",\"value\":\"Okay!\"}");
+    assertThat(message).isSameAs(fallbackError);
+  }
+
+  @Test public void specifiedNullFallbackSubtype() throws IOException {
+    Moshi moshi = new Moshi.Builder()
+        .add(PolymorphicJsonAdapterFactory.of(Message.class, "type")
+            .withSubtype(Success.class, "success")
+            .withSubtype(Error.class, "error")
+            .withDefaultValue(null))
+        .build();
+    JsonAdapter<Message> adapter = moshi.adapter(Message.class);
+
+    Message message = adapter.fromJson("{\"type\":\"data\",\"value\":\"Okay!\"}");
+    assertThat(message).isNull();
+  }
+
   @Test public void unregisteredSubtype() {
     Moshi moshi = new Moshi.Builder()
         .add(PolymorphicJsonAdapterFactory.of(Message.class, "type")

--- a/kotlin/reflect/pom.xml
+++ b/kotlin/reflect/pom.xml
@@ -19,6 +19,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.squareup.moshi</groupId>
+      <artifactId>moshi-adapters</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/moshi/src/main/java/com/squareup/moshi/JsonClass.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonClass.java
@@ -38,4 +38,9 @@ public @interface JsonClass {
    *  * All properties must be either non-transient or have a default value.
    */
   boolean generateAdapter();
+
+  /**
+   * For polymorphic adapters, this can specify a specific name for the type key.
+   */
+  String typeName() default "";
 }

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.7</java.version>
-    <kotlin.version>1.2.71</kotlin.version>
+    <kotlin.version>1.3.0</kotlin.version>
     <kotlin-metadata.version>1.4.0</kotlin-metadata.version>
     <dokka.version>0.9.17</dokka.version>
     <maven-assembly.version>3.1.0</maven-assembly.version>


### PR DESCRIPTION
This demonstrates automatic support for `sealed class`es in moshi-kotlin reflection, saving manual wiring at the `Moshi` instance level. This is just a PoC right now, but code gen can definitely support this too.

Along the way I implemented basic default value support for demonstration purposes (fd48335), and we can pursue that in a separate PR if we want. Ref #739 (CC @ganfra).

API definitely up for discussion. Currently, it's implemented as such (using the same `Message` example from the PolymorphicTypeAdapter tests):

```kotlin
@PolymorphicType(typeLabel = "type", fallbackType = Message.Unknown::class)
sealed class Message {

  @JsonClass(generateAdapter = true, typeName = "success")
  data class Success(val value: String) : Message()

  @JsonClass(generateAdapter = true, typeName = "error")
  data class Error(val error_logs: Map<String, Any>) : Message()

  object Unknown : Message()
}
```

Limitations:
* Only sealed classes. Cannot annotate an interface, abstract class, open class, etc. This is because we need to be able to read the full sealed class subclasses.
* Default fallbacks must be `object` classes.