### PR TITLE
Keep synthesized values() for EnumJsonAdapter

### DIFF
--- a/moshi/src/main/resources/META-INF/proguard/moshi.pro
+++ b/moshi/src/main/resources/META-INF/proguard/moshi.pro
@@ -8,9 +8,11 @@
 -keep @com.squareup.moshi.JsonQualifier interface *
 
 # Enum field names are used by the integrated EnumJsonAdapter.
+# values() is synthesized by the Kotlin compiler and is used by EnumJsonAdapter indirectly
 # Annotate enums with @JsonClass(generateAdapter = false) to use them with Moshi.
 -keepclassmembers @com.squareup.moshi.JsonClass class * extends java.lang.Enum {
     <fields>;
+    **[] values();
 }
 
 # The name of @JsonClass types is used to look up the generated adapter.


### PR DESCRIPTION
Addresses #962 

I removed the function modifiers mentioned in the issue as they didn't seem to be specifically related to the problem at hand. I also added it to the other enum related rule, rather than using the `enum *` matcher.

One less than ideal thing is that it would keep a hand written unused method with the same signature for Java consumers. I suspect that's a small edge case, but if @JakeWharton or others have a suggestion to improve the rule to avoid it, it could be valuable. As far as I can tell the Kotlin compiler doesn't generate a `synthetic` modifier for the generated method, which seems unfortunate.