### PR TITLE
Introduce skipNextName() APIs to JsonReader/JsonWriter

### DIFF
--- a/adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.java
+++ b/adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.java
@@ -245,6 +245,9 @@ public final class PolymorphicJsonAdapterFactory<T> implements JsonAdapter.Facto
         reader.skipValue();
         return defaultValue;
       }
+      if (reader.failOnUnknown()) {
+        reader.skipNextName(labelKey);
+      }
       return jsonAdapters.get(labelIndex).fromJson(reader);
     }
 

--- a/adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.java
+++ b/adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.java
@@ -291,6 +291,7 @@ public final class PolymorphicJsonAdapterFactory<T> implements JsonAdapter.Facto
       JsonAdapter<Object> adapter = jsonAdapters.get(labelIndex);
       writer.beginObject();
       writer.name(labelKey).value(labels.get(labelIndex));
+      writer.skipNextName(labelKey);
       int flattenToken = writer.beginFlatten();
       adapter.toJson(writer, value);
       writer.endFlatten(flattenToken);

--- a/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
@@ -263,6 +263,23 @@ public final class PolymorphicJsonAdapterFactoryTest {
     assertThat(decoded.value).isEqualTo("Okay!");
   }
 
+  // Subtype does have a type, polymorphic adapter writes the type label name and value, subtype's
+  // type should be ignored in serialization to avoid duplication.
+  // Regression test for https://github.com/square/moshi/issues/874
+  @Test public void missingTypeLabel_toJson() throws IOException {
+    Moshi moshi = new Moshi.Builder()
+        .add(PolymorphicJsonAdapterFactory.of(Message.class, "type")
+            .withSubtype(MessageWithType.class, "success"))
+        .build();
+    JsonAdapter<Message> adapter = moshi.adapter(Message.class);
+
+    MessageWithType message = new MessageWithType("success", "Okay!");
+    String encoded = adapter.toJson(message);
+    assertThat(encoded).isEqualTo("{\"type\":\"success\",\"value\":\"Okay!\"}");
+    MessageWithType decoded = (MessageWithType) adapter.fromJson(encoded);
+    assertThat(decoded.value).isEqualTo("Okay!");
+  }
+
   interface Message {
   }
 

--- a/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
@@ -233,6 +233,21 @@ public final class PolymorphicJsonAdapterFactoryTest {
     assertThat(decoded.value).isEqualTo("Okay!");
   }
 
+  // Subtype doesn't have a type label, we should allow this because we have already processed the
+  // type label in the context of the polymorphic adapter.
+  // This is a regression test for https://github.com/square/moshi/issues/858
+  @Test public void failOnUnknownMissingTypeLabel_and_noTypeKeyUsed() throws IOException {
+    Moshi moshi = new Moshi.Builder()
+        .add(PolymorphicJsonAdapterFactory.of(Message.class, "type")
+            .withSubtype(MessageWithoutType.class, "success"))
+        .build();
+    JsonAdapter<Message> adapter = moshi.adapter(Message.class).failOnUnknown();
+
+    MessageWithoutType decoded = (MessageWithoutType) adapter.fromJson(
+        "{\"value\":\"Okay!\",\"type\":\"success\"}");
+    assertThat(decoded.value).isEqualTo("Okay!");
+  }
+
   interface Message {
   }
 

--- a/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
@@ -297,4 +297,12 @@ public final class PolymorphicJsonAdapterFactoryTest {
       this.value = value;
     }
   }
+
+  static final class MessageWithoutType implements Message {
+    final String value;
+
+    MessageWithoutType(String value) {
+      this.value = value;
+    }
+  }
 }

--- a/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
@@ -248,6 +248,21 @@ public final class PolymorphicJsonAdapterFactoryTest {
     assertThat(decoded.value).isEqualTo("Okay!");
   }
 
+  // Subtype doesn't have a type, polymorphic adapter writes the type label name and value
+  @Test public void missingTypeLabel_and_noTypeKeyUsed_toJson() throws IOException {
+    Moshi moshi = new Moshi.Builder()
+        .add(PolymorphicJsonAdapterFactory.of(Message.class, "type")
+            .withSubtype(MessageWithoutType.class, "success"))
+        .build();
+    JsonAdapter<Message> adapter = moshi.adapter(Message.class);
+
+    MessageWithoutType message = new MessageWithoutType("Okay!");
+    String encoded = adapter.toJson(message);
+    assertThat(encoded).isEqualTo("{\"type\":\"success\",\"value\":\"Okay!\"}");
+    MessageWithoutType decoded = (MessageWithoutType) adapter.fromJson(encoded);
+    assertThat(decoded.value).isEqualTo("Okay!");
+  }
+
   interface Message {
   }
 

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -346,6 +346,16 @@ public abstract class JsonReader implements Closeable {
   @CheckReturnValue public abstract int selectName(Options options) throws IOException;
 
   /**
+   * Skips the next name equal to {@code nameToSkip}. Useful in conditions where a name has already
+   * been handled by a delegating adapter and allow for skipping the given name in delegate adapters
+   * in {@link #failOnUnknown()} conditions. The name should only be skipped once.
+   *
+   * <p>Skipping the given name should also result in quietly skipping the subsequent value. even if
+   * {@link #failOnUnknown()} is true.
+   */
+  public abstract void skipNextName(String nameToSkip);
+
+  /**
    * Skips the next token, consuming it. This method is intended for use when the JSON token stream
    * contains unrecognized or unhandled names.
    *

--- a/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
@@ -297,6 +297,15 @@ public abstract class JsonWriter implements Closeable, Flushable {
   public abstract JsonWriter endObject() throws IOException;
 
   /**
+   * Skips the next name with value equal to {@code nameToSkip}. This is useful in conditions where
+   * the name has already been written to the writer manually in a delegating adapter and it wants
+   * to prevent delegate adapters from possibly duplicating the written key and value.
+   *
+   * <p>Skipping the given name should also result in quietly skipping its subsequent value.
+   */
+  public abstract JsonWriter skipNextName(String nameToSkip);
+
+  /**
    * Encodes the property name.
    *
    * @param name the name of the forthcoming value. Must not be null.


### PR DESCRIPTION
This is a proposal implementation for resolving two issues with PolymorphicJsonAdapter usage

The first is #858, and is resolved by marking a processed type label key to be skipped if the reader has failOnUnknown() set to true

The second is #874, and is resolved by marking that a type label has already been written and should be skipped if any delegate adapters try to write it as well. This implementation needs a bit more work to make it only apply on the first level object and not nested ones, but starting with the current implementation for review and feedback. I think this one is definitely worth pursuing because it affects any case where a subtype declares the type label.

Both implementations need more tests in the respective reader/writers, but will circle to those if we want to move forward with these APIs.

Resolves #858
Resolves #874