### PR TITLE
Improve error message for platform types.

### DIFF
--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -481,8 +481,8 @@ class KotlinJsonAdapterTest {
       moshi.adapter(Triple::class.java)
       fail()
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessage("Platform class kotlin.Triple (with no annotations) "
-          + "requires explicit JsonAdapter to be registered")
+      assertThat(e).hasMessage(
+          "Platform class kotlin.Triple requires explicit JsonAdapter to be registered")
     }
   }
 

--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -29,7 +29,6 @@ import java.util.TreeMap;
 import javax.annotation.Nullable;
 
 import static com.squareup.moshi.internal.Util.resolve;
-import static com.squareup.moshi.internal.Util.typeAnnotatedWithAnnotations;
 
 /**
  * Emits a regular class as a JSON object by mapping Java fields to JSON object properties.
@@ -55,12 +54,11 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
       }
       Class<?> rawType = Types.getRawType(type);
       if (rawType.isInterface() || rawType.isEnum()) return null;
-      if (Util.isPlatformType(rawType) && !Types.isAllowedPlatformType(rawType)) {
-        throw new IllegalArgumentException("Platform "
-            + typeAnnotatedWithAnnotations(type, annotations)
-            + " requires explicit JsonAdapter to be registered");
-      }
       if (!annotations.isEmpty()) return null;
+      if (Util.isPlatformType(rawType)) {
+        throw new IllegalArgumentException(
+            "Platform " + type + " requires explicit JsonAdapter to be registered");
+      }
 
       if (rawType.isAnonymousClass()) {
         throw new IllegalArgumentException("Cannot serialize anonymous class " + rawType.getName());

--- a/moshi/src/main/java/com/squareup/moshi/Types.java
+++ b/moshi/src/main/java/com/squareup/moshi/Types.java
@@ -326,20 +326,4 @@ public final class Types {
       return null;
     }
   }
-
-  /**
-   * Returns true if this is a Type supported by {@link StandardJsonAdapters#FACTORY}.
-   */
-  static boolean isAllowedPlatformType(Type type) {
-    return type == Boolean.class
-        || type == Byte.class
-        || type == Character.class
-        || type == Double.class
-        || type == Float.class
-        || type == Integer.class
-        || type == Long.class
-        || type == Short.class
-        || type == String.class
-        || type == Object.class;
-  }
 }

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -937,22 +937,22 @@ public final class MoshiTest {
       moshi.adapter(File.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Platform class java.io.File (with no annotations) "
-          + "requires explicit JsonAdapter to be registered");
+      assertThat(e).hasMessage(
+          "Platform class java.io.File requires explicit JsonAdapter to be registered");
     }
     try {
       moshi.adapter(KeyGenerator.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Platform class javax.crypto.KeyGenerator (with no annotations) "
-          + "requires explicit JsonAdapter to be registered");
+      assertThat(e).hasMessage("Platform class javax.crypto.KeyGenerator requires explicit "
+          + "JsonAdapter to be registered");
     }
     try {
       moshi.adapter(Pair.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Platform class android.util.Pair (with no annotations) "
-          + "requires explicit JsonAdapter to be registered");
+      assertThat(e).hasMessage(
+          "Platform class android.util.Pair requires explicit JsonAdapter to be registered");
     }
   }
 
@@ -975,7 +975,7 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage(
-          "Platform java.util.ArrayList<java.lang.String> (with no annotations) requires explicit "
+          "Platform java.util.ArrayList<java.lang.String> requires explicit "
               + "JsonAdapter to be registered"
               + "\nfor java.util.ArrayList<java.lang.String> strings"
               + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType"
@@ -983,7 +983,7 @@ public final class MoshiTest {
               + "com.squareup.moshi.MoshiTest$HasPlatformType>");
       assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause()).hasMessage("Platform java.util.ArrayList<java.lang.String> "
-          + "(with no annotations) requires explicit JsonAdapter to be registered");
+          + "requires explicit JsonAdapter to be registered");
     }
   }
 
@@ -994,14 +994,14 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage(
-          "Platform java.util.ArrayList<java.lang.String> (with no annotations) requires explicit "
+          "Platform java.util.ArrayList<java.lang.String> requires explicit "
               + "JsonAdapter to be registered"
               + "\nfor java.util.ArrayList<java.lang.String> strings"
               + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType hasPlatformType"
               + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType$Wrapper");
       assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause()).hasMessage("Platform java.util.ArrayList<java.lang.String> "
-          + "(with no annotations) requires explicit JsonAdapter to be registered");
+          + "requires explicit JsonAdapter to be registered");
     }
   }
 
@@ -1012,7 +1012,7 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage(
-          "Platform java.util.ArrayList<java.lang.String> (with no annotations) requires explicit "
+          "Platform java.util.ArrayList<java.lang.String> requires explicit "
               + "JsonAdapter to be registered"
               + "\nfor java.util.ArrayList<java.lang.String> strings"
               + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType"
@@ -1020,7 +1020,7 @@ public final class MoshiTest {
               + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType$ListWrapper");
       assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause()).hasMessage("Platform java.util.ArrayList<java.lang.String> "
-          + "(with no annotations) requires explicit JsonAdapter to be registered");
+          + "requires explicit JsonAdapter to be registered");
     }
   }
 


### PR DESCRIPTION
The error message about platform types will never contain qualifiers.
Also, simplify platform type check.