### PR TITLE
Don't reflect on kotlinx and update doc

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -39,9 +39,11 @@ import static com.squareup.moshi.internal.Util.resolve;
  *
  * <ul>
  *   <li>android.*
+ *   <li>androidx.*
  *   <li>java.*
  *   <li>javax.*
  *   <li>kotlin.*
+ *   <li>kotlinx.*
  *   <li>scala.*
  * </ul>
  */

--- a/moshi/src/main/java/com/squareup/moshi/internal/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/Util.java
@@ -98,6 +98,7 @@ public final class Util {
         || name.startsWith("java.")
         || name.startsWith("javax.")
         || name.startsWith("kotlin.")
+        || name.startsWith("kotlinx.")
         || name.startsWith("scala.");
   }
 


### PR DESCRIPTION
This adds kotlinx to the exclusion list, and also updates the doc on ClassJsonAdapter