### PR TITLE
Refactor ClassFactory to avoid trying certain APIs on known android versions that don't support them

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
@@ -109,7 +109,8 @@ abstract class ClassFactory<T> {
         newInstance.setAccessible(true);
         return new ClassFactory<T>() {
           @SuppressWarnings("unchecked")
-          @Override public T newInstance() throws InvocationTargetException, IllegalAccessException {
+          @Override
+          public T newInstance() throws InvocationTargetException, IllegalAccessException {
             return (T) newInstance.invoke(null, rawType, constructorId);
           }
           @Override public String toString() {
@@ -138,7 +139,8 @@ abstract class ClassFactory<T> {
         newInstance.setAccessible(true);
         return new ClassFactory<T>() {
           @SuppressWarnings("unchecked")
-          @Override public T newInstance() throws InvocationTargetException, IllegalAccessException {
+          @Override
+          public T newInstance() throws InvocationTargetException, IllegalAccessException {
             return (T) newInstance.invoke(null, rawType, Object.class);
           }
           @Override public String toString() {

--- a/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
@@ -126,25 +126,27 @@ abstract class ClassFactory<T> {
 
     }
 
-    // Try (pre-Gingerbread) Dalvik/libcore's ObjectInputStream mechanism.
-    // public class ObjectInputStream {
-    //   private static native Object newInstance(
-    //     Class<?> instantiationClass, Class<?> constructorClass);
-    // }
-    try {
-      final Method newInstance = ObjectInputStream.class.getDeclaredMethod(
-          "newInstance", Class.class, Class.class);
-      newInstance.setAccessible(true);
-      return new ClassFactory<T>() {
-        @SuppressWarnings("unchecked")
-        @Override public T newInstance() throws InvocationTargetException, IllegalAccessException {
-          return (T) newInstance.invoke(null, rawType, Object.class);
-        }
-        @Override public String toString() {
-          return rawType.getName();
-        }
-      };
-    } catch (Exception ignored) {
+    if (!isAndroidSdkAtLeast(10)) {
+      // Try (pre-Gingerbread) Dalvik/libcore's ObjectInputStream mechanism.
+      // public class ObjectInputStream {
+      //   private static native Object newInstance(
+      //     Class<?> instantiationClass, Class<?> constructorClass);
+      // }
+      try {
+        final Method newInstance = ObjectInputStream.class.getDeclaredMethod(
+            "newInstance", Class.class, Class.class);
+        newInstance.setAccessible(true);
+        return new ClassFactory<T>() {
+          @SuppressWarnings("unchecked")
+          @Override public T newInstance() throws InvocationTargetException, IllegalAccessException {
+            return (T) newInstance.invoke(null, rawType, Object.class);
+          }
+          @Override public String toString() {
+            return rawType.getName();
+          }
+        };
+      } catch (Exception ignored) {
+      }
     }
 
     throw new IllegalArgumentException("cannot construct instances of " + rawType.getName());

--- a/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
@@ -60,7 +60,7 @@ abstract class ClassFactory<T> {
     }
 
     if (!androidChecked && isAndroid()) {
-      tryUnsafe = !isAndroidSdkAtLeast(29);
+      tryUnsafe = isBelowAndroidApi(29);
     }
     if (tryUnsafe) {
       // Try the JVM's Unsafe mechanism.
@@ -90,7 +90,7 @@ abstract class ClassFactory<T> {
       }
     }
 
-    if (!isAndroidSdkAtLeast(28)) {
+    if (isBelowAndroidApi(28)) {
       // Try (post-Gingerbread) Dalvik/libcore's ObjectStreamClass mechanism.
       // public class ObjectStreamClass {
       //   private static native int getConstructorId(Class<?> c);
@@ -126,7 +126,7 @@ abstract class ClassFactory<T> {
 
     }
 
-    if (!isAndroidSdkAtLeast(10)) {
+    if (isBelowAndroidApi(10)) {
       // Try (pre-Gingerbread) Dalvik/libcore's ObjectInputStream mechanism.
       // public class ObjectInputStream {
       //   private static native Object newInstance(
@@ -167,12 +167,12 @@ abstract class ClassFactory<T> {
     return isAndroid;
   }
 
-  private static boolean isAndroidSdkAtLeast(int target) {
+  private static boolean isBelowAndroidApi(int target) {
     if (isAndroid()) {
       int sdk = androidSdkInt;
-      return sdk != -1 && sdk >= target;
+      return sdk == -1 || sdk < target;
     } else {
-      return true;
+      return false;
     }
   }
 }

--- a/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
@@ -34,10 +34,10 @@ abstract class ClassFactory<T> {
   abstract T newInstance() throws
       InvocationTargetException, IllegalAccessException, InstantiationException;
 
-  private static volatile boolean tryUnsafe = true;
-  private static volatile int androidSdkInt = -1;
-  private static volatile boolean isInitialized = false;
   private static final Object INIT_LOCK = new Object();
+  private static volatile boolean isInitialized = false;
+  private static boolean tryUnsafe = true;
+  private static int androidSdkInt = -1;
 
   private static void initMagicChecks() {
     if (isInitialized) {

--- a/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
@@ -141,7 +141,6 @@ abstract class ClassFactory<T> {
       } catch (NoSuchMethodException ignored) {
         // Not the expected version of Dalvik/libcore!
       }
-
     }
 
     if (isRunningOnAndroidSdkVersionLowerThan(10)) {
@@ -168,7 +167,12 @@ abstract class ClassFactory<T> {
       }
     }
 
-    throw new IllegalArgumentException("cannot construct instances of " + rawType.getName());
+    String message = "Cannot construct instances of " + rawType.getName();
+    if (androidSdkInt >= 28) {
+      message = message + ". An empty constructor is required for reflective instantiation on Android API 28+. Detected version is " + androidSdkInt + ".";
+    }
+
+    throw new IllegalArgumentException(message);
   }
 
   private static boolean isRunningOnAndroidSdkVersionLowerThan(int target) {

--- a/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
@@ -169,7 +169,8 @@ abstract class ClassFactory<T> {
 
     String message = "Cannot construct instances of " + rawType.getName();
     if (androidSdkInt >= 28) {
-      message = message + ". An empty constructor is required for reflective instantiation on Android API 28+. Detected version is " + androidSdkInt + ".";
+      message = message + ". An empty constructor is required for reflective instantiation on "
+          + "Android API 28+. Detected version is " + androidSdkInt + ".";
     }
 
     throw new IllegalArgumentException(message);

--- a/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassFactory.java
@@ -107,7 +107,7 @@ abstract class ClassFactory<T> {
       }
     }
 
-    if (isBelowAndroidApi(28)) {
+    if (isRunningOnAndroidSdkVersionLowerThan(28)) {
       // Try (post-Gingerbread) Dalvik/libcore's ObjectStreamClass mechanism.
       // public class ObjectStreamClass {
       //   private static native int getConstructorId(Class<?> c);
@@ -144,7 +144,7 @@ abstract class ClassFactory<T> {
 
     }
 
-    if (isBelowAndroidApi(10)) {
+    if (isRunningOnAndroidSdkVersionLowerThan(10)) {
       // Try (pre-Gingerbread) Dalvik/libcore's ObjectInputStream mechanism.
       // public class ObjectInputStream {
       //   private static native Object newInstance(
@@ -171,7 +171,7 @@ abstract class ClassFactory<T> {
     throw new IllegalArgumentException("cannot construct instances of " + rawType.getName());
   }
 
-  private static boolean isBelowAndroidApi(int target) {
+  private static boolean isRunningOnAndroidSdkVersionLowerThan(int target) {
     int sdk = androidSdkInt;
     return sdk == -1 || sdk < target;
   }


### PR DESCRIPTION
This improves the android support in `ClassFactory` to not try grey-listed reflection APIs on 28+, and also gates gingerbread-only APIs to only try below API 10. This leverages some of the prior android support we'd added to support it.

Resolves #949, sort of. The workaround posted in it is the right solution, this just makes it not try something we know won't work.