### PR TITLE
Retain annotated Enum field names with proguard

### DIFF
--- a/moshi/src/main/resources/META-INF/proguard/moshi.pro
+++ b/moshi/src/main/resources/META-INF/proguard/moshi.pro
@@ -7,6 +7,11 @@
 
 -keep @com.squareup.moshi.JsonQualifier interface *
 
+# Retain annotated Enum field names.
+-keepclassmembers class * extends java.lang.Enum {
+    @com.squareup.moshi.* <fields>;
+}
+
 # Enum field names are used by the integrated EnumJsonAdapter.
 # Annotate enums with @JsonClass(generateAdapter = false) to use them with Moshi.
 -keepclassmembers @com.squareup.moshi.JsonClass class * extends java.lang.Enum {


### PR DESCRIPTION
#691 fixed a related issue but only when using the `@JsonClass` annotation on the Enum itself.
Unfortunately `JsonClass` has some restrictions (and can't be used in java):
https://github.com/square/moshi/blob/ded3bccc6089c8a39ca1ebf7227fcee122572512/moshi/src/main/java/com/squareup/moshi/JsonClass.java#L34-L38