### PR TITLE
Exclude unused transitive dependency

### DIFF
--- a/kotlin/codegen/pom.xml
+++ b/kotlin/codegen/pom.xml
@@ -21,6 +21,12 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-common</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.squareup</groupId>

--- a/kotlin/reflect/pom.xml
+++ b/kotlin/reflect/pom.xml
@@ -31,6 +31,12 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-common</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>

--- a/kotlin/tests/pom.xml
+++ b/kotlin/tests/pom.xml
@@ -26,6 +26,12 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-common</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Hello, I noticed that the transitive dependency `kotlin-stdlib-common` is in the dependency tree of modules  `moshi-kotlin`, `moshi-kotlin-codegen`, and `moshi-kotlin-tests` but it is not used. Therefore, excluding this transitive dependency from `kotlin-stdlib` will make these modules smaller and Maven dependency trees clearer. 