### PR TITLE
Handle non-property parameters in kotlin code gen

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/TargetConstructor.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/TargetConstructor.kt
@@ -19,7 +19,7 @@ import com.squareup.kotlinpoet.KModifier
 
 /** A constructor in user code that should be called by generated code. */
 internal data class TargetConstructor(
-  val parameters: Map<String, TargetParameter>,
+  val parameters: LinkedHashMap<String, TargetParameter>,
   val visibility: KModifier
 ) {
   init {

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/TargetParameter.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/TargetParameter.kt
@@ -16,11 +16,13 @@
 package com.squareup.moshi.kotlin.codegen.api
 
 import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.TypeName
 
 /** A parameter in user code that should be populated by generated code. */
 internal data class TargetParameter(
   val name: String,
   val index: Int,
+  val type: TypeName,
   val hasDefault: Boolean,
   val jsonName: String? = null,
   val qualifiers: Set<AnnotationSpec>? = null

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
@@ -78,6 +78,7 @@ internal fun primaryConstructor(kotlinApi: TypeSpec, elements: Elements): Target
     parameters[name] = TargetParameter(
         name = name,
         index = index,
+        type = parameter.type,
         hasDefault = parameter.defaultValue != null,
         qualifiers = parameter.annotations.qualifiers(elements),
         jsonName = parameter.annotations.jsonName()

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
@@ -72,7 +72,7 @@ private fun Collection<KModifier>.visibility(): KModifier {
 internal fun primaryConstructor(kotlinApi: TypeSpec, elements: Elements): TargetConstructor? {
   val primaryConstructor = kotlinApi.primaryConstructor ?: return null
 
-  val parameters = mutableMapOf<String, TargetParameter>()
+  val parameters = LinkedHashMap<String, TargetParameter>()
   for ((index, parameter) in primaryConstructor.parameters.withIndex()) {
     val name = parameter.name
     parameters[name] = TargetParameter(

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -327,6 +327,7 @@ class DualKotlinTest(useReflection: Boolean) {
   @Test fun multipleConstructors() {
     val adapter = moshi.adapter<MultipleConstructorsB>()
 
+    //language=JSON
     assertThat(adapter.toJson(MultipleConstructorsB(6))).isEqualTo("""{"f":{"f":6},"b":6}""")
 
     @Language("JSON")
@@ -341,6 +342,59 @@ class DualKotlinTest(useReflection: Boolean) {
   @JsonClass(generateAdapter = true)
   class MultipleConstructorsB(val f: MultipleConstructorsA = MultipleConstructorsA(5), val b: Int) {
     constructor(f: Int, b: Int = 6): this(MultipleConstructorsA(f), b)
+  }
+
+  @Test fun `multiple non-property parameters`() {
+    val adapter = moshi.adapter<MultipleNonPropertyParameters>()
+
+    @Language("JSON")
+    val testJson = """{"prop":7}"""
+
+    assertThat(adapter.toJson(MultipleNonPropertyParameters(7))).isEqualTo(testJson)
+
+    val result = adapter.fromJson(testJson)!!
+    assertThat(result.prop).isEqualTo(7)
+  }
+
+  @JsonClass(generateAdapter = true)
+  class MultipleNonPropertyParameters(
+      val prop: Int,
+      param1: Int = 1,
+      param2: Int = 2
+  ) {
+    init {
+      // Ensure the params always uses their default value
+      require(param1 == 1)
+      require(param2 == 2)
+    }
+  }
+
+  // Tests the case of multiple parameters with no parameter properties.
+  @Test fun `only multiple non-property parameters`() {
+    val adapter = moshi.adapter<OnlyMultipleNonPropertyParameters>()
+
+    @Language("JSON")
+    val testJson = """{"prop":7}"""
+
+    assertThat(adapter.toJson(OnlyMultipleNonPropertyParameters().apply { prop = 7 }))
+        .isEqualTo(testJson)
+
+    val result = adapter.fromJson(testJson)!!
+    assertThat(result.prop).isEqualTo(7)
+  }
+
+  @JsonClass(generateAdapter = true)
+  class OnlyMultipleNonPropertyParameters(
+      param1: Int = 1,
+      param2: Int = 2
+  ) {
+    init {
+      // Ensure the params always uses their default value
+      require(param1 == 1)
+      require(param2 == 2)
+    }
+
+    var prop: Int = 0
   }
 }
 

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/MultipleMasksTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/MultipleMasksTest.kt
@@ -75,7 +75,7 @@ class MultipleMasks(
     val arg17: Long = 17,
     val arg18: Long = 18,
     val arg19: Long = 19,
-    val arg20: Long = 20,
+    @Suppress("UNUSED_PARAMETER") arg20: Long = 20,
     val arg21: Long = 21,
     val arg22: Long = 22,
     val arg23: Long = 23,


### PR DESCRIPTION
This adds a `FromJsonComponent` sealed type for describing the combination of properties, parameters, and parameter properties. This allows us to handle parameter-only types separately (needed for mask index calculation). Resolves #979

Same suggestions welcome... I couldn't think of what else to call this.