### PR TITLE
Make Rfc3339DateJsonAdapter null-safe

### DIFF
--- a/adapters/src/main/java/com/squareup/moshi/Rfc3339DateJsonAdapter.java
+++ b/adapters/src/main/java/com/squareup/moshi/Rfc3339DateJsonAdapter.java
@@ -23,7 +23,7 @@ import java.util.Date;
  *     The new class is {@code com.squareup.moshi.adapters.Rfc3339DateJsonAdapter}.
  */
 public final class Rfc3339DateJsonAdapter extends JsonAdapter<Date> {
-  com.squareup.moshi.adapters.Rfc3339DateJsonAdapter delegate
+  private final com.squareup.moshi.adapters.Rfc3339DateJsonAdapter delegate
       = new com.squareup.moshi.adapters.Rfc3339DateJsonAdapter();
 
   @Override public Date fromJson(JsonReader reader) throws IOException {

--- a/adapters/src/main/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapter.java
+++ b/adapters/src/main/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapter.java
@@ -23,8 +23,8 @@ import java.util.Date;
 
 /**
  * Formats dates using <a href="https://www.ietf.org/rfc/rfc3339.txt">RFC 3339</a>, which is
- * formatted like {@code 2015-09-26T18:23:50.250Z}. To use, add this as an adapter for {@code
- * Date.class} on your {@link com.squareup.moshi.Moshi.Builder Moshi.Builder}:
+ * formatted like {@code 2015-09-26T18:23:50.250Z}. This adapter is null-safe. To use, add this as
+ * an adapter for {@code Date.class} on your {@link com.squareup.moshi.Moshi.Builder Moshi.Builder}:
  *
  * <pre> {@code
  *
@@ -35,12 +35,19 @@ import java.util.Date;
  */
 public final class Rfc3339DateJsonAdapter extends JsonAdapter<Date> {
   @Override public synchronized Date fromJson(JsonReader reader) throws IOException {
+    if (reader.peek() == JsonReader.Token.NULL) {
+      return reader.nextNull();
+    }
     String string = reader.nextString();
     return Iso8601Utils.parse(string);
   }
 
   @Override public synchronized void toJson(JsonWriter writer, Date value) throws IOException {
-    String string = Iso8601Utils.format(value);
-    writer.value(string);
+    if (value == null) {
+      writer.nullValue();
+    } else {
+      String string = Iso8601Utils.format(value);
+      writer.value(string);
+    }
   }
 }

--- a/adapters/src/test/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapterTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapterTest.java
@@ -63,6 +63,11 @@ public final class Rfc3339DateJsonAdapterTest {
         .isEqualTo("\"1937-01-01T11:40:27.870Z\"");
   }
 
+  @Test public void nullSafety() throws Exception {
+    assertThat(adapter.toJson(null)).isEqualTo("null");
+    assertThat(adapter.fromJson("null")).isNull();
+  }
+
   private Date newDate(
       int year, int month, int day, int hour, int minute, int second, int millis, int offset) {
     Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("GMT"));


### PR DESCRIPTION
Resolves #723, also opportunistically makes the deprecated type's delegate private and final

CC @benjamin-bader @chrisjenx 