### PR TITLE
Refuse kotlin classes in ClassJsonAdapter

### DIFF
--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -957,7 +957,7 @@ class KotlinJsonAdapterTest {
     val moshi = Moshi.Builder().build()
     try {
       moshi.adapter<PlainKotlinClass>(PlainKotlinClass::class.java)
-      throw AssertionError("Should not pass here")
+      fail("Should not pass here")
     } catch (e: IllegalArgumentException) {
       assertThat(e).hasMessageContaining("Reflective serialization of Kotlin classes")
     }

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -952,4 +952,16 @@ class KotlinJsonAdapterTest {
     assertThat(adapter.fromJson("null")).isNull()
     assertThat(adapter.toJson(null)).isEqualTo("null")
   }
+
+  @Test fun kotlinClassesWithoutAdapterAreRefused() {
+    val moshi = Moshi.Builder().build()
+    try {
+      moshi.adapter<PlainKotlinClass>(PlainKotlinClass::class.java)
+      throw AssertionError("Should not pass here")
+    } catch (e: IllegalArgumentException) {
+      assertThat(e).hasMessageContaining("Reflective serialization of Kotlin classes")
+    }
+  }
+
+  class PlainKotlinClass
 }

--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -75,6 +75,14 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
       if (Modifier.isAbstract(rawType.getModifiers())) {
         throw new IllegalArgumentException("Cannot serialize abstract class " + rawType.getName());
       }
+      for (Annotation annotation : rawType.getDeclaredAnnotations()) {
+        if ("kotlin.Metadata".equals(annotation.annotationType().getName())) {
+          throw new IllegalArgumentException("Cannot serialize Kotlin type " + rawType.getName()
+              + ". Reflective serialization of Kotlin classes without using kotlin-reflect can "
+              + "have undefined and unexpected behavior. Please use KotlinJsonAdapter from the "
+              + "moshi-kotlin artifact or use code gen from the moshi-kotlin-codegen artifact.");
+        }
+      }
 
       ClassFactory<Object> classFactory = ClassFactory.get(rawType);
       Map<String, FieldBinding<?>> fields = new TreeMap<>();

--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -78,8 +78,8 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
       for (Annotation annotation : rawType.getDeclaredAnnotations()) {
         if ("kotlin.Metadata".equals(annotation.annotationType().getName())) {
           throw new IllegalArgumentException("Cannot serialize Kotlin type " + rawType.getName()
-              + ". Reflective serialization of Kotlin classes without using kotlin-reflect can "
-              + "have undefined and unexpected behavior. Please use KotlinJsonAdapter from the "
+              + ". Reflective serialization of Kotlin classes without using kotlin-reflect has "
+              + "undefined and unexpected behavior. Please use KotlinJsonAdapter from the "
               + "moshi-kotlin artifact or use code gen from the moshi-kotlin-codegen artifact.");
         }
       }


### PR DESCRIPTION
Resolves #748

There are two existing tests that fail with this now, let me know what you all want to do with them (migrate/adjust/delete/etc)

`KotlinJsonAdapterTest#delegatesToInstalledAdaptersBeforeNullChecking`

`KotlinJsonAdapterTest#nullablePrimitivesUseBoxedPrimitiveAdapters`