### PR TITLE
Implement JsonReader#valueSource()

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -432,6 +432,14 @@ public abstract class JsonReader implements Closeable {
   public abstract void skipValue() throws IOException;
 
   /**
+   * Reads the next value recursively into a {@link BufferedSource}. If it is an object or array,
+   * all nested elements are read into the source as well. This method is intended for use when the
+   * JSON token stream contains custom data that the caller wants to read bytes directly off of the
+   * underlying buffer.
+   */
+  public abstract BufferedSource valueSource() throws IOException;
+
+  /**
    * Returns the value of the next token, consuming it. The result may be a string, number, boolean,
    * null, map, or list, according to the JSON structure.
    *

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -243,6 +243,14 @@ public abstract class JsonReader implements Closeable {
     }
   }
 
+  /** Returns the scope on the top of the stack. */
+  final int peekScope() {
+    if (stackSize == 0) {
+      throw new IllegalStateException("JsonReader is closed.");
+    }
+    return scopes[stackSize - 1];
+  }
+
   /**
    * Configure this parser to be liberal in what it accepts. By default
    * this parser is strict and only accepts JSON as specified by <a

--- a/moshi/src/main/java/com/squareup/moshi/JsonScope.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonScope.java
@@ -44,6 +44,9 @@ final class JsonScope {
   /** A document that's been closed and cannot be accessed. */
   static final int CLOSED = 8;
 
+  /** Sits above the actual state to indicate that a value is currently being streamed in. */
+  static final int STREAMING_VALUE = 9;
+
   /**
    * Renders the path in a JSON document to a string. The {@code pathNames} and {@code pathIndices}
    * parameters corresponds directly to stack: At indices where the stack contains an object

--- a/moshi/src/main/java/com/squareup/moshi/JsonUtf8Reader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonUtf8Reader.java
@@ -959,6 +959,9 @@ final class JsonUtf8Reader extends JsonReader {
   }
 
   @Override public void close() throws IOException {
+    if (peekScope() == STREAMING_VALUE) {
+      throw new IllegalStateException("Sink from valueSource() was not closed");
+    }
     peeked = PEEKED_NONE;
     scopes[0] = JsonScope.CLOSED;
     stackSize = 1;

--- a/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
@@ -22,8 +22,14 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import okio.Buffer;
+import okio.BufferedSource;
+import okio.Okio;
+import okio.Source;
+import okio.Timeout;
 
 import static com.squareup.moshi.JsonScope.CLOSED;
+import static com.squareup.moshi.JsonScope.STREAMING_VALUE;
 
 /**
  * This class reads a JSON document by traversing a Java object comprising maps, lists, and JSON
@@ -299,6 +305,79 @@ final class JsonValueReader extends JsonReader {
     return result;
   }
 
+  @Override public BufferedSource valueSource() {
+    Object peeked = stackSize != 0 ? stack[stackSize - 1] : null;
+    pushScope(STREAMING_VALUE);
+    final Buffer buffer = new Buffer();
+    writeValueToBuffer(peeked, buffer);
+    return Okio.buffer(new Source() {
+      @Override public long read(Buffer sink, long byteCount) {
+        return buffer.read(sink, byteCount);
+      }
+
+      @Override public Timeout timeout() {
+        return Timeout.NONE;
+      }
+
+      @Override public void close() {
+        if (peekScope() != STREAMING_VALUE) {
+          throw new AssertionError();
+        }
+        remove();
+      }
+    });
+  }
+
+  private void writeValueToBuffer(@Nullable Object value, Buffer buffer) {
+    if (value == null) {
+      buffer.writeUtf8("null");
+    } else if (value instanceof Boolean) {
+      buffer.writeUtf8(Boolean.toString((Boolean) value));
+    } else if (value instanceof Number) {
+      // These are always written as doubles when parsing JSON value objects.
+      if (value instanceof Integer) {
+        buffer.writeUtf8(Integer.toString((Integer) value));
+      } else if (value instanceof Long) {
+        buffer.writeUtf8(Long.toString((Long) value));
+      } else if (value instanceof Double) {
+        buffer.writeUtf8(Double.toString((Double) value));
+      } else {
+        buffer.writeUtf8(value.toString());
+      }
+    } else if (value instanceof String) {
+      buffer.writeByte('\"');
+      buffer.writeUtf8((String) value);
+      buffer.writeByte('\"');
+    } else if (value instanceof List) {
+      buffer.writeUtf8("[");
+      boolean first = true;
+      for (Object element : ((List) value)) {
+        if (first) {
+          first = false;
+        } else {
+          buffer.writeUtf8(",");
+        }
+        writeValueToBuffer(element, buffer);
+      }
+      buffer.writeUtf8("]");
+    } else if (value instanceof Map) {
+      buffer.writeUtf8("{");
+      boolean first = true;
+      //noinspection unchecked
+      for (Map.Entry<String, ?> entry : ((Map<String, ?>) value).entrySet()) {
+        if (first) {
+          first = false;
+        } else {
+          buffer.writeUtf8(",");
+        }
+        writeValueToBuffer(entry.getKey(), buffer);
+        buffer.writeUtf8(":");
+        writeValueToBuffer(entry.getValue(), buffer);
+      }
+      buffer.writeUtf8("}");
+    }
+  }
+
   @Override public void skipValue() throws IOException {
     if (failOnUnknown) {
       throw new JsonDataException("Cannot skip unexpected " + peek() + " at " + getPath());
@@ -386,7 +465,7 @@ final class JsonValueReader extends JsonReader {
    * Removes a value and prepares for the next. If we're iterating a map or list this advances the
    * iterator.
    */
-  private void remove() {
+  void remove() {
     stackSize--;
     stack[stackSize] = null;
     scopes[stackSize] = 0;

--- a/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
@@ -417,6 +417,9 @@ final class JsonValueReader extends JsonReader {
   }
 
   @Override public void close() throws IOException {
+    if (peekScope() == STREAMING_VALUE) {
+      throw new IllegalStateException("Sink from valueSource() was not closed");
+    }
     Arrays.fill(stack, 0, stackSize, null);
     stack[0] = JSON_READER_CLOSED;
     scopes[0] = CLOSED;

--- a/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
@@ -1264,7 +1264,7 @@ public final class JsonUtf8ReaderTest {
     //language=JSON
     JsonReader reader = newReader("{\"a\":\"this is a string\"}");
     reader.beginObject();
-    reader.nextName();
+    String name = reader.nextName();
     BufferedSource valueSource = reader.valueSource();
     String readStringValue = valueSource.readUtf8();
     valueSource.close();
@@ -1275,7 +1275,7 @@ public final class JsonUtf8ReaderTest {
     //language=JSON
     JsonReader reader = newReader("{\"a\":-2}");
     reader.beginObject();
-    reader.nextName();
+    String name = reader.nextName();
     BufferedSource valueSource = reader.valueSource();
     String readStringValue = valueSource.readUtf8();
     valueSource.close();
@@ -1286,7 +1286,7 @@ public final class JsonUtf8ReaderTest {
     //language=JSON
     JsonReader reader = newReader("{\"a\":{\"b\":2,\"c\":3}}");
     reader.beginObject();
-    reader.nextName();
+    String name = reader.nextName();
     BufferedSource valueSource = reader.valueSource();
     String readStringValue = valueSource.readUtf8();
     valueSource.close();
@@ -1298,7 +1298,7 @@ public final class JsonUtf8ReaderTest {
     //language=JSON
     JsonReader reader = newReader("{\"a\":[2,2,3]}");
     reader.beginObject();
-    reader.nextName();
+    String name = reader.nextName();
     BufferedSource valueSource = reader.valueSource();
     String readStringValue = valueSource.readUtf8();
     valueSource.close();
@@ -1310,7 +1310,7 @@ public final class JsonUtf8ReaderTest {
     //language=JSON
     JsonReader reader = newReader("{\n" + "  " + "\"a\": -2\n" + "}");
     reader.beginObject();
-    reader.nextName();
+    String name = reader.nextName();
     BufferedSource valueSource = reader.valueSource();
     String readStringValue = valueSource.readUtf8();
     valueSource.close();
@@ -1326,7 +1326,7 @@ public final class JsonUtf8ReaderTest {
         + "  }\n"
         + "}");
     reader.beginObject();
-    reader.nextName();
+    String name = reader.nextName();
     BufferedSource valueSource = reader.valueSource();
     String readStringValue = valueSource.readUtf8();
     valueSource.close();

--- a/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
@@ -19,6 +19,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.util.Arrays;
 import okio.Buffer;
+import okio.BufferedSource;
 import okio.ForwardingSource;
 import okio.Okio;
 import org.junit.Ignore;
@@ -1257,6 +1258,80 @@ public final class JsonUtf8ReaderTest {
     reader.setLenient(true);
     reader.beginArray();
     assertThat(reader.nextString()).isEqualTo("string");
+  }
+
+  @Test public void valueSourceString() throws IOException {
+    //language=JSON
+    JsonReader reader = newReader("{\"a\":\"this is a string\"}");
+    reader.beginObject();
+    reader.nextName();
+    BufferedSource valueSource = reader.valueSource();
+    String readStringValue = valueSource.readUtf8();
+    valueSource.close();
+    assertEquals("\"this is a string\"", readStringValue);
+  }
+
+  @Test public void valueSourceLong() throws IOException {
+    //language=JSON
+    JsonReader reader = newReader("{\"a\":-2}");
+    reader.beginObject();
+    reader.nextName();
+    BufferedSource valueSource = reader.valueSource();
+    String readStringValue = valueSource.readUtf8();
+    valueSource.close();
+    assertEquals(-2, Integer.parseInt(readStringValue));
+  }
+
+  @Test public void valueSourceObject() throws IOException {
+    //language=JSON
+    JsonReader reader = newReader("{\"a\":{\"b\":2,\"c\":3}}");
+    reader.beginObject();
+    reader.nextName();
+    BufferedSource valueSource = reader.valueSource();
+    String readStringValue = valueSource.readUtf8();
+    valueSource.close();
+    //language=JSON
+    assertEquals("{\"b\":2,\"c\":3}", readStringValue);
+  }
+
+  @Test public void valueSourceArray() throws IOException {
+    //language=JSON
+    JsonReader reader = newReader("{\"a\":[2,2,3]}");
+    reader.beginObject();
+    reader.nextName();
+    BufferedSource valueSource = reader.valueSource();
+    String readStringValue = valueSource.readUtf8();
+    valueSource.close();
+    //language=JSON
+    assertEquals("[2,2,3]", readStringValue);
+  }
+
+  @Test public void valueSourceLong_WithWhitespace() throws IOException {
+    //language=JSON
+    JsonReader reader = newReader("{\n" + "  " + "\"a\": -2\n" + "}");
+    reader.beginObject();
+    reader.nextName();
+    BufferedSource valueSource = reader.valueSource();
+    String readStringValue = valueSource.readUtf8();
+    valueSource.close();
+    assertEquals(-2, Integer.parseInt(readStringValue));
+  }
+
+  @Test public void valueSourceObject_withWhitespace() throws IOException {
+    //language=JSON
+    JsonReader reader = newReader("{\n"
+        + "  \"a\": {\n"
+        + "    \"b\": 2,\n"
+        + "    \"c\": 3\n"
+        + "  }\n"
+        + "}");
+    reader.beginObject();
+    reader.nextName();
+    BufferedSource valueSource = reader.valueSource();
+    String readStringValue = valueSource.readUtf8();
+    valueSource.close();
+    //language=JSON
+    assertEquals("{\n" + "    \"b\": 2,\n" + "    \"c\": 3\n" + "  }", readStringValue);
   }
 
   private void assertDocument(String document, Object... expectations) throws IOException {

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
@@ -481,7 +481,7 @@ public final class JsonValueReaderTest {
     map.put("a", "this is a string");
     JsonReader reader = new JsonValueReader(map);
     reader.beginObject();
-    reader.nextName();
+    String name = reader.nextName();
     BufferedSource valueSource = reader.valueSource();
     String readStringValue = valueSource.readUtf8();
     valueSource.close();
@@ -493,7 +493,7 @@ public final class JsonValueReaderTest {
     map.put("a", -2);
     JsonReader reader = new JsonValueReader(map);
     reader.beginObject();
-    reader.nextName();
+    String name = reader.nextName();
     BufferedSource valueSource = reader.valueSource();
     String readStringValue = valueSource.readUtf8();
     valueSource.close();
@@ -508,7 +508,7 @@ public final class JsonValueReaderTest {
     map.put("a", nested);
     JsonReader reader = new JsonValueReader(map);
     reader.beginObject();
-    reader.nextName();
+    String name = reader.nextName();
     BufferedSource valueSource = reader.valueSource();
     String readStringValue = valueSource.readUtf8();
     valueSource.close();
@@ -521,7 +521,7 @@ public final class JsonValueReaderTest {
     map.put("a", Arrays.asList(2, 2, 3));
     JsonReader reader = new JsonValueReader(map);
     reader.beginObject();
-    reader.nextName();
+    String name = reader.nextName();
     BufferedSource valueSource = reader.valueSource();
     String readStringValue = valueSource.readUtf8();
     valueSource.close();

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import okio.BufferedSource;
 import org.junit.Test;
 
 import static com.squareup.moshi.TestUtil.MAX_DEPTH;
@@ -29,6 +30,7 @@ import static com.squareup.moshi.TestUtil.repeat;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public final class JsonValueReaderTest {
@@ -472,5 +474,58 @@ public final class JsonValueReaderTest {
     } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Nesting too deep at $" + repeat(".a", MAX_DEPTH) + ".");
     }
+  }
+
+  @Test public void valueSourceString() throws IOException {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("a", "this is a string");
+    JsonReader reader = new JsonValueReader(map);
+    reader.beginObject();
+    reader.nextName();
+    BufferedSource valueSource = reader.valueSource();
+    String readStringValue = valueSource.readUtf8();
+    valueSource.close();
+    assertEquals("\"this is a string\"", readStringValue);
+  }
+
+  @Test public void valueSourceLong() throws IOException {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("a", -2);
+    JsonReader reader = new JsonValueReader(map);
+    reader.beginObject();
+    reader.nextName();
+    BufferedSource valueSource = reader.valueSource();
+    String readStringValue = valueSource.readUtf8();
+    valueSource.close();
+    assertEquals(-2, Integer.parseInt(readStringValue));
+  }
+
+  @Test public void valueSourceObject() throws IOException {
+    Map<String, Object> nested = new LinkedHashMap<>();
+    nested.put("b", 2);
+    nested.put("c", 3);
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("a", nested);
+    JsonReader reader = new JsonValueReader(map);
+    reader.beginObject();
+    reader.nextName();
+    BufferedSource valueSource = reader.valueSource();
+    String readStringValue = valueSource.readUtf8();
+    valueSource.close();
+    //language=JSON
+    assertEquals("{\"b\":2,\"c\":3}", readStringValue);
+  }
+
+  @Test public void valueSourceArray() throws IOException {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("a", Arrays.asList(2, 2, 3));
+    JsonReader reader = new JsonValueReader(map);
+    reader.beginObject();
+    reader.nextName();
+    BufferedSource valueSource = reader.valueSource();
+    String readStringValue = valueSource.readUtf8();
+    valueSource.close();
+    //language=JSON
+    assertEquals("[2,2,3]", readStringValue);
   }
 }


### PR DESCRIPTION
This is a reader analog for #943. The tests need a bit more fleshing out, but want to start with this for review.

At a high level
- JsonUtf8Reader works by basically replacing `skipValue()` with one that optionally accepts a `Sink`. `skipValue()` calls this method with a black hole, and `valueSource()` calls this with a `Buffer` that the returned `BufferedSource` ultimately consumes. A lot of `skip()`/`readByte()` calls are reworked to defer to this sink, so blackhole behavior just skips under the hood like before and valueSource() keeps the data in its buffer. I don't know if there's a lazier way to push this along though, as right now it eagerly reads the value like skipValue does.
- JsonValueReader works by just emitting utf8 values directly to a buffer that the returned source consumes. One interesting caveat here is that when creating value maps, it always uses doubles for numbers, which could create asymmetric inputs/outputs.

There's probably a couple places these need to check scope in other methods, I'm in unfamiliar territory with this PR so feedback welcome