### PR TITLE
added test for internal property without backing field (#921)

### DIFF
--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -1081,6 +1081,27 @@ class GeneratedAdaptersTest {
       assertThat(e).hasMessageContaining("Failed to find the generated JsonAdapter class")
     }
   }
+
+  // https://github.com/square/moshi/issues/921
+  @Test fun internalPropertyWithoutBackingField() {
+    val adapter = moshi.adapter<InternalPropertyWithoutBackingField>()
+
+    val test = InternalPropertyWithoutBackingField()
+    assertThat(adapter.toJson(test)).isEqualTo("""{"bar":5}""")
+
+    assertThat(adapter.fromJson("""{"bar":6}""")!!.bar).isEqualTo(6)
+  }
+
+  @JsonClass(generateAdapter = true)
+  class InternalPropertyWithoutBackingField  {
+
+    @Transient
+    private var foo: Int = 5
+
+    internal var bar
+      get() = foo
+      set(f) { foo = f}
+  }
 }
 
 // Has to be outside to avoid Types seeing an owning class


### PR DESCRIPTION
Test for #921, the fix for the bug seems to be part of #903 