### PR TITLE
added test for transient delegate in kotlin code gen (#922)

### DIFF
--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -35,6 +35,7 @@ import org.junit.Assert.fail
 import org.junit.Ignore
 import org.junit.Test
 import java.util.Locale
+import kotlin.properties.Delegates
 import kotlin.reflect.full.memberProperties
 
 @ExperimentalStdlibApi
@@ -558,6 +559,38 @@ class GeneratedAdaptersTest {
 
     fun getB() = b
 
+    fun setB(b: Int) {
+      this.b = b
+    }
+  }
+
+  @Test fun transientDelegateProperty() {
+    val jsonAdapter = moshi.adapter<TransientDelegateProperty>()
+
+    val encoded = TransientDelegateProperty()
+    encoded.a = 3
+    encoded.setB(4)
+    encoded.c = 5
+    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"c":5}""")
+
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":5,"c":6}""")!!
+    assertThat(decoded.a).isEqualTo(-1)
+    assertThat(decoded.getB()).isEqualTo(-1)
+    assertThat(decoded.c).isEqualTo(6)
+  }
+
+  @JsonClass(generateAdapter=true)
+  class TransientDelegateProperty {
+
+    private fun <T>delegate(initial: T) = Delegates.observable(initial) { _, _, _-> }
+
+    @delegate:Transient var a: Int by delegate(-1)
+    @delegate:Transient private var b: Int by delegate(-1)
+    var c: Int by delegate(-1)
+
+    @JvmName("getBPublic")
+    fun getB() = b
+    @JvmName("setBPublic")
     fun setB(b: Int) {
       this.b = b
     }

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -579,7 +579,7 @@ class GeneratedAdaptersTest {
     assertThat(decoded.c).isEqualTo(6)
   }
 
-  @JsonClass(generateAdapter=true)
+  @JsonClass(generateAdapter = true)
   class TransientDelegateProperty {
 
     private fun <T>delegate(initial: T) = Delegates.observable(initial) { _, _, _-> }


### PR DESCRIPTION
The fix for #922 is part of #903. The backend rework seems to have done the trick :wink: 
This PR just adds a test case.