### PR TITLE
Unconditionally close the peeked JsonReader.

### DIFF
--- a/adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.java
+++ b/adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.java
@@ -235,7 +235,12 @@ public final class PolymorphicJsonAdapterFactory<T> implements JsonAdapter.Facto
     @Override public Object fromJson(JsonReader reader) throws IOException {
       JsonReader peeked = reader.peekJson();
       peeked.setFailOnUnknown(false);
-      int labelIndex = labelIndex(peeked);
+      int labelIndex;
+      try {
+        labelIndex = labelIndex(peeked);
+      } finally {
+        peeked.close();
+      }
       if (labelIndex == -1) {
         reader.skipValue();
         return defaultValue;
@@ -262,7 +267,6 @@ public final class PolymorphicJsonAdapterFactory<T> implements JsonAdapter.Facto
               + reader.nextString()
               + "'. Register a subtype for this label.");
         }
-        reader.close();
         return labelIndex;
       }
 


### PR DESCRIPTION
It doesn't have an effect now, but this is for the future when closing the peeked source also clears buffers.