### PR TITLE
Correct error for duplicate JSON key for Kotlin.

### DIFF
--- a/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
+++ b/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
@@ -17,7 +17,6 @@ package com.squareup.moshi.kotlin.reflect
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.JsonClass
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
@@ -77,7 +76,7 @@ internal class KotlinJsonAdapter<T>(
 
       if (values[index] !== ABSENT_VALUE) {
         throw JsonDataException(
-            "Multiple values for '${constructor.parameters[index].name}' at ${reader.path}")
+            "Multiple values for '${binding.property.name}' at ${reader.path}")
       }
 
       values[index] = binding.adapter.fromJson(reader)

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codgen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codgen/GeneratedAdaptersTest.kt
@@ -808,20 +808,37 @@ class GeneratedAdaptersTest {
   }
 
   /** Generated adapters don't track enough state to detect duplicated values. */
-  @Ignore @Test fun duplicatedValue() {
+  @Ignore @Test fun duplicatedValueParameter() {
     val moshi = Moshi.Builder().build()
-    val jsonAdapter = moshi.adapter(DuplicateValue::class.java)
+    val jsonAdapter = moshi.adapter(DuplicateValueParameter::class.java)
 
     try {
       jsonAdapter.fromJson("""{"a":4,"a":4}""")
       fail()
     } catch(expected: JsonDataException) {
-      assertThat(expected).hasMessage("Multiple values for a at $.a")
+      assertThat(expected).hasMessage("Multiple values for 'a' at $.a")
     }
   }
 
-  @JsonClass(generateAdapter = true)
-  class DuplicateValue(var a: Int = -1, var b: Int = -2)
+  class DuplicateValueParameter(var a: Int = -1, var b: Int = -2)
+
+  /** Generated adapters don't track enough state to detect duplicated values. */
+  @Ignore @Test fun duplicatedValueProperty() {
+    val moshi = Moshi.Builder().build()
+    val jsonAdapter = moshi.adapter(DuplicateValueProperty::class.java)
+
+    try {
+      jsonAdapter.fromJson("""{"a":4,"a":4}""")
+      fail()
+    } catch(expected: JsonDataException) {
+      assertThat(expected).hasMessage("Multiple values for 'a' at $.a")
+    }
+  }
+
+  class DuplicateValueProperty {
+    var a: Int = -1
+    var b: Int = -2
+  }
 
   @Test fun extensionProperty() {
     val moshi = Moshi.Builder().build()

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -205,9 +205,9 @@ class KotlinJsonAdapterTest {
     var a: String = ""
   }
 
-  @Test fun duplicatedValue() {
+  @Test fun duplicatedValueParameter() {
     val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
-    val jsonAdapter = moshi.adapter(DuplicateValue::class.java)
+    val jsonAdapter = moshi.adapter(DuplicateValueParameter::class.java)
 
     try {
       jsonAdapter.fromJson("""{"a":4,"a":4}""")
@@ -217,7 +217,24 @@ class KotlinJsonAdapterTest {
     }
   }
 
-  class DuplicateValue(var a: Int = -1, var b: Int = -2)
+  class DuplicateValueParameter(var a: Int = -1, var b: Int = -2)
+
+  @Test fun duplicatedValueProperty() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    val jsonAdapter = moshi.adapter(DuplicateValueProperty::class.java)
+
+    try {
+      jsonAdapter.fromJson("""{"a":4,"a":4}""")
+      fail()
+    } catch(expected: JsonDataException) {
+      assertThat(expected).hasMessage("Multiple values for 'a' at $.a")
+    }
+  }
+
+  class DuplicateValueProperty {
+    var a: Int = -1
+    var b: Int = -2
+  }
 
   @Test fun explicitNull() {
     val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()


### PR DESCRIPTION
Before, the KotlinJsonAdapter threw "java.lang.IndexOutOfBoundsException: Index: 0, Size: 0" on a duplicate key when the key matched a property that was not a constructor parameter.