### PR TITLE
Add JsonWriter.valueSink for streaming data

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonScope.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonScope.java
@@ -44,6 +44,9 @@ final class JsonScope {
   /** A document that's been closed and cannot be accessed. */
   static final int CLOSED = 8;
 
+  /** Sits above the actual state to indicate that a value is currently being streamed in. */
+  static final int STREAMING_VALUE = 9;
+
   /**
    * Renders the path in a JSON document to a string. The {@code pathNames} and {@code pathIndices}
    * parameters corresponds directly to stack: At indices where the stack contains an object

--- a/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
+import okio.BufferedSink;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -615,5 +616,130 @@ public final class JsonWriterTest {
     } catch (IllegalStateException expected) {
       assertThat(expected).hasMessage("Dangling name: a");
     }
+  }
+
+  @Test public void streamingValueInObject() throws IOException {
+    JsonWriter writer = factory.newWriter();
+    writer.beginObject();
+    writer.name("a");
+    BufferedSink value = writer.valueSink();
+    value.writeByte('"');
+    value.writeHexadecimalUnsignedLong(-1L);
+    value.writeUtf8("sup");
+    value.writeDecimalLong(-1L);
+    value.writeByte('"');
+    value.close();
+    writer.endObject();
+    assertThat(factory.json()).isEqualTo("{\"a\":\"ffffffffffffffffsup-1\"}");
+  }
+
+  @Test public void streamingValueInArray() throws IOException {
+    JsonWriter writer = factory.newWriter();
+    writer.beginArray();
+    writer.valueSink()
+        .writeByte('"')
+        .writeHexadecimalUnsignedLong(-1L)
+        .writeByte('"')
+        .close();
+    writer.valueSink()
+        .writeByte('"')
+        .writeUtf8("sup")
+        .writeByte('"')
+        .close();
+    writer.valueSink()
+        .writeUtf8("-1.0")
+        .close();
+    writer.endArray();
+    assertThat(factory.json()).isEqualTo("[\"ffffffffffffffff\",\"sup\",-1.0]");
+  }
+
+  @Test public void streamingValueTopLevel() throws IOException {
+    JsonWriter writer = factory.newWriter();
+    writer.valueSink()
+        .writeUtf8("-1.0")
+        .close();
+    assertThat(factory.json()).isEqualTo("-1.0");
+  }
+
+  @Test public void streamingValueTwiceBeforeCloseFails() throws IOException {
+    JsonWriter writer = factory.newWriter();
+    writer.beginObject();
+    writer.name("a");
+    BufferedSink sink = writer.valueSink();
+    try {
+      writer.valueSink();
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage("Sink from valueSink() was not closed");
+    }
+  }
+
+  @Test public void streamingValueTwiceAfterCloseFails() throws IOException {
+    JsonWriter writer = factory.newWriter();
+    writer.beginObject();
+    writer.name("a");
+    writer.valueSink().writeByte('0').close();
+    try {
+      // TODO currently UTF-8 fails eagerly on valueSink() but value does not fail until close().
+      writer.valueSink().writeByte('0').close();
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage("Nesting problem.");
+    }
+  }
+
+  @Test public void streamingValueAndScalarValueFails() throws IOException {
+    JsonWriter writer = factory.newWriter();
+    writer.beginObject();
+    writer.name("a");
+    BufferedSink sink = writer.valueSink();
+    try {
+      writer.value("b");
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage("Sink from valueSink() was not closed");
+    }
+  }
+
+  @Test public void streamingValueAndNameFails() throws IOException {
+    JsonWriter writer = factory.newWriter();
+    writer.beginObject();
+    writer.name("a");
+    BufferedSink sink = writer.valueSink();
+    try {
+      writer.name("b");
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage("Nesting problem.");
+    }
+  }
+
+  @Test public void streamingValueInteractionAfterCloseFails() throws IOException {
+    JsonWriter writer = factory.newWriter();
+    writer.beginObject();
+    writer.name("a");
+    BufferedSink sink = writer.valueSink();
+    sink.writeUtf8("1.0");
+    sink.close();
+    try {
+      sink.writeByte('1');
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage("closed");
+    }
+  }
+
+  @Test public void streamingValueCloseIsIdempotent() throws IOException {
+    JsonWriter writer = factory.newWriter();
+    writer.beginObject();
+    writer.name("a");
+    BufferedSink sink = writer.valueSink();
+    sink.writeUtf8("1.0");
+    sink.close();
+    sink.close();
+    writer.endObject();
+    sink.close();
+    assertThat(factory.json()).isEqualTo("{\"a\":1.0}");
+    sink.close();
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/PromoteNameToValueTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/PromoteNameToValueTest.java
@@ -351,4 +351,21 @@ public final class PromoteNameToValueTest {
     writer.endObject();
     assertThat(factory.json()).isEqualTo("{\"a\":\"a value\"}");
   }
+
+  @Test public void writerValueSinkFails() throws Exception {
+    JsonWriter writer = factory.newWriter();
+    writer.beginObject();
+    writer.promoteValueToName();
+    try {
+      writer.valueSink();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertThat(expected).hasMessage(
+          "BufferedSink cannot be used as a map key in JSON at path $.");
+    }
+    writer.value("a");
+    writer.value("a value");
+    writer.endObject();
+    assertThat(factory.json()).isEqualTo("{\"a\":\"a value\"}");
+  }
 }


### PR DESCRIPTION
Unlike `value(BufferedSource)`, this retains the push-based nature of JsonWriter and allows layering other sinks (such as a base64-encoding Sink for binary data). Since `value(BufferedSource)` is trivially replaced by reading the source into the value sink, it is deprecated.

Potentially helps out #100 a bit.