### PR TITLE
Handle enclosing visibility + cache metadata parsing

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AppliedType.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/AppliedType.kt
@@ -30,8 +30,8 @@ internal class AppliedType private constructor(
   /** Returns all supertypes of this, recursively. Includes both interface and class supertypes. */
   fun supertypes(
     types: Types,
-    result: MutableSet<AppliedType> = mutableSetOf()
-  ): Set<AppliedType> {
+    result: LinkedHashSet<AppliedType> = LinkedHashSet()
+  ): LinkedHashSet<AppliedType> {
     result.add(this)
     for (supertype in types.directSupertypes(mirror)) {
       val supertypeDeclaredType = supertype as DeclaredType

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/MoshiCachedClassInspector.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/MoshiCachedClassInspector.kt
@@ -1,0 +1,37 @@
+package com.squareup.moshi.kotlin.codegen
+
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.metadata.ImmutableKmClass
+import com.squareup.kotlinpoet.metadata.specs.ClassInspector
+import com.squareup.kotlinpoet.metadata.specs.toTypeSpec
+import com.squareup.kotlinpoet.metadata.toImmutableKmClass
+import javax.lang.model.element.TypeElement
+
+/**
+ * This cached API over [ClassInspector] that caches certain lookups Moshi does potentially multiple
+ * times. This is useful mostly because it avoids duplicate reloads in cases like common base
+ * classes, common enclosing types, etc.
+ */
+internal class MoshiCachedClassInspector(private val classInspector: ClassInspector) {
+  private val elementToSpecCache = mutableMapOf<TypeElement, TypeSpec>()
+  private val kmClassToSpecCache = mutableMapOf<ImmutableKmClass, TypeSpec>()
+  private val metadataToKmClassCache = mutableMapOf<Metadata, ImmutableKmClass>()
+
+  fun toImmutableKmClass(metadata: Metadata): ImmutableKmClass {
+    return metadataToKmClassCache.getOrPut(metadata) {
+      metadata.toImmutableKmClass()
+    }
+  }
+
+  fun toTypeSpec(kmClass: ImmutableKmClass): TypeSpec {
+    return kmClassToSpecCache.getOrPut(kmClass) {
+      kmClass.toTypeSpec(classInspector)
+    }
+  }
+
+  fun toTypeSpec(element: TypeElement): TypeSpec {
+    return elementToSpecCache.getOrPut(element) {
+      toTypeSpec(toImmutableKmClass(element.metadata))
+    }
+  }
+}

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
@@ -207,12 +207,13 @@ internal fun targetType(messager: Messager,
     }
   }
   val visibility = kotlinApi.modifiers.visibility()
-  // If any class in the enclosing cl
+  // If any class in the enclosing class hierarchy is internal, they must all have internal
+  // generated adapters.
   val resolvedVisibility = if (visibility == KModifier.INTERNAL) {
-    // If our nested type is already internal, no need
+    // Our nested type is already internal, no need to search
     visibility
   } else {
-    // Implicitly public.
+    // Implicitly public, so now look up the hierarchy
     val forceInternal = generateSequence<Element>(element) { it.enclosingElement }
         .filterIsInstance<TypeElement>()
         .map { cachedClassInspector.toImmutableKmClass(it.metadata) }

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
@@ -156,6 +156,12 @@ internal fun targetType(messager: Messager,
           element)
       return null
     }
+    !kmClass.isPublic && !kmClass.isInternal -> {
+      messager.printMessage(
+          Diagnostic.Kind.ERROR, "@JsonClass can't be applied to $element: must be internal or public",
+          element)
+      return null
+    }
   }
 
   val elementHandler = ElementsClassInspector.create(elements, types)

--- a/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessorTest.kt
+++ b/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessorTest.kt
@@ -182,6 +182,20 @@ class JsonClassCodegenProcessorTest {
         "error: @JsonClass can't be applied to LocalClass: must not be local")
   }
 
+  @Test fun privateClassesNotSupported() {
+    val result = compile(kotlin("source.kt",
+        """
+          import com.squareup.moshi.JsonClass
+          
+          @JsonClass(generateAdapter = true)
+          private class PrivateClass(val a: Int)
+          """
+    ))
+    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertThat(result.messages).contains(
+        "error: @JsonClass can't be applied to PrivateClass: must be internal or public")
+  }
+
   @Test fun objectDeclarationsNotSupported() {
     val result = compile(kotlin("source.kt",
         """

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -1171,6 +1171,20 @@ class GeneratedAdaptersTest {
   }
 }
 
+// Regression test for https://github.com/square/moshi/issues/1022
+// Compile-only test
+@JsonClass(generateAdapter = true)
+internal data class MismatchParentAndNestedClassVisibility(
+    val type: Int,
+    val name: String? = null
+) {
+
+  @JsonClass(generateAdapter = true)
+  data class NestedClass(
+      val nestedProperty: String
+  )
+}
+
 // Has to be outside to avoid Types seeing an owning class
 @JsonClass(generateAdapter = true)
 data class NullableTypeParams<T>(


### PR DESCRIPTION
This resolves #1022 and also became a good opportunity to refactor metadata parsing a bit. This allows us to put a cache in front of it now, which should give us a nice little performance win.

Also added an extra check + test for private classes