### PR TITLE
Update to KotlinPoet 1.4.2

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
@@ -18,6 +18,7 @@ package com.squareup.moshi.kotlin.codegen
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
@@ -30,8 +31,10 @@ import com.squareup.kotlinpoet.metadata.isInner
 import com.squareup.kotlinpoet.metadata.isLocal
 import com.squareup.kotlinpoet.metadata.isSealed
 import com.squareup.kotlinpoet.metadata.specs.ClassInspector
+import com.squareup.kotlinpoet.metadata.specs.TypeNameAliasTag
 import com.squareup.kotlinpoet.metadata.specs.toTypeSpec
 import com.squareup.kotlinpoet.metadata.toImmutableKmClass
+import com.squareup.kotlinpoet.tag
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonQualifier
 import com.squareup.moshi.kotlin.codegen.api.DelegateKey
@@ -207,7 +210,8 @@ private fun declaredProperties(
 ): Map<String, TargetProperty> {
 
   val result = mutableMapOf<String, TargetProperty>()
-  for (property in kotlinApi.propertySpecs) {
+  for (initialProperty in kotlinApi.propertySpecs) {
+    val property = initialProperty.toBuilder(type = initialProperty.type.unwrapTypeAlias()).build()
     val name = property.name
     val parameter = constructor.parameters[name]
     result[name] = TargetProperty(
@@ -307,4 +311,8 @@ private fun List<AnnotationSpec>?.jsonName(): String? {
 
 private fun String.escapeDollarSigns(): String {
   return replace("\$", "\${\'\$\'}")
+}
+
+private fun TypeName.unwrapTypeAlias(): TypeName {
+  return tag<TypeNameAliasTag>()?.type ?: this
 }

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -302,6 +302,26 @@ class DualKotlinTest(useReflection: Boolean) {
   class TextAsset : Asset<TextAsset>()
   abstract class Asset<A : Asset<A>>
   abstract class AssetMetaData<A : Asset<A>>
+
+  // Regression test for https://github.com/square/moshi/issues/968
+  @Test fun abstractSuperProperties() {
+    val adapter = moshi.adapter<InternalAbstractProperty>()
+
+    @Language("JSON")
+    val testJson = """{"test":"text"}"""
+
+    assertThat(adapter.toJson(InternalAbstractProperty("text"))).isEqualTo(testJson)
+
+    val result = adapter.fromJson(testJson)!!
+    assertThat(result.test).isEqualTo("text")
+  }
+
+  abstract class InternalAbstractPropertyBase {
+    internal abstract val test: String
+  }
+
+  @JsonClass(generateAdapter = true)
+  class InternalAbstractProperty(override val test: String) : InternalAbstractPropertyBase()
 }
 
 // Has to be outside since inline classes are only allowed on top level

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <okio.version>1.16.0</okio.version>
     <okio2.version>2.1.0</okio2.version>
     <kotlin.version>1.3.50</kotlin.version>
-    <kotlinpoet.version>1.4.1</kotlinpoet.version>
+    <kotlinpoet.version>1.4.2</kotlinpoet.version>
     <kotlinx-metadata.version>0.1.0</kotlinx-metadata.version>
     <maven-assembly.version>3.1.0</maven-assembly.version>
 


### PR DESCRIPTION
Fixes #968 

We have to manually unwrap typealiases now, as kotlinpoet now (correctly) reports the aliases and just leaves a tag to retrieve the underlying type as needed.