### PR TITLE
Throw on missing type variables in Types.newParameterizedType* methods

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/Types.java
+++ b/moshi/src/main/java/com/squareup/moshi/Types.java
@@ -109,6 +109,9 @@ public final class Types {
    * method if {@code rawType} is not enclosed in another type.
    */
   public static ParameterizedType newParameterizedType(Type rawType, Type... typeArguments) {
+    if (typeArguments.length == 0) {
+      throw new IllegalArgumentException("Missing type arguments for " + rawType);
+    }
     return new ParameterizedTypeImpl(null, rawType, typeArguments);
   }
 
@@ -118,6 +121,9 @@ public final class Types {
    */
   public static ParameterizedType newParameterizedTypeWithOwner(
       Type ownerType, Type rawType, Type... typeArguments) {
+    if (typeArguments.length == 0) {
+      throw new IllegalArgumentException("Missing type arguments for " + rawType);
+    }
     return new ParameterizedTypeImpl(ownerType, rawType, typeArguments);
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/TypesTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/TypesTest.java
@@ -85,6 +85,22 @@ public final class TypesTest {
     assertThat(getFirstTypeArgument(type)).isEqualTo(B.class);
   }
 
+  @Test public void newParameterizedType_missingTypeVars() {
+    try {
+      Types.newParameterizedType(List.class);
+      fail("Should have errored due to missing type variable");
+    } catch (Exception e) {
+      assertThat(e).hasMessageContaining("Missing type arguments");
+    }
+
+    try {
+      Types.newParameterizedTypeWithOwner(TypesTest.class, A.class);
+      fail("Should have errored due to missing type variable");
+    } catch (Exception e) {
+      assertThat(e).hasMessageContaining("Missing type arguments");
+    }
+  }
+
   @Test public void parameterizedTypeWithRequiredOwnerMissing() throws Exception {
     try {
       Types.newParameterizedType(A.class, B.class);


### PR DESCRIPTION
It's programmer error to omit this, but vararg declaration allows you to. This checks that.

We could improve it to ensure matching lengths or bounds, but this is a good start.

Helps clarify cases like #931