### PR TITLE
Add reified adapter extension for Kotlin

### DIFF
--- a/moshi/pom.xml
+++ b/moshi/pom.xml
@@ -32,10 +32,35 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/moshi/src/main/java/com/squareup/moshi/KotlinExtensions.kt
+++ b/moshi/src/main/java/com/squareup/moshi/KotlinExtensions.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Hide the class from Java consumers.
+@file:JvmName("-KotlinExtensions")
+
+package com.squareup.moshi
+
+inline fun <reified T> Moshi.adapter(): JsonAdapter<T> = adapter(T::class.java)

--- a/moshi/src/main/resources/META-INF/proguard/moshi.pro
+++ b/moshi/src/main/resources/META-INF/proguard/moshi.pro
@@ -47,3 +47,6 @@
     <init>(...);
     <fields>;
 }
+
+# Top-level functions that can only be used by Kotlin.
+-dontwarn com.squareup.moshi.-KotlinExtensions

--- a/moshi/src/test/java/com/squareup/moshi/KotlinExtensionsTest.kt
+++ b/moshi/src/test/java/com/squareup/moshi/KotlinExtensionsTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2018 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.moshi
+
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.Test
+
+class KotlinExtensionsTest {
+
+  @Test fun reifiedAdapter() {
+    val moshi = Moshi.Builder().build()
+
+    assertThatCode { moshi.adapter<TestUtil.Empty>() }.doesNotThrowAnyException()
+  }
+}

--- a/moshi/src/test/java/com/squareup/moshi/TestUtil.java
+++ b/moshi/src/test/java/com/squareup/moshi/TestUtil.java
@@ -40,6 +40,9 @@ final class TestUtil {
     return result.toString();
   }
 
+  static class Empty {
+  }
+
   private TestUtil() {
     throw new AssertionError("No instances.");
   }


### PR DESCRIPTION
I thought it would be nice to have this extension similar to how it's done in [retrofit](https://github.com/square/retrofit/blob/master/retrofit/src/main/java/retrofit2/KotlinExtensions.kt)

```Kotlin
val adapter = moshi.adapter<BlackjackHand>()
```