### PR TITLE
Pass raw type rather than possibly-generic type in platform type error

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -57,7 +57,7 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
       if (!annotations.isEmpty()) return null;
       if (Util.isPlatformType(rawType)) {
         throw new IllegalArgumentException(
-            "Platform " + type + " requires explicit JsonAdapter to be registered");
+            "Platform " + rawType + " requires explicit JsonAdapter to be registered");
       }
 
       if (rawType.isAnonymousClass()) {

--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -56,8 +56,12 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
       if (rawType.isInterface() || rawType.isEnum()) return null;
       if (!annotations.isEmpty()) return null;
       if (Util.isPlatformType(rawType)) {
+        String messagePrefix = "Platform " + rawType;
+        if (type instanceof ParameterizedType) {
+          messagePrefix += " in " + type;
+        }
         throw new IllegalArgumentException(
-            "Platform " + rawType + " requires explicit JsonAdapter to be registered");
+            messagePrefix + " requires explicit JsonAdapter to be registered");
       }
 
       if (rawType.isAnonymousClass()) {

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -973,14 +973,14 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage(
-          "Platform java.util.ArrayList<java.lang.String> requires explicit "
+          "Platform class java.util.ArrayList in java.util.ArrayList<java.lang.String> requires explicit "
               + "JsonAdapter to be registered"
               + "\nfor java.util.ArrayList<java.lang.String> strings"
               + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType"
               + "\nfor java.util.Map<java.lang.String, "
               + "com.squareup.moshi.MoshiTest$HasPlatformType>");
       assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
-      assertThat(e.getCause()).hasMessage("Platform java.util.ArrayList<java.lang.String> "
+      assertThat(e.getCause()).hasMessage("Platform class java.util.ArrayList in java.util.ArrayList<java.lang.String> "
           + "requires explicit JsonAdapter to be registered");
     }
   }
@@ -992,13 +992,13 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage(
-          "Platform java.util.ArrayList<java.lang.String> requires explicit "
+          "Platform class java.util.ArrayList in java.util.ArrayList<java.lang.String> requires explicit "
               + "JsonAdapter to be registered"
               + "\nfor java.util.ArrayList<java.lang.String> strings"
               + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType hasPlatformType"
               + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType$Wrapper");
       assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
-      assertThat(e.getCause()).hasMessage("Platform java.util.ArrayList<java.lang.String> "
+      assertThat(e.getCause()).hasMessage("Platform class java.util.ArrayList in java.util.ArrayList<java.lang.String> "
           + "requires explicit JsonAdapter to be registered");
     }
   }
@@ -1010,14 +1010,14 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage(
-          "Platform java.util.ArrayList<java.lang.String> requires explicit "
+          "Platform class java.util.ArrayList in java.util.ArrayList<java.lang.String> requires explicit "
               + "JsonAdapter to be registered"
               + "\nfor java.util.ArrayList<java.lang.String> strings"
               + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType"
               + "\nfor java.util.List<com.squareup.moshi.MoshiTest$HasPlatformType> platformTypes"
               + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType$ListWrapper");
       assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
-      assertThat(e.getCause()).hasMessage("Platform java.util.ArrayList<java.lang.String> "
+      assertThat(e.getCause()).hasMessage("Platform class java.util.ArrayList in java.util.ArrayList<java.lang.String> "
           + "requires explicit JsonAdapter to be registered");
     }
   }


### PR DESCRIPTION
We only check the raw type here, so the message should match

Example case - in #875 a `Triple<*, *, *>` would yield an error message that `kotlin.Triple<java.lang.Object, java.lang.Object, java.lang.Object>` required an adapter, which doesn't tell you immediately which type it was confused on