### PR TITLE
Support dynamic defaults constructor invocation in kotlin code gen without kotlin-reflect

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
@@ -271,7 +271,7 @@ internal class AdapterGenerator(
         }
       }.joinToCode(", ")
       result.addStatement(
-          "val %1L = this.%2L ?: %3T.lookupDefaultsConstructor(%4T::class.java).also { this.%2L = it  }",
+          "val·%1L·= this.%2N ?: %3T.lookupDefaultsConstructor(%4T::class.java).also·{·this.%2N·=·it·}",
           localConstructorName,
           constructorProperty,
           MOSHI_UTIL,

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
@@ -271,7 +271,7 @@ internal class AdapterGenerator(
         }
       }.joinToCode(", ")
       result.addStatement(
-          "val·%1L·= this.%2N ?: %3T.lookupDefaultsConstructor(%4T::class.java).also·{·this.%2N·=·it·}",
+          "val %1L·= this.%2N ?: %3T.lookupDefaultsConstructor(%4T::class.java).also·{ this.%2N = it }",
           localConstructorName,
           constructorProperty,
           MOSHI_UTIL,

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
@@ -93,7 +93,8 @@ internal class AdapterGenerator(
 
   private val constructorProperty = PropertySpec.builder(
       nameAllocator.newName("constructorRef"),
-      Constructor::class.asClassName().parameterizedBy(originalTypeName).copy(nullable = true))
+      Constructor::class.asClassName().parameterizedBy(originalTypeName).copy(nullable = true),
+      KModifier.PRIVATE)
       .addAnnotation(Volatile::class)
       .mutable(true)
       .initializer("null")

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
@@ -247,7 +247,7 @@ internal class AdapterGenerator(
     } else {
       CodeBlock.of("return·")
     }
-    val maskName = nameAllocator.newName("make")
+    val maskName = nameAllocator.newName("mask")
     val argsName = nameAllocator.newName("ars")
     if (useDefaultsConstructor) {
       // Dynamic default constructor call

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
@@ -272,7 +272,7 @@ internal class AdapterGenerator(
         }
       }.joinToCode(", ")
       result.addStatement(
-          "val %1L·= this.%2N ?: %3T.lookupDefaultsConstructor(%4T::class.java).also·{ this.%2N = it }",
+          "val %1L·= this.%2N ?: %3T.lookupDefaultsConstructor(%4T::class.java).also·{ this.%2N·= it }",
           localConstructorName,
           constructorProperty,
           MOSHI_UTIL,

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AdapterGenerator.kt
@@ -239,6 +239,8 @@ internal class AdapterGenerator(
         }
         .toList()
 
+    val argPresentValuesName = nameAllocator.newName("argPresentValues")
+    val argsName = nameAllocator.newName("ars")
     if (useDefaultsConstructor) {
       // Dynamic default constructor call
       val booleanArrayBlock = parameterProperties.map { param ->
@@ -248,8 +250,8 @@ internal class AdapterGenerator(
           else -> CodeBlock.of("true")
         }
       }.joinToCode(", ")
-      result.addStatement("val argPresentValues = booleanArrayOf(%L)", booleanArrayBlock)
-      result.addCode("«val args: %T = arrayOf(", ARRAY.parameterizedBy(ANY.copy(nullable = true)))
+      result.addStatement("val %L = booleanArrayOf(%L)", argPresentValuesName, booleanArrayBlock)
+      result.addCode("«val %L: %T = arrayOf(", argsName, ARRAY.parameterizedBy(ANY.copy(nullable = true)))
     } else {
       // Standard constructor call
       result.addCode("«val %N = %T(", resultName, originalTypeName)
@@ -279,10 +281,12 @@ internal class AdapterGenerator(
     result.addCode(")»\n")
     if (useDefaultsConstructor) {
       result.addStatement(
-          "val %N = %T.invokeDefaultConstructor(%T::class.java, args, argPresentValues)",
+          "val %N = %T.invokeDefaultConstructor(%T::class.java, %L, %L)",
           resultName,
           Util::class.asClassName(),
-          originalTypeName
+          originalTypeName,
+          argsName,
+          argPresentValuesName
       )
     }
 

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/PropertyGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/PropertyGenerator.kt
@@ -22,7 +22,8 @@ import com.squareup.kotlinpoet.PropertySpec
 /** Generates functions to encode and decode a property as JSON. */
 internal class PropertyGenerator(
   val target: TargetProperty,
-  val delegateKey: DelegateKey
+  val delegateKey: DelegateKey,
+  val isTransient: Boolean = false
 ) {
   val name = target.name
   val jsonName = target.jsonName()

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/PropertyGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/PropertyGenerator.kt
@@ -39,6 +39,16 @@ internal class PropertyGenerator(
   /** We prefer to use 'null' to mean absent, but for some properties those are distinct. */
   val differentiateAbsentFromNull get() = delegateKey.nullable && hasDefault
 
+  /**
+   * IsPresent is required if the following conditions are met:
+   * - Is not transient
+   * - Has a default and one of the below
+   *   - Is a constructor property
+   *   - Is a nullable non-constructor property
+   */
+  val hasLocalIsPresentName = !isTransient && hasDefault &&
+      (hasConstructorParameter || delegateKey.nullable)
+
   fun allocateNames(nameAllocator: NameAllocator) {
     localName = nameAllocator.newName(name)
     localIsPresentName = nameAllocator.newName("${name}Set")
@@ -47,7 +57,13 @@ internal class PropertyGenerator(
   fun generateLocalProperty(): PropertySpec {
     return PropertySpec.builder(localName, target.type.copy(nullable = true))
         .mutable(true)
-        .initializer("null")
+        .apply {
+          if (hasLocalIsPresentName) {
+            initializer(target.type.defaultPrimitiveValue())
+          } else {
+            initializer("null")
+          }
+        }
         .build()
   }
 

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TargetProperty.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/TargetProperty.kt
@@ -80,7 +80,7 @@ internal data class TargetProperty(
             Diagnostic.Kind.ERROR, "No default value for transient property ${this}", element)
         return null
       }
-      return null // This property is transient and has a default value. Ignore it.
+      return PropertyGenerator(this, DelegateKey(type, emptyList()), true)
     }
 
     if (!isVisible) {

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/kotlintypes.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/kotlintypes.kt
@@ -15,9 +15,20 @@
  */
 package com.squareup.moshi.kotlin.codegen
 
+import com.squareup.kotlinpoet.BOOLEAN
+import com.squareup.kotlinpoet.BYTE
+import com.squareup.kotlinpoet.CHAR
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.DOUBLE
+import com.squareup.kotlinpoet.FLOAT
+import com.squareup.kotlinpoet.INT
+import com.squareup.kotlinpoet.LONG
 import com.squareup.kotlinpoet.ParameterizedTypeName
+import com.squareup.kotlinpoet.SHORT
 import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.UNIT
+import com.squareup.kotlinpoet.asTypeName
 
 internal fun TypeName.rawType(): ClassName {
   return when (this) {
@@ -26,3 +37,17 @@ internal fun TypeName.rawType(): ClassName {
     else -> throw IllegalArgumentException("Cannot get raw type from $this")
   }
 }
+
+internal fun TypeName.defaultPrimitiveValue(): CodeBlock =
+    when (this) {
+      BOOLEAN -> CodeBlock.of("false")
+      CHAR -> CodeBlock.of("0.toChar()")
+      BYTE -> CodeBlock.of("0.toByte()")
+      SHORT -> CodeBlock.of("0.toShort()")
+      INT -> CodeBlock.of("0")
+      FLOAT -> CodeBlock.of("0f")
+      LONG -> CodeBlock.of("0L")
+      DOUBLE -> CodeBlock.of("0.0")
+      UNIT, Void::class.asTypeName() -> throw IllegalStateException("Parameter with void or Unit type is illegal")
+      else -> CodeBlock.of("null")
+    }

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DefaultConstructorTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DefaultConstructorTest.kt
@@ -10,8 +10,8 @@ class DefaultConstructorTest {
   @Test fun minimal() {
     val expected = TestClass("requiredClass")
     val args = arrayOf("requiredClass", null, 0, null, 0, 0)
-    val argPresentValues = booleanArrayOf(true, false, false, false, false, false)
-    val instance = Util.invokeDefaultConstructor(TestClass::class.java, args, argPresentValues)
+    val mask = Util.createDefaultValuesParametersMask(true, false, false, false, false, false)
+    val instance = Util.invokeDefaultConstructor(TestClass::class.java, args, mask)
     check(instance == expected) {
       "No match:\nActual  : $instance\nExpected: $expected"
     }
@@ -20,8 +20,8 @@ class DefaultConstructorTest {
   @Test fun allSet() {
     val expected = TestClass("requiredClass", "customOptional", 4, "setDynamic", 5, 6)
     val args = arrayOf("requiredClass", "customOptional", 4, "setDynamic", 5, 6)
-    val argPresentValues = booleanArrayOf(true, true, true, true, true, true)
-    val instance = Util.invokeDefaultConstructor(TestClass::class.java, args, argPresentValues)
+    val mask = Util.createDefaultValuesParametersMask(true, true, true, true, true, true)
+    val instance = Util.invokeDefaultConstructor(TestClass::class.java, args, mask)
     check(instance == expected) {
       "No match:\nActual  : $instance\nExpected: $expected"
     }
@@ -30,8 +30,8 @@ class DefaultConstructorTest {
   @Test fun customDynamic() {
     val expected = TestClass("requiredClass", "customOptional")
     val args = arrayOf("requiredClass", "customOptional", 0, null, 0, 0)
-    val argPresentValues = booleanArrayOf(true, true, false, false, false, false)
-    val instance = Util.invokeDefaultConstructor(TestClass::class.java, args, argPresentValues)
+    val mask = Util.createDefaultValuesParametersMask(true, true, false, false, false, false)
+    val instance = Util.invokeDefaultConstructor(TestClass::class.java, args, mask)
     check(instance == expected) {
       "No match:\nActual  : $instance\nExpected: $expected"
     }

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DefaultConstructorTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DefaultConstructorTest.kt
@@ -1,5 +1,7 @@
 package com.squareup.moshi.kotlin
 
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
 import com.squareup.moshi.internal.Util
 import org.junit.Test
 
@@ -34,8 +36,39 @@ class DefaultConstructorTest {
       "No match:\nActual  : $instance\nExpected: $expected"
     }
   }
+
+  @Test fun minimal_codeGen() {
+    val expected = TestClass("requiredClass")
+    val json = """{"required":"requiredClass"}"""
+    val instance = Moshi.Builder().build().adapter<TestClass>(TestClass::class.java)
+        .fromJson(json)!!
+    check(instance == expected) {
+      "No match:\nActual  : $instance\nExpected: $expected"
+    }
+  }
+
+  @Test fun customDynamic_codeGen() {
+    val expected = TestClass("requiredClass", "customOptional", 4, "setDynamic", 5, 6)
+    val json = """{"required":"requiredClass","optional":"customOptional","optional2":4,"dynamicSelfReferenceOptional":"setDynamic","dynamicOptional":5,"dynamicInlineOptional":6}"""
+    val instance = Moshi.Builder().build().adapter<TestClass>(TestClass::class.java)
+        .fromJson(json)!!
+    check(instance == expected) {
+      "No match:\nActual  : $instance\nExpected: $expected"
+    }
+  }
+
+  @Test fun allSet_codeGen() {
+    val expected = TestClass("requiredClass", "customOptional")
+    val json = """{"required":"requiredClass","optional":"customOptional"}"""
+    val instance = Moshi.Builder().build().adapter<TestClass>(TestClass::class.java)
+        .fromJson(json)!!
+    check(instance == expected) {
+      "No match:\nActual  : $instance\nExpected: $expected"
+    }
+  }
 }
 
+@JsonClass(generateAdapter = true)
 data class TestClass(
     val required: String,
     val optional: String = "optional",

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DefaultConstructorTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DefaultConstructorTest.kt
@@ -11,7 +11,8 @@ class DefaultConstructorTest {
     val expected = TestClass("requiredClass")
     val args = arrayOf("requiredClass", null, 0, null, 0, 0)
     val mask = Util.createDefaultValuesParametersMask(true, false, false, false, false, false)
-    val instance = Util.invokeDefaultConstructor(TestClass::class.java, args, mask)
+    val constructor = Util.lookupDefaultsConstructor(TestClass::class.java)
+    val instance = Util.invokeDefaultConstructor(TestClass::class.java, constructor, args, mask)
     check(instance == expected) {
       "No match:\nActual  : $instance\nExpected: $expected"
     }
@@ -21,7 +22,8 @@ class DefaultConstructorTest {
     val expected = TestClass("requiredClass", "customOptional", 4, "setDynamic", 5, 6)
     val args = arrayOf("requiredClass", "customOptional", 4, "setDynamic", 5, 6)
     val mask = Util.createDefaultValuesParametersMask(true, true, true, true, true, true)
-    val instance = Util.invokeDefaultConstructor(TestClass::class.java, args, mask)
+    val constructor = Util.lookupDefaultsConstructor(TestClass::class.java)
+    val instance = Util.invokeDefaultConstructor(TestClass::class.java, constructor, args, mask)
     check(instance == expected) {
       "No match:\nActual  : $instance\nExpected: $expected"
     }
@@ -31,7 +33,8 @@ class DefaultConstructorTest {
     val expected = TestClass("requiredClass", "customOptional")
     val args = arrayOf("requiredClass", "customOptional", 0, null, 0, 0)
     val mask = Util.createDefaultValuesParametersMask(true, true, false, false, false, false)
-    val instance = Util.invokeDefaultConstructor(TestClass::class.java, args, mask)
+    val constructor = Util.lookupDefaultsConstructor(TestClass::class.java)
+    val instance = Util.invokeDefaultConstructor(TestClass::class.java, constructor, args, mask)
     check(instance == expected) {
       "No match:\nActual  : $instance\nExpected: $expected"
     }

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DefaultConstructorTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DefaultConstructorTest.kt
@@ -17,7 +17,7 @@ class DefaultConstructorTest {
     }
   }
 
-  @Test fun customDynamic() {
+  @Test fun allSet() {
     val expected = TestClass("requiredClass", "customOptional", 4, "setDynamic", 5, 6)
     val args = arrayOf("requiredClass", "customOptional", 4, "setDynamic", 5, 6)
     val argPresentValues = booleanArrayOf(true, true, true, true, true, true)
@@ -27,7 +27,7 @@ class DefaultConstructorTest {
     }
   }
 
-  @Test fun allSet() {
+  @Test fun customDynamic() {
     val expected = TestClass("requiredClass", "customOptional")
     val args = arrayOf("requiredClass", "customOptional", 0, null, 0, 0)
     val argPresentValues = booleanArrayOf(true, true, false, false, false, false)
@@ -47,7 +47,7 @@ class DefaultConstructorTest {
     }
   }
 
-  @Test fun customDynamic_codeGen() {
+  @Test fun allSet_codeGen() {
     val expected = TestClass("requiredClass", "customOptional", 4, "setDynamic", 5, 6)
     val json = """{"required":"requiredClass","optional":"customOptional","optional2":4,"dynamicSelfReferenceOptional":"setDynamic","dynamicOptional":5,"dynamicInlineOptional":6}"""
     val instance = Moshi.Builder().build().adapter<TestClass>(TestClass::class.java)
@@ -57,7 +57,7 @@ class DefaultConstructorTest {
     }
   }
 
-  @Test fun allSet_codeGen() {
+  @Test fun customDynamic_codeGen() {
     val expected = TestClass("requiredClass", "customOptional")
     val json = """{"required":"requiredClass","optional":"customOptional"}"""
     val instance = Moshi.Builder().build().adapter<TestClass>(TestClass::class.java)

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DefaultConstructorTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DefaultConstructorTest.kt
@@ -12,7 +12,7 @@ class DefaultConstructorTest {
     val args = arrayOf("requiredClass", null, 0, null, 0, 0)
     val mask = Util.createDefaultValuesParametersMask(true, false, false, false, false, false)
     val constructor = Util.lookupDefaultsConstructor(TestClass::class.java)
-    val instance = Util.invokeDefaultConstructor(TestClass::class.java, constructor, args, mask)
+    val instance = Util.invokeDefaultConstructor(TestClass::class.java, constructor, mask, *args)
     check(instance == expected) {
       "No match:\nActual  : $instance\nExpected: $expected"
     }
@@ -23,7 +23,7 @@ class DefaultConstructorTest {
     val args = arrayOf("requiredClass", "customOptional", 4, "setDynamic", 5, 6)
     val mask = Util.createDefaultValuesParametersMask(true, true, true, true, true, true)
     val constructor = Util.lookupDefaultsConstructor(TestClass::class.java)
-    val instance = Util.invokeDefaultConstructor(TestClass::class.java, constructor, args, mask)
+    val instance = Util.invokeDefaultConstructor(TestClass::class.java, constructor, mask, *args)
     check(instance == expected) {
       "No match:\nActual  : $instance\nExpected: $expected"
     }
@@ -34,7 +34,7 @@ class DefaultConstructorTest {
     val args = arrayOf("requiredClass", "customOptional", 0, null, 0, 0)
     val mask = Util.createDefaultValuesParametersMask(true, true, false, false, false, false)
     val constructor = Util.lookupDefaultsConstructor(TestClass::class.java)
-    val instance = Util.invokeDefaultConstructor(TestClass::class.java, constructor, args, mask)
+    val instance = Util.invokeDefaultConstructor(TestClass::class.java, constructor, mask, *args)
     check(instance == expected) {
       "No match:\nActual  : $instance\nExpected: $expected"
     }

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DefaultConstructorTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DefaultConstructorTest.kt
@@ -1,0 +1,55 @@
+package com.squareup.moshi.kotlin
+
+import com.squareup.moshi.internal.Util
+import org.junit.Test
+
+class DefaultConstructorTest {
+
+  @Test fun minimal() {
+    val expected = TestClass("requiredClass")
+    val args = arrayOf("requiredClass", null, 0, null, 0, 0)
+    val argPresentValues = booleanArrayOf(true, false, false, false, false, false)
+    val instance = Util.invokeDefaultConstructor(TestClass::class.java, args, argPresentValues)
+    check(instance == expected) {
+      "No match:\nActual  : $instance\nExpected: $expected"
+    }
+  }
+
+  @Test fun customDynamic() {
+    val expected = TestClass("requiredClass", "customOptional", 4, "setDynamic", 5, 6)
+    val args = arrayOf("requiredClass", "customOptional", 4, "setDynamic", 5, 6)
+    val argPresentValues = booleanArrayOf(true, true, true, true, true, true)
+    val instance = Util.invokeDefaultConstructor(TestClass::class.java, args, argPresentValues)
+    check(instance == expected) {
+      "No match:\nActual  : $instance\nExpected: $expected"
+    }
+  }
+
+  @Test fun allSet() {
+    val expected = TestClass("requiredClass", "customOptional")
+    val args = arrayOf("requiredClass", "customOptional", 0, null, 0, 0)
+    val argPresentValues = booleanArrayOf(true, true, false, false, false, false)
+    val instance = Util.invokeDefaultConstructor(TestClass::class.java, args, argPresentValues)
+    check(instance == expected) {
+      "No match:\nActual  : $instance\nExpected: $expected"
+    }
+  }
+}
+
+data class TestClass(
+    val required: String,
+    val optional: String = "optional",
+    val optional2: Int = 2,
+    val dynamicSelfReferenceOptional: String = required,
+    val dynamicOptional: Int = createInt(),
+    val dynamicInlineOptional: Int = createInlineInt()
+)
+
+private fun createInt(): Int {
+  return 3
+}
+
+@Suppress("NOTHING_TO_INLINE")
+private inline fun createInlineInt(): Int {
+  return 3
+}

--- a/moshi/src/main/java/com/squareup/moshi/internal/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/Util.java
@@ -562,8 +562,7 @@ public final class Util {
       DEFAULT_CONSTRUCTOR_CACHE.put(targetClass, defaultConstructor);
     }
     int mask = createMask(argPresentValues);
-    Object[] finalArgs = new Object[args.length + 2];
-    System.arraycopy(args, 0, finalArgs, 0, args.length);
+    Object[] finalArgs = Arrays.copyOf(args, args.length + 2);
     finalArgs[finalArgs.length - 2] = mask;
     finalArgs[finalArgs.length - 1] = null; // DefaultConstructorMarker param
     try {

--- a/moshi/src/main/java/com/squareup/moshi/internal/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/Util.java
@@ -606,7 +606,7 @@ public final class Util {
     int mask = 0;
     for (int i = 0; i < argPresentValues.length; ++i) {
       if (!argPresentValues[i]) {
-        mask = mask | (1 << (i % Integer.SIZE));
+        mask = mask | (1 << i);
       }
     }
     return mask;

--- a/moshi/src/main/java/com/squareup/moshi/internal/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/Util.java
@@ -573,7 +573,10 @@ public final class Util {
     } catch (IllegalAccessException e) {
       throw new IllegalStateException("Could not access defaults constructor of " + targetClass);
     } catch (InvocationTargetException e) {
-      throw new IllegalStateException("Could not invoke defaults constructor of " + targetClass);
+      Throwable cause = e.getCause();
+      if (cause instanceof RuntimeException) throw (RuntimeException) cause;
+      if (cause instanceof Error) throw (Error) cause;
+      throw new RuntimeException("Could not invoke defaults constructor of " + targetClass, cause);
     }
   }
 

--- a/moshi/src/main/java/com/squareup/moshi/internal/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/Util.java
@@ -557,9 +557,9 @@ public final class Util {
    *
    * @param targetClass the target kotlin class to instantiate.
    * @param defaultsConstructor the target class's defaults constructor in kotlin invoke.
+   * @param mask an int mask indicating which {@code args} are present.
    * @param args the constructor arguments, including "unset" values (set to null or the primitive
    *             default).
-   * @param mask an int mask indicating which {@code args} are present.
    * @param <T> the type of {@code targetClass}.
    * @return the instantiated {@code targetClass} instance.
    * @see #createDefaultValuesParametersMask(boolean...)
@@ -567,8 +567,8 @@ public final class Util {
   public static <T> T invokeDefaultConstructor(
       Class<T> targetClass,
       Constructor<T> defaultsConstructor,
-      Object[] args,
-      int mask) {
+      int mask,
+      Object... args) {
     Object[] finalArgs = Arrays.copyOf(args, args.length + 2);
     finalArgs[finalArgs.length - 2] = mask;
     finalArgs[finalArgs.length - 1] = null; // DefaultConstructorMarker param

--- a/moshi/src/main/resources/META-INF/proguard/moshi.pro
+++ b/moshi/src/main/resources/META-INF/proguard/moshi.pro
@@ -16,6 +16,12 @@
 # The name of @JsonClass types is used to look up the generated adapter.
 -keepnames @com.squareup.moshi.JsonClass class *
 
+# Retain generated target class's synthetic defaults constructor.
+# We will look this up reflectively to invoke the type's constructor.
+-keepclassmembers @com.squareup.moshi.JsonClass class * {
+    <init>(..., kotlin.jvm.internal.DefaultConstructorMarker);
+}
+
 # Retain generated JsonAdapters if annotated type is retained.
 -if @com.squareup.moshi.JsonClass class *
 -keep class <1>JsonAdapter {

--- a/moshi/src/main/resources/META-INF/proguard/moshi.pro
+++ b/moshi/src/main/resources/META-INF/proguard/moshi.pro
@@ -16,10 +16,14 @@
 # The name of @JsonClass types is used to look up the generated adapter.
 -keepnames @com.squareup.moshi.JsonClass class *
 
-# Retain generated target class's synthetic defaults constructor.
-# We will look this up reflectively to invoke the type's constructor.
+# Retain generated target class's synthetic defaults constructor and keep DefaultConstructorMarker's
+# name. We will look this up reflectively to invoke the type's constructor.
+#
+# We can't _just_ keep the defaults constructor because Proguard/R8's spec doesn't allow wildcard
+# matching preceding parameters.
+-keepnames class kotlin.jvm.internal.DefaultConstructorMarker
 -keepclassmembers @com.squareup.moshi.JsonClass class * {
-    <init>(..., kotlin.jvm.internal.DefaultConstructorMarker);
+    <init>(...);
 }
 
 # Retain generated JsonAdapters if annotated type is retained.


### PR DESCRIPTION
This switches code gen to be able to dynamically invoke constructors and indicate which parameters are not set. No more need for the `copy()` trick! Now full dynamic default values are supported as well.

Caveat: This uses reflection to look up the synthetic defaults constructor that kotlinc generates for these types. Its signature is the original constructor + two extra parameters: one `mask` int parameter that's used to indicate which parameter values are set, and one throwaway `DefaultConstructorMarker` just used to differentiate it. This latter type is also what we use to find this constructor. The reflection is cached, and should be simple to set up with proguard (have pinged proguard folks separately to see if we can just match on that `DefaultConstructorMarker` parameter).

Implementation: There's a new `Util#invokeDefaultConstructor` helper method that accepts a target class, argument values (what the adapter has parsed), and a boolean array of which ones are set. The mask just sets bits that correspond to parameter indices. The boolean array is used to create a mask int, and then the args + mask and `null` throwaway for `DefaultConstructorMarker` are all invoked on the looked up defaults constructor. After eyeballing the [kotlin-reflect implementation](https://github.com/JetBrains/kotlin/blob/deb416484c5128a6f4bc76c39a3d9878b38cec8c/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KCallableImpl.kt#L114-L168), this is fairly similar. It has more mechanics for general use (give it a map of parameter names to values) and figures out the set ones for the mask under the hood, but we know exactly which ones are already set from our parsing already and can just skip that step 👍.

To give a better sense - for a given `TestClass`:

```kotlin
data class TestClass(
    val required: String,
    val optional: String = "optional",
    val optional2: Int = 2,
    val dynamicSelfReferenceOptional: String = required,
    val dynamicOptional: Int = createInt(),
    val dynamicInlineOptional: Int = createInlineInt()
)

fun createInt(): Int {
  return 3
}

inline fun createInlineInt(): Int {
  return 3
}
```

The final bytecode for the constructor we're targeting is roughly this:

```kotlin
// $FF: synthetic method
   public TestClass(String var1, String var2, int var3, String var4, int var5, int var6, int var7, DefaultConstructorMarker var8) {
      if ((var7 & 2) != 0) {
         var2 = "";
      }

      if ((var7 & 4) != 0) {
         var3 = 2;
      }

      if ((var7 & 8) != 0) {
         var4 = var1;
      }

      if ((var7 & 16) != 0) {
         var5 = TestClassKt.createInt();
      }

      if ((var7 & 32) != 0) {
         int $i$f$createInlineInt = false;
         var6 = Random.Default.nextInt();
      }

      this(var1, var2, var3, var4, var5, var6);
   }
```

Pros:
- Full dynamic default values support, no more functional caveats
- No more double instantiation hacks needed
- No kotlin-reflect needed

Cons:
- Reflection cost, but amortized by the caching and (ideally) whatever I/O process this is running in partnership with.