### PR TITLE
Suppress common warnings in generated classes

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -58,6 +58,14 @@ internal class AdapterGenerator(
   companion object {
     private val INT_TYPE_BLOCK = CodeBlock.of("%T::class.javaPrimitiveType", INT)
     private val DEFAULT_CONSTRUCTOR_MARKER_TYPE_BLOCK = CodeBlock.of("%T.DEFAULT_CONSTRUCTOR_MARKER", Util::class)
+
+    private val COMMON_SUPPRESS = AnnotationSpec.builder(Suppress::class)
+        .addMember("%S, %S, %S",
+            "DEPRECATION", // https://github.com/square/moshi/issues/1023
+            "unused", // Because we look it up reflectively
+            "ClassName" // Because we include underscores
+        )
+        .build()
   }
 
   private val nonTransientProperties = propertyList.filterNot { it.isTransient }
@@ -126,6 +134,7 @@ internal class AdapterGenerator(
 
   private fun generateType(): TypeSpec {
     val result = TypeSpec.classBuilder(adapterName)
+        .addAnnotation(COMMON_SUPPRESS)
 
     result.superclass(jsonAdapterTypeName)
 

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -57,13 +57,20 @@ internal class AdapterGenerator(
 
   companion object {
     private val INT_TYPE_BLOCK = CodeBlock.of("%T::class.javaPrimitiveType", INT)
-    private val DEFAULT_CONSTRUCTOR_MARKER_TYPE_BLOCK = CodeBlock.of("%T.DEFAULT_CONSTRUCTOR_MARKER", Util::class)
+    private val DEFAULT_CONSTRUCTOR_MARKER_TYPE_BLOCK = CodeBlock.of(
+        "%T.DEFAULT_CONSTRUCTOR_MARKER", Util::class)
 
     private val COMMON_SUPPRESS = AnnotationSpec.builder(Suppress::class)
-        .addMember("%S, %S, %S",
-            "DEPRECATION", // https://github.com/square/moshi/issues/1023
-            "unused", // Because we look it up reflectively
-            "ClassName" // Because we include underscores
+        .addMember("%S, %S, %S, %S",
+            // https://github.com/square/moshi/issues/1023
+            "DEPRECATION",
+            // Because we look it up reflectively
+            "unused",
+            // Because we include underscores
+            "ClassName",
+            // Because we generate redundant `out` variance for some generics and there's no way
+            // for us to know when it's redundant.
+            "REDUNDANT_PROJECTION"
         )
         .build()
   }
@@ -313,7 +320,8 @@ internal class AdapterGenerator(
         if (property.hasConstructorDefault) {
           val inverted = (1 shl maskIndex).inv()
           result.addComment("\$mask = \$mask and (1 shl %L).inv()", maskIndex)
-          result.addStatement("%1L = %1L and 0x%2L.toInt()", maskNames[maskNameIndex], Integer.toHexString(inverted))
+          result.addStatement("%1L = %1L and 0x%2L.toInt()", maskNames[maskNameIndex],
+              Integer.toHexString(inverted))
         } else {
           // Presence tracker for a mutable property
           result.addStatement("%N = true", property.localIsPresentName)
@@ -486,6 +494,7 @@ private interface PropertyComponent {
   val property: PropertyGenerator
   val type: TypeName
 }
+
 private interface ParameterComponent {
   val parameter: TargetParameter
   val type: TypeName
@@ -512,8 +521,8 @@ private sealed class FromJsonComponent {
   }
 
   data class ParameterProperty(
-    override val parameter: TargetParameter,
-    override val property: PropertyGenerator
+      override val parameter: TargetParameter,
+      override val property: PropertyGenerator
   ) : FromJsonComponent(), ParameterComponent, PropertyComponent {
     override val type: TypeName = parameter.type
   }

--- a/kotlin/tests/pom.xml
+++ b/kotlin/tests/pom.xml
@@ -115,11 +115,7 @@
         </executions>
         <configuration>
           <args>
-          <!--
-          Disabled for now because we generate redundant `out` variance for some generics,
-          but there's no way for us to know when it's redundant.
-          -->
-<!--            <arg>-Werror</arg>-->
+            <arg>-Werror</arg>
             <arg>-Xuse-experimental=kotlin.ExperimentalStdlibApi</arg>
               <arg>-XXLanguage:+InlineClasses</arg>
           </args>

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -513,6 +513,7 @@ class DualKotlinTest(useReflection: Boolean) {
     assertThat(result).isEqualTo(instance)
   }
 
+  @Suppress("REDUNDANT_NULLABLE")
   @JsonClass(generateAdapter = true)
   data class TypeAliasNullability(
       val aShouldBeNonNull: A,

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -1169,6 +1169,22 @@ class GeneratedAdaptersTest {
     val instance = adapter.fromJson("""{"_links": "link", "_ids": "id" }""")!!
     assertThat(instance).isEqualTo(ClassWithFieldJson("link").apply { ids = "id" })
   }
+
+  /*
+   * These are a smoke test for https://github.com/square/moshi/issues/1023 to ensure that we
+   * suppress deprecation warnings for using deprecated properties or classes.
+   *
+   * Ideally when stubs are fixed to actually included Deprecated annotations, we could then only
+   * generate a deprecation suppression as needed and on targeted usages.
+   * https://youtrack.jetbrains.com/issue/KT-34951
+   */
+
+  @Deprecated("Deprecated for reasons")
+  @JsonClass(generateAdapter = true)
+  data class DeprecatedClass(val foo: String)
+
+  @JsonClass(generateAdapter = true)
+  data class DeprecatedProperty(@Deprecated("Deprecated for reasons") val foo: String)
 }
 
 // Regression test for https://github.com/square/moshi/issues/1022


### PR DESCRIPTION
Followup from #1023 (Resolves #1023 too). Since we can't do targeted deprecation suppressions, we can just stick with blanket deprecations suppressions for now. This also suppresses a couple other common issues with all our generated adapters and allows us to re-enable -Werror in tests.

Have just eyeballed the results for now, can add a proper test as a followup once #1014 is in

Example

```kotlin
@Suppress("DEPRECATION", "unused", "ClassName", "REDUNDANT_PROJECTION")
internal class MismatchParentAndNestedClassVisibilityJsonAdapter(
  moshi: Moshi
) : JsonAdapter<MismatchParentAndNestedClassVisibility>() {
```