### PR TITLE
Fix support for classes w/ multiple constructors in code gen

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -20,6 +20,7 @@ import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.NameAllocator
@@ -31,6 +32,7 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
+import com.squareup.kotlinpoet.joinToCode
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
@@ -48,6 +50,14 @@ internal class AdapterGenerator(
     target: TargetType,
     private val propertyList: List<PropertyGenerator>
 ) {
+
+  companion object {
+    private val DEFAULT_CONSTRUCTOR_EXTRA_PARAMS = arrayOf(
+        CodeBlock.of("%T::class.javaPrimitiveType", INT),
+        CodeBlock.of("%T.DEFAULT_CONSTRUCTOR_MARKER", Util::class)
+    )
+  }
+
   private val nonTransientProperties = propertyList.filterNot { it.isTransient }
   private val className = target.typeName.rawType()
   private val visibility = target.visibility
@@ -56,6 +66,7 @@ internal class AdapterGenerator(
   private val nameAllocator = NameAllocator()
   private val adapterName = "${className.simpleNames.joinToString(separator = "_")}JsonAdapter"
   private val originalTypeName = target.typeName
+  private val originalRawTypeName = originalTypeName.rawType()
 
   private val moshiParam = ParameterSpec.builder(
       nameAllocator.newName("moshi"),
@@ -97,6 +108,25 @@ internal class AdapterGenerator(
       .mutable(true)
       .initializer("null")
       .build()
+
+//  private val getOrFindConstructorRefFunction = FunSpec.builder(
+//      nameAllocator.newName("getOrFindConstructorRef"))
+//      .addModifiers(KModifier.PRIVATE, KModifier.INLINE)
+//      .returns(constructorProperty.type.copy(nullable = false))
+//      .apply {
+//        val args =
+////        addStatement("«return·%N·?:·%T::class.java.getDeclaredConstructor(", constructorProperty, originalRawTypeName)
+//        val initializerBlock = CodeBlock.of(
+//            "return this.%1N·?:·%2L.also·{ this.%1N·= it }",
+//            constructorProperty,
+//            lookupBlock
+//        )
+//      }
+//      .beginControlFlow("return %N ?:")
+//      .nextControlFlow("also")
+//      .addStatement("%N = it", constructorProperty)
+//      .endControlFlow()
+//      .build()
 
   fun generateFile(typeHook: (TypeSpec) -> TypeSpec = { it }): FileSpec {
     for (property in nonTransientProperties) {
@@ -158,7 +188,7 @@ internal class AdapterGenerator(
   }
 
   private fun generateToStringFun(): FunSpec {
-    val name = originalTypeName.rawType().simpleNames.joinToString(".")
+    val name = originalRawTypeName.simpleNames.joinToString(".")
     val size = TO_STRING_SIZE_BASE + name.length
     return FunSpec.builder("toString")
         .addModifiers(KModifier.OVERRIDE)
@@ -201,10 +231,12 @@ internal class AdapterGenerator(
     // JsonReader.Options.
     var propertyIndex = 0
     var maskIndex = 0
+    val constructorPropertyTypes = mutableListOf<CodeBlock>()
     for (property in propertyList) {
       if (property.isTransient) {
         if (property.hasConstructorParameter) {
           maskIndex++
+          constructorPropertyTypes += property.target.type.asTypeBlock()
         }
         continue
       }
@@ -238,6 +270,9 @@ internal class AdapterGenerator(
               exception)
         }
       }
+      if (property.hasConstructorParameter) {
+        constructorPropertyTypes += property.target.type.asTypeBlock()
+      }
       propertyIndex++
       maskIndex++
     }
@@ -267,12 +302,13 @@ internal class AdapterGenerator(
     if (useDefaultsConstructor) {
       classBuilder.addProperty(constructorProperty)
       // Dynamic default constructor call
-      val rawOriginalTypeName = originalTypeName.rawType()
       val nonNullConstructorType = constructorProperty.type.copy(nullable = false)
+      val args = constructorPropertyTypes.plus(DEFAULT_CONSTRUCTOR_EXTRA_PARAMS)
+          .joinToCode(", ")
       val coreLookupBlock = CodeBlock.of(
-          "%T.lookupDefaultsConstructor(%T::class.java)",
-          MOSHI_UTIL,
-          rawOriginalTypeName
+          "%T::class.java.getDeclaredConstructor(%L)",
+          originalRawTypeName,
+          args
       )
       val lookupBlock = if (originalTypeName is ParameterizedTypeName) {
         CodeBlock.of("(%L·as·%T)", coreLookupBlock, nonNullConstructorType)
@@ -280,7 +316,7 @@ internal class AdapterGenerator(
         coreLookupBlock
       }
       val initializerBlock = CodeBlock.of(
-          "this.%1N ?:·%2L.also·{ this.%1N·= it }",
+          "this.%1N·?: %2L.also·{ this.%1N·= it }",
           constructorProperty,
           lookupBlock
       )
@@ -310,7 +346,7 @@ internal class AdapterGenerator(
           // We have to use the default primitive for the available type in order for
           // invokeDefaultConstructor to properly invoke it. Just using "null" isn't safe because
           // the transient type may be a primitive type.
-          result.addCode(property.target.type.defaultPrimitiveValue())
+          result.addCode(property.target.type.rawType().defaultPrimitiveValue())
         } else {
           result.addCode("%N", property.localName)
         }

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -109,25 +109,6 @@ internal class AdapterGenerator(
       .initializer("null")
       .build()
 
-//  private val getOrFindConstructorRefFunction = FunSpec.builder(
-//      nameAllocator.newName("getOrFindConstructorRef"))
-//      .addModifiers(KModifier.PRIVATE, KModifier.INLINE)
-//      .returns(constructorProperty.type.copy(nullable = false))
-//      .apply {
-//        val args =
-////        addStatement("«return·%N·?:·%T::class.java.getDeclaredConstructor(", constructorProperty, originalRawTypeName)
-//        val initializerBlock = CodeBlock.of(
-//            "return this.%1N·?:·%2L.also·{ this.%1N·= it }",
-//            constructorProperty,
-//            lookupBlock
-//        )
-//      }
-//      .beginControlFlow("return %N ?:")
-//      .nextControlFlow("also")
-//      .addStatement("%N = it", constructorProperty)
-//      .endControlFlow()
-//      .build()
-
   fun generateFile(typeHook: (TypeSpec) -> TypeSpec = { it }): FileSpec {
     for (property in nonTransientProperties) {
       property.allocateNames(nameAllocator)

--- a/kotlin/reflect/src/main/test/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/kotlin/reflect/src/main/test/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -15,7 +15,7 @@ class KotlinJsonAdapterTest {
     val moshi = Moshi.Builder()
         .add(KotlinJsonAdapterFactory())
         .build()
-    val adapter = moshi.adapter<Data>()
+    val adapter = moshi.adapter(Data::class.java)
     assertThat(adapter.toString()).isEqualTo(
         "KotlinJsonAdapter(com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest.Data).nullSafe()"
     )

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -322,6 +322,26 @@ class DualKotlinTest(useReflection: Boolean) {
 
   @JsonClass(generateAdapter = true)
   class InternalAbstractProperty(override val test: String) : InternalAbstractPropertyBase()
+
+  // Regression test for https://github.com/square/moshi/issues/975
+  @Test fun multipleConstructors() {
+    val adapter = moshi.adapter<MultipleConstructorsB>()
+
+    assertThat(adapter.toJson(MultipleConstructorsB(6))).isEqualTo("""{"f":{"f":6},"b":6}""")
+
+    @Language("JSON")
+    val testJson = """{"b":6}"""
+    val result = adapter.fromJson(testJson)!!
+    assertThat(result.b).isEqualTo(6)
+  }
+
+  @JsonClass(generateAdapter = true)
+  class MultipleConstructorsA(val f: Int)
+
+  @JsonClass(generateAdapter = true)
+  class MultipleConstructorsB(val f: MultipleConstructorsA = MultipleConstructorsA(5), val b: Int) {
+    constructor(f: Int, b: Int = 6): this(MultipleConstructorsA(f), b)
+  }
 }
 
 // Has to be outside since inline classes are only allowed on top level

--- a/moshi/src/main/java/com/squareup/moshi/internal/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/Util.java
@@ -47,7 +47,7 @@ import static com.squareup.moshi.Types.supertypeOf;
 public final class Util {
   public static final Set<Annotation> NO_ANNOTATIONS = Collections.emptySet();
   public static final Type[] EMPTY_TYPE_ARRAY = new Type[] {};
-  @Nullable private static final Class<?> DEFAULT_CONSTRUCTOR_MARKER;
+  @Nullable public static final Class<?> DEFAULT_CONSTRUCTOR_MARKER;
   @Nullable private static final Class<? extends Annotation> METADATA;
 
   static {


### PR DESCRIPTION
This fixes #975 by directly looking up the constructor via `getDeclaredConstructors` and the exact parameter types + mask and default constructor marker. 