### PR TITLE
Some miscellaneous kotlinpoet updates

### DIFF
--- a/kotlin/codegen/pom.xml
+++ b/kotlin/codegen/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.squareup</groupId>
       <artifactId>kotlinpoet</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto</groupId>

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TypeResolver.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TypeResolver.kt
@@ -35,18 +35,18 @@ open class TypeResolver {
 
       is ParameterizedTypeName -> {
             typeName.rawType.parameterizedBy(*(typeName.typeArguments.map { resolve(it) }.toTypedArray()))
-            .asNullableIf(typeName.isNullable)
+            .copy(nullable = typeName.isNullable)
       }
 
       is WildcardTypeName -> {
         when {
           typeName.inTypes.size == 1 -> {
             WildcardTypeName.consumerOf(resolve(typeName.inTypes[0]))
-                .asNullableIf(typeName.isNullable)
+                .copy(nullable = typeName.isNullable)
           }
           typeName.outTypes.size == 1 -> {
             WildcardTypeName.producerOf(resolve(typeName.outTypes[0]))
-                .asNullableIf(typeName.isNullable)
+                .copy(nullable = typeName.isNullable)
           }
           else -> {
             throw IllegalArgumentException(

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/kotlintypes.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/kotlintypes.kt
@@ -26,7 +26,3 @@ internal fun TypeName.rawType(): ClassName {
     else -> throw IllegalArgumentException("Cannot get raw type from $this")
   }
 }
-
-internal fun TypeName.asNullableIf(condition: Boolean): TypeName {
-  return if (condition) copy(nullable = true) else this
-}

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
@@ -77,17 +77,17 @@ internal fun Type.asTypeName(
   if (hasFlexibleUpperBound()) {
     return WildcardTypeName.producerOf(
         flexibleUpperBound.asTypeName(nameResolver, getTypeParameter, useAbbreviatedType))
-        .asNullableIf(nullable)
+        .copy(nullable = nullable)
   } else if (hasOuterType()) {
     return WildcardTypeName.consumerOf(
         outerType.asTypeName(nameResolver, getTypeParameter, useAbbreviatedType))
-        .asNullableIf(nullable)
+        .copy(nullable = nullable)
   }
 
   val realType = when {
     hasTypeParameter() -> return getTypeParameter(typeParameter)
         .asTypeName(nameResolver, getTypeParameter, useAbbreviatedType)
-        .asNullableIf(nullable)
+        .copy(nullable = nullable)
     hasTypeParameterName() -> typeParameterName
     useAbbreviatedType && hasAbbreviatedType() -> abbreviatedType.typeAliasName
     else -> className
@@ -121,5 +121,5 @@ internal fun Type.asTypeName(
     typeName = (typeName as ClassName).parameterizedBy(*remappedArgs)
   }
 
-  return typeName.asNullableIf(nullable)
+  return typeName.copy(nullable = nullable)
 }

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codgen/LooksLikeAClass/ClassInPackageThatLooksLikeAClass.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codgen/LooksLikeAClass/ClassInPackageThatLooksLikeAClass.kt
@@ -1,0 +1,9 @@
+package com.squareup.moshi.kotlin.codgen.LooksLikeAClass
+
+import com.squareup.moshi.JsonClass
+
+/**
+ * https://github.com/square/moshi/issues/783
+ */
+@JsonClass(generateAdapter = true)
+data class ClassInPackageThatLooksLikeAClass(val foo: String)


### PR DESCRIPTION
- Update KotlinPoet to 1.0.1
- Drop `asNullableIf` in favor of the plain `copy()` functions
- Add a test for #783