### PR TITLE
Fix `@field:Json` parameters annotations always taking precedence

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/PropertyGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/PropertyGenerator.kt
@@ -26,7 +26,7 @@ internal class PropertyGenerator(
   val isTransient: Boolean = false
 ) {
   val name = target.name
-  val jsonName = target.jsonName
+  val jsonName = target.jsonName ?: target.name
   val hasDefault = target.hasDefault
 
   lateinit var localName: String

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/TargetParameter.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/TargetParameter.kt
@@ -22,6 +22,6 @@ internal data class TargetParameter(
   val name: String,
   val index: Int,
   val hasDefault: Boolean,
-  val jsonName: String = name,
+  val jsonName: String? = null,
   val qualifiers: Set<AnnotationSpec>? = null
 )

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/TargetProperty.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/TargetProperty.kt
@@ -24,7 +24,7 @@ internal data class TargetProperty(
   val propertySpec: PropertySpec,
   val parameter: TargetParameter?,
   val visibility: KModifier,
-  val jsonName: String
+  val jsonName: String?
 ) {
   val name: String get() = propertySpec.name
   val type: TypeName get() = propertySpec.type

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
@@ -77,7 +77,7 @@ internal fun primaryConstructor(kotlinApi: TypeSpec, elements: Elements): Target
         index = index,
         hasDefault = parameter.defaultValue != null,
         qualifiers = parameter.annotations.qualifiers(elements),
-        jsonName = parameter.annotations.jsonName() ?: name.escapeDollarSigns()
+        jsonName = parameter.annotations.jsonName()
     )
   }
 

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -1126,14 +1126,32 @@ class GeneratedAdaptersTest {
   }
 
   @JsonClass(generateAdapter = true)
-  class InternalPropertyWithoutBackingField  {
+  class InternalPropertyWithoutBackingField {
 
     @Transient
     private var foo: Int = 5
 
     internal var bar
       get() = foo
-      set(f) { foo = f}
+      set(f) {
+        foo = f
+      }
+  }
+
+  @JsonClass(generateAdapter = true)
+  data class ClassWithFieldJson(
+      @field:Json(name = "_links") val links: String
+  ) {
+    @field:Json(name = "_ids") var ids: String? = null
+  }
+
+  // Regression test to ensure annotations with field site targets still use the right name
+  @Test fun classWithFieldJsonTargets() {
+    val moshi = Moshi.Builder().build()
+    val adapter = moshi.adapter<ClassWithFieldJson>()
+    //language=JSON
+    val instance = adapter.fromJson("""{"_links": "link", "_ids": "id" }""")!!
+    assertThat(instance).isEqualTo(ClassWithFieldJson("link").apply { ids = "id" })
   }
 }
 


### PR DESCRIPTION
This fixes an issue for an edge case where parameter `@Json` annotations defined with `@field:` site targets always use the parameter name rather than the actual Json `name` annotation value for the property. With `field:` site targets, this annotation would only come up in reading the property annotations.

This would happen because the `TargetParameter#jsonName` property would default to the parameter name. While the `TargetProperty` annotations later would have the correct value, it would yield to the parameter every time since it said it had a value (it only checked nullability, even though the property wasn't nullable!). This fixes that by just denoting an absent `@Json` name definition by making the `jsonName` properties in both target classes nullable, and only falling back to the property name at the end usage in the `PropertyGenerator`.

This doesn't cover cases where property and field possible both have the same annotation with different values assigned, but that's a significant enough change to be worth handling separately.