### PR TITLE
Add LocalVariableName to common suppressions

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -61,7 +61,7 @@ internal class AdapterGenerator(
         "%T.DEFAULT_CONSTRUCTOR_MARKER", Util::class)
 
     private val COMMON_SUPPRESS = AnnotationSpec.builder(Suppress::class)
-        .addMember("%S, %S, %S, %S",
+        .addMember("%S, %S, %S, %S, %S",
             // https://github.com/square/moshi/issues/1023
             "DEPRECATION",
             // Because we look it up reflectively
@@ -70,7 +70,10 @@ internal class AdapterGenerator(
             "ClassName",
             // Because we generate redundant `out` variance for some generics and there's no way
             // for us to know when it's redundant.
-            "REDUNDANT_PROJECTION"
+            "REDUNDANT_PROJECTION",
+            // NameAllocator will just add underscores to differentiate names, which Kotlin doesn't
+            // like for stylistic reasons.
+            "LocalVariableName"
         )
         .build()
   }

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -60,22 +60,27 @@ internal class AdapterGenerator(
     private val DEFAULT_CONSTRUCTOR_MARKER_TYPE_BLOCK = CodeBlock.of(
         "%T.DEFAULT_CONSTRUCTOR_MARKER", Util::class)
 
-    private val COMMON_SUPPRESS = AnnotationSpec.builder(Suppress::class)
-        .addMember("%S, %S, %S, %S, %S",
-            // https://github.com/square/moshi/issues/1023
-            "DEPRECATION",
-            // Because we look it up reflectively
-            "unused",
-            // Because we include underscores
-            "ClassName",
-            // Because we generate redundant `out` variance for some generics and there's no way
-            // for us to know when it's redundant.
-            "REDUNDANT_PROJECTION",
-            // NameAllocator will just add underscores to differentiate names, which Kotlin doesn't
-            // like for stylistic reasons.
-            "LocalVariableName"
-        )
-        .build()
+    private val COMMON_SUPPRESS = arrayOf(
+        // https://github.com/square/moshi/issues/1023
+        "DEPRECATION",
+        // Because we look it up reflectively
+        "unused",
+        // Because we include underscores
+        "ClassName",
+        // Because we generate redundant `out` variance for some generics and there's no way
+        // for us to know when it's redundant.
+        "REDUNDANT_PROJECTION",
+        // NameAllocator will just add underscores to differentiate names, which Kotlin doesn't
+        // like for stylistic reasons.
+        "LocalVariableName"
+    ).let { suppressions ->
+      AnnotationSpec.builder(Suppress::class)
+          .addMember(
+              suppressions.indices.joinToString { "%S" },
+              *suppressions
+          )
+          .build()
+    }
   }
 
   private val nonTransientProperties = propertyList.filterNot { it.isTransient }


### PR DESCRIPTION
NameAllocator will add underscores to names, which kotlin doesn't like for stylistic reasons