### PR TITLE
Check against non-nullable known primitives when rendering class blocks

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/kotlintypes.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/kotlintypes.kt
@@ -71,7 +71,9 @@ internal fun TypeName.asTypeBlock(): CodeBlock {
       return bound.asTypeBlock()
     }
     is ClassName -> {
-      return when (this) {
+      // Check against the non-nullable version for equality, but we'll keep the nullability in
+      // consideration when creating the CodeBlock if needed.
+      return when (copy(nullable = false)) {
         BOOLEAN, CHAR, BYTE, SHORT, INT, FLOAT, LONG, DOUBLE -> {
           if (isNullable) {
             // Remove nullable but keep the java object type

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -435,6 +435,35 @@ class DualKotlinTest(useReflection: Boolean) {
       val wildcardOut: GenericClass<out TypeAlias>,
       val complex: GenericClass<GenericTypeAlias>
   )
+
+  // Regression test for https://github.com/square/moshi/issues/991
+  @Test fun nullablePrimitiveProperties() {
+    val adapter = moshi.adapter<NullablePrimitives>()
+
+    @Language("JSON")
+    val testOutputJson = """{"oh_boy":"testing","that_is_a_test":3,"test_again":0}"""
+
+    assertThat(adapter.serializeNulls().toJson(NullablePrimitives("testing", 3)))
+        .isEqualTo(testOutputJson)
+
+    @Language("JSON")
+    val testInputJson = """{"oh_boy":"testing","that_is_a_test":3}"""
+    val result = adapter.fromJson(testInputJson)!!
+    assertThat(result.ohboy).isEqualTo("testing")
+    assertThat(result.thatIsATest).isEqualTo(3)
+    assertThat(result.testAgain).isEqualTo(0)
+  }
+
+  // public Testy(String var1, Integer var2, int var3, int var4, DefaultConstructorMarker var5)
+  @JsonClass(generateAdapter = true)
+  data class NullablePrimitives(
+      @Json(name = "oh_boy")
+      val ohboy: String,
+      @Json(name = "that_is_a_test")
+      val thatIsATest: Int?,
+      @Json(name = "test_again")
+      val testAgain: Int = 0
+  )
 }
 
 typealias TypeAlias = Int

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -454,7 +454,6 @@ class DualKotlinTest(useReflection: Boolean) {
     assertThat(result.testAgain).isEqualTo(0)
   }
 
-  // public Testy(String var1, Integer var2, int var3, int var4, DefaultConstructorMarker var5)
   @JsonClass(generateAdapter = true)
   data class NullablePrimitives(
       @Json(name = "oh_boy")

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -441,27 +441,45 @@ class DualKotlinTest(useReflection: Boolean) {
     val adapter = moshi.adapter<NullablePrimitives>()
 
     @Language("JSON")
-    val testOutputJson = """{"oh_boy":"testing","that_is_a_test":3,"test_again":0}"""
+    val testJson = """{"objectType":"value","boolean":true,"byte":3,"char":"a","short":3,"int":3,"long":3,"float":3.2,"double":3.2}"""
 
-    assertThat(adapter.serializeNulls().toJson(NullablePrimitives("testing", 3)))
-        .isEqualTo(testOutputJson)
+    val instance = NullablePrimitives(
+        objectType = "value",
+        boolean = true,
+        byte = 3,
+        char = 'a',
+        short = 3,
+        int = 3,
+        long = 3,
+        float = 3.2f,
+        double = 3.2
+    )
+    assertThat(adapter.toJson(instance))
+        .isEqualTo(testJson)
 
-    @Language("JSON")
-    val testInputJson = """{"oh_boy":"testing","that_is_a_test":3}"""
-    val result = adapter.fromJson(testInputJson)!!
-    assertThat(result.ohboy).isEqualTo("testing")
-    assertThat(result.thatIsATest).isEqualTo(3)
-    assertThat(result.testAgain).isEqualTo(0)
+    val result = adapter.fromJson(testJson)!!
+    assertThat(result).isEqualTo(instance)
   }
 
   @JsonClass(generateAdapter = true)
   data class NullablePrimitives(
-      @Json(name = "oh_boy")
-      val ohboy: String,
-      @Json(name = "that_is_a_test")
-      val thatIsATest: Int?,
-      @Json(name = "test_again")
-      val testAgain: Int = 0
+      val objectType: String = "",
+      val boolean: Boolean,
+      val nullableBoolean: Boolean? = null,
+      val byte: Byte,
+      val nullableByte: Byte? = null,
+      val char: Char,
+      val nullableChar: Char? = null,
+      val short: Short,
+      val nullableShort: Short? = null,
+      val int: Int,
+      val nullableInt: Int? = null,
+      val long: Long,
+      val nullableLong: Long? = null,
+      val float: Float,
+      val nullableFloat: Float? = null,
+      val double: Double,
+      val nullableDouble: Double? = null
   )
 }
 


### PR DESCRIPTION
`Int?` will not equal `Int` in KotlinPoet, so this was always falling through to the default `::class.java` code.

Resolves #991