### PR TITLE
Allow Object base type for PolymorphicJsonAdapterFactory.

### DIFF
--- a/adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.java
+++ b/adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.java
@@ -86,8 +86,7 @@ import javax.annotation.CheckReturnValue;
  * <p>This class imposes strict requirements on its use:
  *
  * <ul>
- *   <li>Base types may be classes or interfaces. You may not use {@code Object.class} as a base
- *       type.
+ *   <li>Base types may be classes or interfaces.
  *   <li>Subtypes must encode as JSON objects.
  *   <li>Type information must be in the encoded object. Each message must have a type label like
  *       {@code hand_type} whose value is a string like {@code blackjack} that identifies which type
@@ -125,10 +124,6 @@ public final class PolymorphicJsonAdapterFactory<T> implements JsonAdapter.Facto
   public static <T> PolymorphicJsonAdapterFactory<T> of(Class<T> baseType, String labelKey) {
     if (baseType == null) throw new NullPointerException("baseType == null");
     if (labelKey == null) throw new NullPointerException("labelKey == null");
-    if (baseType == Object.class) {
-      throw new IllegalArgumentException(
-          "The base type must not be Object. Consider using a marker interface.");
-    }
     return new PolymorphicJsonAdapterFactory<>(
         baseType, labelKey, Collections.<String>emptyList(), Collections.<Type>emptyList());
   }
@@ -162,9 +157,7 @@ public final class PolymorphicJsonAdapterFactory<T> implements JsonAdapter.Facto
       jsonAdapters.add(moshi.adapter(subtypes.get(i)));
     }
 
-    JsonAdapter<Object> objectJsonAdapter = moshi.adapter(Object.class);
-    return new PolymorphicJsonAdapter(
-        labelKey, labels, subtypes, jsonAdapters, objectJsonAdapter).nullSafe();
+    return new PolymorphicJsonAdapter(labelKey, labels, subtypes, jsonAdapters).nullSafe();
   }
 
   static final class PolymorphicJsonAdapter extends JsonAdapter<Object> {
@@ -172,7 +165,6 @@ public final class PolymorphicJsonAdapterFactory<T> implements JsonAdapter.Facto
     final List<String> labels;
     final List<Type> subtypes;
     final List<JsonAdapter<Object>> jsonAdapters;
-    final JsonAdapter<Object> objectJsonAdapter;
 
     /** Single-element options containing the label's key only. */
     final JsonReader.Options labelKeyOptions;
@@ -180,13 +172,11 @@ public final class PolymorphicJsonAdapterFactory<T> implements JsonAdapter.Facto
     final JsonReader.Options labelOptions;
 
     PolymorphicJsonAdapter(String labelKey, List<String> labels,
-        List<Type> subtypes, List<JsonAdapter<Object>> jsonAdapters,
-        JsonAdapter<Object> objectJsonAdapter) {
+        List<Type> subtypes, List<JsonAdapter<Object>> jsonAdapters) {
       this.labelKey = labelKey;
       this.labels = labels;
       this.subtypes = subtypes;
       this.jsonAdapters = jsonAdapters;
-      this.objectJsonAdapter = objectJsonAdapter;
 
       this.labelKeyOptions = JsonReader.Options.of(labelKey);
       this.labelOptions = JsonReader.Options.of(labels.toArray(new String[0]));

--- a/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
@@ -170,14 +170,17 @@ public final class PolymorphicJsonAdapterFactoryTest {
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
   }
 
-  @Test public void disallowObjectBaseType() {
-    try {
-      PolymorphicJsonAdapterFactory.of(Object.class, "type");
-      fail();
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage(
-          "The base type must not be Object. Consider using a marker interface.");
-    }
+  @Test public void objectBaseType() throws IOException {
+    Moshi moshi = new Moshi.Builder()
+        .add(PolymorphicJsonAdapterFactory.of(Object.class, "type")
+            .withSubtype(Success.class, "success"))
+        .build();
+    JsonAdapter<Object> adapter = moshi.adapter(Object.class);
+
+    assertThat(adapter.fromJson("{\"type\":\"success\",\"value\":\"Okay!\"}"))
+        .isEqualTo(new Success("Okay!"));
+    assertThat(adapter.toJson(new Success("Okay!")))
+        .isEqualTo("{\"type\":\"success\",\"value\":\"Okay!\"}");
   }
 
   /**

--- a/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
@@ -170,19 +170,6 @@ public final class PolymorphicJsonAdapterFactoryTest {
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
   }
 
-  @Test public void objectBaseType() throws IOException {
-    Moshi moshi = new Moshi.Builder()
-        .add(PolymorphicJsonAdapterFactory.of(Object.class, "type")
-            .withSubtype(Success.class, "success"))
-        .build();
-    JsonAdapter<Object> adapter = moshi.adapter(Object.class);
-
-    assertThat(adapter.fromJson("{\"type\":\"success\",\"value\":\"Okay!\"}"))
-        .isEqualTo(new Success("Okay!"));
-    assertThat(adapter.toJson(new Success("Okay!")))
-        .isEqualTo("{\"type\":\"success\",\"value\":\"Okay!\"}");
-  }
-
   /**
    * Longs that do not have an exact double representation are problematic for JSON. It is a bad
    * idea to use JSON for these values! But Moshi tries to retain long precision where possible.


### PR DESCRIPTION
This works now.
Using general types like Object, Map, or List for the base type is error-prone, but the checks for these cases are not worth the code cost.