### PR TITLE
Create logic to register base sub types

### DIFF
--- a/adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.java
+++ b/adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.java
@@ -180,7 +180,8 @@ public final class PolymorphicJsonAdapterFactory<T> implements JsonAdapter.Facto
    * Use this method to decode sub types of {@code baseType} and your {@code subtype}.
    * inherits from {@code baseSubType}.
    */
-  public PolymorphicJsonAdapterFactory<T> withBaseSubType(@Nullable Class<? extends T> baseSubType) {
+  public PolymorphicJsonAdapterFactory<T> withBaseSubType(
+          @Nullable Class<? extends T> baseSubType) {
     if (baseSubType == null) throw new NullPointerException("baseSubTypes == null");
     if (baseSubTypes.contains(baseSubType)) {
       throw new IllegalArgumentException("BaseSubType must be unique.");

--- a/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
@@ -251,7 +251,7 @@ public final class PolymorphicJsonAdapterFactoryTest {
     assertThat(blockingMessageType.value).isEqualTo("Okay!");
   }
 
-  @Test public void failsWhenNotPassBaseSubTypes() throws IOException {
+  @Test public void failsWhenBaseSubTypesIsNotProvided() throws IOException {
     Moshi moshi = new Moshi.Builder()
             .add(PolymorphicJsonAdapterFactory.of(Message.class, "type")
                     .withSubtype(MessageWithBlockingMessage.class, "subType")


### PR DESCRIPTION
I had a problem when trying to deserialize an interface that is a sub-type of `baseType` and is used as an interface in another `subType` of `baseType`.

This is the exception that is thrown:
`java.lang.IllegalArgumentException: No JsonAdapter for interface com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$BlockingMessage (with no annotations) for interface com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$BlockingMessage blockingMessage for class com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$MessageWithBlockingMessage for interface com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$Message`

Here is an example of the problem for better understanding:

```java
// My BaseType
interface Message {
}

// My BaseSubType
interface BlockingMessage extends Message {
}

// BaseSubType implementation
class BlockingMessageType implements BlockingMessage {
  final String value;

  BlockingMessageType(String value) {
    this.value = value;
  }
}

// SubType of BaseType that uses BaseSubType
class MessageWithBlockingMessage implements Message {
  final BlockingMessage blockingMessage;

  MessageWithBlockingMessage(BlockingMessage blockingMessage) {
    this.blockingMessage = blockingMessage;
  }
}
```

My implementation solves that problem by adding a extra parameter to the `PolymorphicJsonAdapterFactory` named `baseSubTypes` using the method `withBaseSubType`. With this method I can register extra sub-types (`BlockingMessage`) of class `Message`.