### PR TITLE
Fix codegen generating wrong name in exception message (#800)

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
@@ -188,7 +188,7 @@ internal class AdapterGenerator(
           result.addStatement("%N = %N.fromJson(%N) ?: throw·%T(%P)",
               property.localName, nameAllocator[property.delegateKey], readerParam,
               JsonDataException::class,
-              "Non-null value '${property.localName}' was null at \${${readerParam.name}.path}")
+              "Non-null value '${property.jsonName}' was null at \${${readerParam.name}.path}")
         }
         result.addStatement("%N = true", property.localIsPresentName)
         result.endControlFlow()


### PR DESCRIPTION
Fixes https://github.com/square/moshi/issues/800