### PR TITLE
Added codegen support for inline classes

### DIFF
--- a/kotlin/tests/pom.xml
+++ b/kotlin/tests/pom.xml
@@ -117,6 +117,7 @@
           <args>
             <arg>-Werror</arg>
             <arg>-Xuse-experimental=kotlin.ExperimentalStdlibApi</arg>
+              <arg>-XXLanguage:+InlineClasses</arg>
           </args>
         </configuration>
       </plugin>

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -252,4 +252,21 @@ class DualKotlinTest(useReflection: Boolean) {
     assertThat(decoded.a).isEqualTo(null)
   }
 
+  @Test fun inlineClass() {
+    val adapter = moshi.adapter<InlineClass>()
+
+    val inline = InlineClass(5)
+
+    val expectedJson = """{"f":5}"""
+    assertThat(adapter.toJson(inline)).isEqualTo(expectedJson)
+
+    val testJson = """{"f":6}"""
+    val result = adapter.fromJson(testJson)!!
+    assertThat(result.f).isEqualTo(6)
+  }
+
 }
+
+// Has to be outside since inline classes are only allowed on top level
+@JsonClass(generateAdapter = true)
+inline class InlineClass(val f: Int)

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -257,16 +257,31 @@ class DualKotlinTest(useReflection: Boolean) {
 
     val inline = InlineClass(5)
 
-    val expectedJson = """{"f":5}"""
+    val expectedJson = """{"i":5}"""
     assertThat(adapter.toJson(inline)).isEqualTo(expectedJson)
 
-    val testJson = """{"f":6}"""
+    val testJson = """{"i":6}"""
     val result = adapter.fromJson(testJson)!!
-    assertThat(result.f).isEqualTo(6)
+    assertThat(result.i).isEqualTo(6)
   }
 
+  @JsonClass(generateAdapter = true)
+  data class InlineConsumer(val inline: InlineClass)
+
+  @Test fun inlineClassConsumer() {
+    val adapter = moshi.adapter<InlineConsumer>()
+
+    val consumer = InlineConsumer(InlineClass(23))
+
+    val expectedJson= """{"inline":{"i":23}}"""
+    assertThat(adapter.toJson(consumer)).isEqualTo(expectedJson)
+
+    val testJson = """{"inline":{"i":42}}"""
+    val result = adapter.fromJson(testJson)!!
+    assertThat(result.inline.i).isEqualTo(42)
+  }
 }
 
 // Has to be outside since inline classes are only allowed on top level
 @JsonClass(generateAdapter = true)
-inline class InlineClass(val f: Int)
+inline class InlineClass(val i: Int)

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -1115,6 +1115,21 @@ class GeneratedAdaptersTest {
     }
   }
 
+  @Test fun inlineClass() {
+    val adapter = moshi.adapter<InlineClass>()
+
+    val inline = InlineClass(5)
+
+    @Language("JSON")
+    val expectedJson = """{"f":5}"""
+    assertThat(adapter.toJson(inline)).isEqualTo(expectedJson)
+
+    @Language("JSON")
+    val testJson = """{"f":6}"""
+    val result = adapter.fromJson(testJson)!!
+    assertThat(result.f).isEqualTo(6)
+  }
+
   // https://github.com/square/moshi/issues/921
   @Test fun internalPropertyWithoutBackingField() {
     val adapter = moshi.adapter<InternalPropertyWithoutBackingField>()
@@ -1154,6 +1169,10 @@ class GeneratedAdaptersTest {
     assertThat(instance).isEqualTo(ClassWithFieldJson("link").apply { ids = "id" })
   }
 }
+
+// Has to be outside since inline classes are only allowed on top level
+@JsonClass(generateAdapter = true)
+inline class InlineClass(val f: Int)
 
 // Has to be outside to avoid Types seeing an owning class
 @JsonClass(generateAdapter = true)

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -1115,21 +1115,6 @@ class GeneratedAdaptersTest {
     }
   }
 
-  @Test fun inlineClass() {
-    val adapter = moshi.adapter<InlineClass>()
-
-    val inline = InlineClass(5)
-
-    @Language("JSON")
-    val expectedJson = """{"f":5}"""
-    assertThat(adapter.toJson(inline)).isEqualTo(expectedJson)
-
-    @Language("JSON")
-    val testJson = """{"f":6}"""
-    val result = adapter.fromJson(testJson)!!
-    assertThat(result.f).isEqualTo(6)
-  }
-
   // https://github.com/square/moshi/issues/921
   @Test fun internalPropertyWithoutBackingField() {
     val adapter = moshi.adapter<InternalPropertyWithoutBackingField>()
@@ -1169,10 +1154,6 @@ class GeneratedAdaptersTest {
     assertThat(instance).isEqualTo(ClassWithFieldJson("link").apply { ids = "id" })
   }
 }
-
-// Has to be outside since inline classes are only allowed on top level
-@JsonClass(generateAdapter = true)
-inline class InlineClass(val f: Int)
 
 // Has to be outside to avoid Types seeing an owning class
 @JsonClass(generateAdapter = true)


### PR DESCRIPTION
This was discussed in #776. The fix is really simple. I also added tests since I am using this in my own projects. 
I'm not sure if you want to pull this into master before inline classes become stable. To run the tests I enabled inline classes for the moshi-kotlin-test module. Also I don't think this will break unless they change the protobuff flag in the metadata declaring a class to be inline, which I think is very unlikely. 
Also this might not fix #776 completely since I haven't looked into using inline classes with the reflection based adapter.
___
For everyone else finding this, if this isn't merged into master [here](https://jitpack.io/#Wasabi375/moshi/inline_class-SNAPSHOT) is a link to jitpack where you can get the current version of the build. I will try to keep this up with master (as I am using it), but no promises :wink: