### PR TITLE
Add EnumJsonAdapter.NullFallbackFactory

### DIFF
--- a/adapters/src/test/java/com/squareup/moshi/adapters/EnumJsonAdapterTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/EnumJsonAdapterTest.java
@@ -16,8 +16,10 @@
 package com.squareup.moshi.adapters;
 
 import com.squareup.moshi.Json;
+import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonDataException;
 import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.Moshi;
 import okio.Buffer;
 import org.junit.Test;
 
@@ -71,5 +73,38 @@ public final class EnumJsonAdapterTest {
     ROCK,
     PAPER,
     @Json(name = "scr") SCISSORS
+  }
+
+  static class Model {
+    Roshambo val1;
+    Roshambo val2;
+    Roshambo val3;
+    Roshambo val4;
+    Roshambo val5;
+  }
+
+  @Test public void nullFallbackFactory() throws Exception {
+    Moshi moshi = new Moshi.Builder().add(new EnumJsonAdapter.NullFallbackFactory()).build();
+    JsonAdapter<Model> adapter = moshi.adapter(Model.class);
+    Model obj = adapter.fromJson(
+        "{\"val1\":\"ROCK\"," +
+        "\"val2\":\"scr\"," +
+        "\"val3\":\"SCISSORS\"," +
+        "\"val4\":null," +
+        "\"val5\":\"FOOBAR\"}");
+
+    assertThat(obj).isNotNull();
+    assertThat(obj.val1).isEqualTo(Roshambo.ROCK);
+    assertThat(obj.val2).isEqualTo(Roshambo.SCISSORS);
+    assertThat(obj.val3).isNull();
+    assertThat(obj.val4).isNull();
+    assertThat(obj.val5).isNull();
+    assertThat(adapter.toJson(obj)).isEqualTo("{\"val1\":\"ROCK\",\"val2\":\"scr\"}");
+    assertThat(adapter.serializeNulls().toJson(obj)).isEqualTo(
+        "{\"val1\":\"ROCK\"," +
+        "\"val2\":\"scr\"," +
+        "\"val3\":null," +
+        "\"val4\":null," +
+        "\"val5\":null}");
   }
 }


### PR DESCRIPTION
Provide an adapter factory for deserializing all unrecognized enum values within the same Moshi instance as `null` using existing `EnumJsonAdapter`  with fallback value.

**Why:** This is the default, out of the box behavior of Gson. One of the stated goals of Moshi is [similarity to Gson, but with fewer built-in adapters](https://github.com/square/moshi#borrows-from-gson). 

In an ideal world, one never needs to deserialize unrecognized enum values. But APIs change, and e.g. a user might be running an outdated version of a client. The server might have added new values to an existing enum that did not exist at the time the client was written. It's far easier to build your clients to fail gracefully on `null` enum values than to e.g. introduce a new JSON field every time you need to expand said enum. With Gson this is the default behavior, but with Moshi whole document serialization throws unless one adds an `EnumJsonAdapter` for *every single* enum type in the project that might be expanded in the future (this is especially daunting for a project that are migrating from Gson to Moshi), or figure how to write a custom `JsonAdapter.Factory`. Moshi should preferably just provide the latter as standard add-on component.

This behavior has [been](https://github.com/square/moshi/issues/218) [requested](https://github.com/square/moshi/pull/607#issuecomment-413057681) [multiple](https://github.com/square/moshi/pull/607#issuecomment-413302505) [times](https://github.com/square/moshi/issues/263#issuecomment-481305545), but the [complete](https://github.com/square/moshi/issues/218#issuecomment-262664970) [solution](https://github.com/Meisolsson/GitHubSdk/pull/25#issuecomment-462058587) was never delivered AFAIK.