### PR TITLE
Fix TypeVariable/WildcardType recursion causing stackoverflows

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/Types.java
+++ b/moshi/src/main/java/com/squareup/moshi/Types.java
@@ -139,7 +139,13 @@ public final class Types {
    * ? extends Object}.
    */
   public static WildcardType subtypeOf(Type bound) {
-    return new WildcardTypeImpl(new Type[] { bound }, EMPTY_TYPE_ARRAY);
+    Type[] upperBounds;
+    if (bound instanceof WildcardType) {
+      upperBounds = ((WildcardType) bound).getUpperBounds();
+    } else {
+      upperBounds = new Type[] { bound };
+    }
+    return new WildcardTypeImpl(upperBounds, EMPTY_TYPE_ARRAY);
   }
 
   /**
@@ -147,7 +153,13 @@ public final class Types {
    * bound} is {@code String.class}, this returns {@code ? super String}.
    */
   public static WildcardType supertypeOf(Type bound) {
-    return new WildcardTypeImpl(new Type[] { Object.class }, new Type[] { bound });
+    Type[] lowerBounds;
+    if (bound instanceof WildcardType) {
+      lowerBounds = ((WildcardType) bound).getLowerBounds();
+    } else {
+      lowerBounds = new Type[] { bound };
+    }
+    return new WildcardTypeImpl(new Type[] { Object.class }, lowerBounds);
   }
 
   public static Class<?> getRawType(Type type) {

--- a/moshi/src/main/java/com/squareup/moshi/internal/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/Util.java
@@ -33,7 +33,9 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -169,17 +171,29 @@ public final class Util {
   }
 
   public static Type resolve(Type context, Class<?> contextRawType, Type toResolve) {
+    return resolve(context, contextRawType, toResolve, new HashSet<TypeVariable>());
+  }
+
+  private static Type resolve(Type context, Class<?> contextRawType, Type toResolve,
+      Collection<TypeVariable> visitedTypeVariables) {
     // This implementation is made a little more complicated in an attempt to avoid object-creation.
     while (true) {
       if (toResolve instanceof TypeVariable) {
         TypeVariable<?> typeVariable = (TypeVariable<?>) toResolve;
+        if (visitedTypeVariables.contains(typeVariable)) {
+          // cannot reduce due to infinite recursion
+          return toResolve;
+        } else {
+          visitedTypeVariables.add(typeVariable);
+        }
         toResolve = resolveTypeVariable(context, contextRawType, typeVariable);
         if (toResolve == typeVariable) return toResolve;
 
       } else if (toResolve instanceof Class && ((Class<?>) toResolve).isArray()) {
         Class<?> original = (Class<?>) toResolve;
         Type componentType = original.getComponentType();
-        Type newComponentType = resolve(context, contextRawType, componentType);
+        Type newComponentType = resolve(context, contextRawType, componentType,
+            visitedTypeVariables);
         return componentType == newComponentType
             ? original
             : arrayOf(newComponentType);
@@ -187,7 +201,8 @@ public final class Util {
       } else if (toResolve instanceof GenericArrayType) {
         GenericArrayType original = (GenericArrayType) toResolve;
         Type componentType = original.getGenericComponentType();
-        Type newComponentType = resolve(context, contextRawType, componentType);
+        Type newComponentType = resolve(context, contextRawType, componentType,
+            visitedTypeVariables);
         return componentType == newComponentType
             ? original
             : arrayOf(newComponentType);
@@ -195,12 +210,13 @@ public final class Util {
       } else if (toResolve instanceof ParameterizedType) {
         ParameterizedType original = (ParameterizedType) toResolve;
         Type ownerType = original.getOwnerType();
-        Type newOwnerType = resolve(context, contextRawType, ownerType);
+        Type newOwnerType = resolve(context, contextRawType, ownerType, visitedTypeVariables);
         boolean changed = newOwnerType != ownerType;
 
         Type[] args = original.getActualTypeArguments();
         for (int t = 0, length = args.length; t < length; t++) {
-          Type resolvedTypeArgument = resolve(context, contextRawType, args[t]);
+          Type resolvedTypeArgument = resolve(context, contextRawType, args[t],
+              visitedTypeVariables);
           if (resolvedTypeArgument != args[t]) {
             if (!changed) {
               args = args.clone();
@@ -220,12 +236,14 @@ public final class Util {
         Type[] originalUpperBound = original.getUpperBounds();
 
         if (originalLowerBound.length == 1) {
-          Type lowerBound = resolve(context, contextRawType, originalLowerBound[0]);
+          Type lowerBound = resolve(context, contextRawType, originalLowerBound[0],
+              visitedTypeVariables);
           if (lowerBound != originalLowerBound[0]) {
             return supertypeOf(lowerBound);
           }
         } else if (originalUpperBound.length == 1) {
-          Type upperBound = resolve(context, contextRawType, originalUpperBound[0]);
+          Type upperBound = resolve(context, contextRawType, originalUpperBound[0],
+              visitedTypeVariables);
           if (upperBound != originalUpperBound[0]) {
             return subtypeOf(upperBound);
           }

--- a/moshi/src/test/java/com/squareup/moshi/RecursiveTypesResolveTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/RecursiveTypesResolveTest.java
@@ -46,7 +46,7 @@ public final class RecursiveTypesResolveTest {
   /**
    * Test simplest case of recursion.
    */
-  @Test public void testRecursiveResolveSimple() {
+  @Test public void recursiveResolveSimple() {
     JsonAdapter<Foo1> adapter = new Moshi.Builder().build().adapter(Foo1.class);
     assertNotNull(adapter);
   }
@@ -55,22 +55,22 @@ public final class RecursiveTypesResolveTest {
   // Tests belows check the behaviour of the methods changed for the fix
   //
 
-  @Test public void testDoubleSupertype() {
+  @Test public void doubleSupertype() {
     assertEquals(Types.supertypeOf(Number.class),
             Types.supertypeOf(Types.supertypeOf(Number.class)));
   }
 
-  @Test public void testDoubleSubtype() {
+  @Test public void doubleSubtype() {
     assertEquals(Types.subtypeOf(Number.class),
             Types.subtypeOf(Types.subtypeOf(Number.class)));
   }
 
-  @Test public void testSuperSubtype() {
+  @Test public void superSubtype() {
     assertEquals(Types.subtypeOf(Object.class),
             Types.supertypeOf(Types.subtypeOf(Number.class)));
   }
 
-  @Test public void testSubSupertype() {
+  @Test public void subSupertype() {
     assertEquals(Types.subtypeOf(Object.class),
             Types.subtypeOf(Types.supertypeOf(Number.class)));
   }

--- a/moshi/src/test/java/com/squareup/moshi/RecursiveTypesResolveTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/RecursiveTypesResolveTest.java
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-package com.squareup.moshi.internal;
+package com.squareup.moshi;
 
-import com.squareup.moshi.JsonAdapter;
-import com.squareup.moshi.Moshi;
-import com.squareup.moshi.Types;
+import com.squareup.moshi.internal.Util;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/moshi/src/test/java/com/squareup/moshi/TypesTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/TypesTest.java
@@ -321,6 +321,39 @@ public final class TypesTest {
     }
   }
 
+  //
+  // Regression tests for https://github.com/square/moshi/issues/338
+  //
+  // Adapted from https://github.com/google/gson/pull/1128
+  //
+
+  private static final class RecursiveTypeVars<T> {
+    RecursiveTypeVars<? super T> superType;
+  }
+
+  @Test public void recursiveTypeVariablesResolve() {
+    new Moshi.Builder().build().adapter(Types
+        .newParameterizedTypeWithOwner(TypesTest.class, RecursiveTypeVars.class, String.class));
+  }
+
+  @Test public void testRecursiveTypeVariablesResolve1() {
+    JsonAdapter<TestType> adapter = new Moshi.Builder().build().adapter(TestType.class);
+    assertThat(adapter).isNotNull();
+  }
+
+  @Test public void testRecursiveTypeVariablesResolve12() {
+    JsonAdapter<TestType2> adapter = new Moshi.Builder().build().adapter(TestType2.class);
+    assertThat(adapter).isNotNull();
+  }
+
+  private static class TestType<X> {
+    TestType<? super X> superType;
+  }
+
+  private static class TestType2<X, Y> {
+    TestType2<? super Y, ? super X> superReversedType;
+  }
+
   @JsonClass(generateAdapter = false)
   static class TestJsonClass {
 

--- a/moshi/src/test/java/com/squareup/moshi/TypesTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/TypesTest.java
@@ -337,12 +337,12 @@ public final class TypesTest {
     assertThat(adapter).isNotNull();
   }
 
-  @Test public void testRecursiveTypeVariablesResolve1() {
+  @Test public void recursiveTypeVariablesResolve1() {
     JsonAdapter<TestType> adapter = new Moshi.Builder().build().adapter(TestType.class);
     assertThat(adapter).isNotNull();
   }
 
-  @Test public void testRecursiveTypeVariablesResolve12() {
+  @Test public void recursiveTypeVariablesResolve12() {
     JsonAdapter<TestType2> adapter = new Moshi.Builder().build().adapter(TestType2.class);
     assertThat(adapter).isNotNull();
   }

--- a/moshi/src/test/java/com/squareup/moshi/TypesTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/TypesTest.java
@@ -342,7 +342,7 @@ public final class TypesTest {
     assertThat(adapter).isNotNull();
   }
 
-  @Test public void recursiveTypeVariablesResolve12() {
+  @Test public void recursiveTypeVariablesResolve2() {
     JsonAdapter<TestType2> adapter = new Moshi.Builder().build().adapter(TestType2.class);
     assertThat(adapter).isNotNull();
   }

--- a/moshi/src/test/java/com/squareup/moshi/TypesTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/TypesTest.java
@@ -332,8 +332,9 @@ public final class TypesTest {
   }
 
   @Test public void recursiveTypeVariablesResolve() {
-    new Moshi.Builder().build().adapter(Types
+    JsonAdapter<RecursiveTypeVars<String>> adapter = new Moshi.Builder().build().adapter(Types
         .newParameterizedTypeWithOwner(TypesTest.class, RecursiveTypeVars.class, String.class));
+    assertThat(adapter).isNotNull();
   }
 
   @Test public void testRecursiveTypeVariablesResolve1() {

--- a/moshi/src/test/java/com/squareup/moshi/internal/RecursiveTypesResolveTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/internal/RecursiveTypesResolveTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2017 Gson Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.moshi.internal;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import com.squareup.moshi.Types;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test fixes for infinite recursion on {@link Util#resolve(java.lang.reflect.Type, Class,
+ * java.lang.reflect.Type)}, described at <a href="https://github.com/google/gson/issues/440">Issue #440</a>
+ * and similar issues.
+ * <p>
+ * These tests originally caused {@link StackOverflowError} because of infinite recursion on attempts to
+ * resolve generics on types, with an intermediate types like 'Foo2&lt;? extends ? super ? extends ... ? extends A&gt;'
+ * <p>
+ * Adapted from https://github.com/google/gson/commit/a300148003e3a067875b1444e8268b6e0f0e0e02 in
+ * service of https://github.com/square/moshi/issues/338.
+ */
+public final class RecursiveTypesResolveTest {
+
+  private static class Foo1<A> {
+    public Foo2<? extends A> foo2;
+  }
+
+  private static class Foo2<B> {
+    public Foo1<? super B> foo1;
+  }
+
+  /**
+   * Test simplest case of recursion.
+   */
+  @Test public void testRecursiveResolveSimple() {
+    JsonAdapter<Foo1> adapter = new Moshi.Builder().build().adapter(Foo1.class);
+    assertNotNull(adapter);
+  }
+
+  //
+  // Tests belows check the behaviour of the methods changed for the fix
+  //
+
+  @Test public void testDoubleSupertype() {
+    assertEquals(Types.supertypeOf(Number.class),
+            Types.supertypeOf(Types.supertypeOf(Number.class)));
+  }
+
+  @Test public void testDoubleSubtype() {
+    assertEquals(Types.subtypeOf(Number.class),
+            Types.subtypeOf(Types.subtypeOf(Number.class)));
+  }
+
+  @Test public void testSuperSubtype() {
+    assertEquals(Types.subtypeOf(Object.class),
+            Types.supertypeOf(Types.subtypeOf(Number.class)));
+  }
+
+  @Test public void testSubSupertype() {
+    assertEquals(Types.subtypeOf(Object.class),
+            Types.subtypeOf(Types.supertypeOf(Number.class)));
+  }
+}


### PR DESCRIPTION
This fixes two related issues, one documented in #338. Both cases are solved borrowing the Gson solutions for them, since all the code/logic around wildcard types for them are borrowed from them as well.

The first is fixing recursion in `Util#sub/supertypeOf` using the solution from https://github.com/google/gson/commit/a300148003e3a067875b1444e8268b6e0f0e0e02. This is a bugfix itself, but also necessary for the next issue.

The second is fixing recursion in `Types#resolve()` by tracking previously visited type variables using the solution from https://github.com/google/gson/pull/1128

Resolves #338 