### PR TITLE
Omit unnecessary generic type from standard constructor call

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -403,8 +403,8 @@ internal class AdapterGenerator(
           localConstructorProperty
       )
     } else {
-      // Standard constructor call
-      result.addCode("«%L%T(", returnOrResultAssignment, originalTypeName)
+      // Standard constructor call. Can omit generics as they're inferred
+      result.addCode("«%L%T(", returnOrResultAssignment, originalTypeName.rawType())
     }
 
     for (input in components.filterIsInstance<ParameterComponent>()) {


### PR DESCRIPTION
These were redundant. Was `return Foo<T>(...)` and is now `return Foo(...)`