### PR TITLE
Always check for DefaultConstructorMarker class

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/internal/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/Util.java
@@ -52,13 +52,20 @@ public final class Util {
 
   static {
     Class<? extends Annotation> metadata = null;
-    Class<?> defaultConstructorMarker = null;
     try {
+      //noinspection unchecked
       metadata = (Class<? extends Annotation>) Class.forName("kotlin.Metadata");
-      defaultConstructorMarker = Class.forName("kotlin.jvm.internal.DefaultConstructorMarker");
     } catch (ClassNotFoundException ignored) {
     }
     METADATA = metadata;
+
+    // We look up the constructor marker separately because Metadata might be (justifiably)
+    // stripped by R8/Proguard but the DefaultConstructorMarker is still present.
+    Class<?> defaultConstructorMarker = null;
+    try {
+      defaultConstructorMarker = Class.forName("kotlin.jvm.internal.DefaultConstructorMarker");
+    } catch (ClassNotFoundException ignored) {
+    }
     DEFAULT_CONSTRUCTOR_MARKER = defaultConstructorMarker;
   }
 


### PR DESCRIPTION
Reported by a Googler - We currently gate the lookup of the class on the presence of `Metadata`. However, `Metadata` might be justifiably stripped by Proguard/R8, even though `DefaultConstructorMarker` might still be present. This means Moshi's defaults invocation is likely broken on (at least) R8 builds without this.

Workaround until next release is to keep Metadata annotations