### PR TITLE
Remove kotlin-reflect, replace with kotlinx-metadata-jvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,11 +614,31 @@ Snapshots of the development version are available in [Sonatype's `snapshots` re
 R8 / ProGuard
 --------
 
-If you are using R8 or ProGuard add the options from [this file](https://github.com/square/moshi/blob/master/moshi/src/main/resources/META-INF/proguard/moshi.pro). If using Android, this requires Android Gradle Plugin 3.2.0+.
+If using Android, the Android Gradle Plugin should automatically extract embedded rules included in 
+Moshi's jar artifacts.
 
-The `moshi-kotlin` artifact additionally requires the options from [this file](https://github.com/square/moshi/blob/master/kotlin/reflect/src/main/resources/META-INF/proguard/moshi-kotlin.pro)
+If you need to add them manually, you can add them from the following files:
+ 
+- [`moshi`](https://github.com/square/moshi/blob/master/moshi/src/main/resources/META-INF/proguard/moshi.pro). 
+- [`moshi-kotlin`](https://github.com/square/moshi/blob/master/kotlin/reflect/src/main/resources/META-INF/proguard/moshi-kotlin.pro)
+- You might also need rules for [Okio](https://github.com/square/okio), which is a dependency of this library.
 
-You might also need rules for Okio which is a dependency of this library.
+**Important note:** These rules only cover Moshi's core machinery. You will still need to add appropriate
+rules for your own code based on your usage of reflection. `moshi-kotlin` relies on introspection of Kotlin's
+`@Metadata` classes, so you must keep appropriate JVM members that they read. In practice, such a set of
+rules could look like this:
+
+```proguard
+# Keep names of Kotlin classes but allow shrinking if unused
+-keepnames @kotlin.Metadata class your.class.Here
+
+# Keep fields, constructors, and methods in Kotlin classes.
+-keepclassmembers @kotlin.Metadata class your.class.Here {
+  <fields>;
+  <init>(...);
+  <methods>;
+}
+```
 
 License
 --------

--- a/kotlin/reflect/pom.xml
+++ b/kotlin/reflect/pom.xml
@@ -104,6 +104,36 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>org.jetbrains.kotlinx:kotlinx-metadata-jvm</include>
+                </includes>
+              </artifactSet>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+              </transformers>
+              <relocations>
+                <!-- Repackage kotlinx-metadata until their APIs are stable. -->
+                <relocation>
+                  <pattern>kotlinx.metadata</pattern>
+                  <shadedPattern>com.squareup.moshi.kotlinx.metadata</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>${maven-assembly.version}</version>
         <executions>

--- a/kotlin/reflect/pom.xml
+++ b/kotlin/reflect/pom.xml
@@ -33,8 +33,9 @@
       <artifactId>kotlin-stdlib</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-reflect</artifactId>
+      <groupId>org.jetbrains.kotlinx</groupId>
+      <artifactId>kotlinx-metadata-jvm</artifactId>
+      <version>${kotlinx-metadata.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>

--- a/kotlin/reflect/pom.xml
+++ b/kotlin/reflect/pom.xml
@@ -125,7 +125,7 @@
                 <!-- Repackage kotlinx-metadata until their APIs are stable. -->
                 <relocation>
                   <pattern>kotlinx.metadata</pattern>
-                  <shadedPattern>com.squareup.moshi.kotlinx.metadata</shadedPattern>
+                  <shadedPattern>com.squareup.moshi.kotlin.kotlinx.metadata</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/JvmDescriptorUtil.kt
+++ b/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/JvmDescriptorUtil.kt
@@ -1,0 +1,74 @@
+package com.squareup.moshi.kotlin.reflect
+
+import kotlinx.metadata.jvm.JvmFieldSignature
+import kotlinx.metadata.jvm.JvmMethodSignature
+import java.lang.reflect.Constructor
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+
+internal val Class<*>.descriptor: String
+  get() {
+    return when {
+      isPrimitive -> when (kotlin) {
+        Byte::class -> "B"
+        Char::class -> "C"
+        Double::class -> "D"
+        Float::class -> "F"
+        Int::class -> "I"
+        Long::class -> "J"
+        Short::class -> "S"
+        Boolean::class -> "Z"
+        Void::class -> "V"
+        else -> throw RuntimeException("Unrecognized primitive $this")
+      }
+      isArray -> name.replace('.', '/')
+      else -> "L$name;".replace('.', '/')
+    }
+  }
+
+internal val Method.descriptor: String
+  get() {
+    return buildString {
+      append('(')
+      parameterTypes.joinTo(this, separator = "", transform = { it.descriptor })
+      append(')')
+      append(returnType.descriptor)
+    }
+  }
+
+/**
+ * Returns the JVM signature in the form "$Name$MethodDescriptor", for example: `equals(Ljava/lang/Object;)Z`.
+ *
+ * Useful for comparing with [JvmMethodSignature].
+ *
+ * For reference, see the [JVM specification, section 4.3](http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.3).
+ */
+internal val Method.jvmMethodSignature: String get() = "$name$descriptor"
+
+internal val Constructor<*>.descriptor: String
+  get() {
+    return buildString {
+      append('(')
+      parameterTypes.joinTo(this, separator = "", transform = { it.descriptor })
+      append(')')
+      append('V')
+    }
+  }
+
+/**
+ * Returns the JVM signature in the form "<init>$MethodDescriptor", for example: `"<init>(Ljava/lang/Object;)V")`.
+ *
+ * Useful for comparing with [JvmMethodSignature].
+ *
+ * For reference, see the [JVM specification, section 4.3](http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.3).
+ */
+internal val Constructor<*>.jvmMethodSignature: String get() = "<init>$descriptor"
+
+/**
+ * Returns the JVM signature in the form "$Name:$FieldDescriptor", for example: `"value:Ljava/lang/String;"`.
+ *
+ * Useful for comparing with [JvmFieldSignature].
+ *
+ * For reference, see the [JVM specification, section 4.3](http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.3).
+ */
+internal val Field.jvmFieldSignature: String get() = "$name:${type.descriptor}"

--- a/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/JvmDescriptorUtil.kt
+++ b/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/JvmDescriptorUtil.kt
@@ -27,14 +27,7 @@ internal val Class<*>.descriptor: String
   }
 
 internal val Method.descriptor: String
-  get() {
-    return buildString {
-      append('(')
-      parameterTypes.joinTo(this, separator = "", transform = { it.descriptor })
-      append(')')
-      append(returnType.descriptor)
-    }
-  }
+  get() = parameterTypes.joinToString(separator = "", prefix = "(", postfix = ")${returnType.descriptor}") { it.descriptor }
 
 /**
  * Returns the JVM signature in the form "$Name$MethodDescriptor", for example: `equals(Ljava/lang/Object;)Z`.
@@ -46,14 +39,7 @@ internal val Method.descriptor: String
 internal val Method.jvmMethodSignature: String get() = "$name$descriptor"
 
 internal val Constructor<*>.descriptor: String
-  get() {
-    return buildString {
-      append('(')
-      parameterTypes.joinTo(this, separator = "", transform = { it.descriptor })
-      append(')')
-      append('V')
-    }
-  }
+  get() = parameterTypes.joinToString(separator = "", prefix = "(", postfix = ")V") { it.descriptor }
 
 /**
  * Returns the JVM signature in the form "<init>$MethodDescriptor", for example: `"<init>(Ljava/lang/Object;)V")`.

--- a/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
+++ b/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
@@ -386,8 +386,9 @@ class KotlinJsonAdapterFactory : JsonAdapter.Factory {
     return when {
       this === other -> true
       this != null && other != null -> {
-        abbreviatedType == other.abbreviatedType
-            && arguments areEqualTo other.arguments
+        // Note we don't check abbreviatedType because typealiases and their backing types are equal
+        // for our purposes.
+        arguments areEqualTo other.arguments
             && classifier == other.classifier
             && flags == other.flags
             && flexibleTypeUpperBound isEqualTo other.flexibleTypeUpperBound

--- a/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
+++ b/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
@@ -449,28 +449,29 @@ class KotlinJsonAdapterFactory : JsonAdapter.Factory {
 }
 
 private val KmType.isNullable: Boolean get() = Flag.Type.IS_NULLABLE(flags)
-private val KmType.canonicalName: String get() {
-  return buildString {
-    val classifierString = when (val cl = classifier) {
-      is KmClassifier.Class -> createClassName(cl.name)
-      is TypeAlias -> createClassName(cl.name)
-      is TypeParameter -> arguments[cl.id].type?.canonicalName ?: "TypeVar(${cl.id})"
-    }
-    append(classifierString)
+private val KmType.canonicalName: String
+  get() {
+    return buildString {
+      val classifierString = when (val cl = classifier) {
+        is KmClassifier.Class -> createClassName(cl.name)
+        is TypeAlias -> createClassName(cl.name)
+        is TypeParameter -> arguments[cl.id].type?.canonicalName ?: "TypeVar(${cl.id})"
+      }
+      append(classifierString)
 
-    val args = arguments.joinToString(", ") {
-      "${it.variance?.name} ${it.type?.canonicalName ?: "*" }".trim()
-    }
+      val args = arguments.joinToString(", ") {
+        "${it.variance?.name} ${it.type?.canonicalName ?: "*"}".trim()
+      }
 
-    if (args.isNotBlank()) {
-      append('<')
-      append(args)
-      append('>')
-    }
+      if (args.isNotBlank()) {
+        append('<')
+        append(args)
+        append('>')
+      }
 
-    // TODO not sure if we care about expressing the other type information here
+      // TODO not sure if we care about expressing the other type information here
+    }
   }
-}
 
 /**
  * Creates a canonical class name as represented in Metadata's [kotlinx.metadata.ClassName], where

--- a/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
+++ b/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
@@ -394,7 +394,6 @@ class KotlinJsonAdapterFactory : JsonAdapter.Factory {
             && flexibleTypeUpperBound isEqualTo other.flexibleTypeUpperBound
             && outerType isEqualTo other.outerType
       }
-      this == null && other == null -> true
       else -> false
     }
   }
@@ -424,7 +423,6 @@ class KotlinJsonAdapterFactory : JsonAdapter.Factory {
         variance == other.variance
             && type isEqualTo other.type
       }
-      this == null && other == null -> true
       else -> false
     }
   }
@@ -436,7 +434,6 @@ class KotlinJsonAdapterFactory : JsonAdapter.Factory {
         typeFlexibilityId == other.typeFlexibilityId
             && type isEqualTo other.type
       }
-      this == null && other == null -> true
       else -> false
     }
   }

--- a/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
+++ b/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
@@ -48,7 +48,6 @@ import java.lang.reflect.Constructor
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
-import java.lang.reflect.Parameter
 import java.lang.reflect.Type
 import java.util.AbstractMap.SimpleEntry
 import kotlin.collections.Map.Entry
@@ -252,19 +251,21 @@ class KotlinJsonAdapterFactory : JsonAdapter.Factory {
     val kmConstructorSignature = kmConstructor.signature?.asString() ?: return null
     val constructorsBySignature = rawType.declaredConstructors.associateBy { it.jvmMethodSignature }
     val jvmConstructor = constructorsBySignature[kmConstructorSignature] ?: return null
+    val parameterAnnotations = jvmConstructor.parameterAnnotations
+    val parameterTypes = jvmConstructor.parameterTypes
     val parameters = kmConstructor.valueParameters.withIndex()
         .map { (index, kmParam) ->
-          val jvmParam = jvmConstructor.parameters[index]
-          ParameterData(kmParam, jvmParam, index)
+          ParameterData(kmParam, index, parameterTypes[index], parameterAnnotations[index].toList())
         }
 
     val anyOptional = parameters.any { it.isOptional }
     val actualConstructor = if (anyOptional) {
       val prefix = jvmConstructor.jvmMethodSignature.removeSuffix(")V")
-      val maskParamsToAdd = if (jvmConstructor.parameterCount == 0) {
+      val parameterCount = jvmConstructor.parameterTypes.size
+      val maskParamsToAdd = if (parameterCount == 0) {
         0
       } else {
-        (jvmConstructor.parameterCount + 31) / 32
+        (parameterCount + 31) / 32
       }
       val defaultConstructorSignature = buildString {
         append(prefix)
@@ -554,7 +555,12 @@ private fun Class<*>.allMethods(): Sequence<Method> {
   return declaredMethods.asSequence() + methods.asSequence()
 }
 
-internal data class ParameterData(val km: KmValueParameter, val jvm: Parameter, val index: Int) {
+internal data class ParameterData(
+    val km: KmValueParameter,
+    val index: Int,
+    val rawType: Class<*>,
+    val annotations: List<Annotation>
+) {
   val name get() = km.name
   val isOptional get() = Flag.ValueParameter.DECLARES_DEFAULT_VALUE(km.flags)
 }
@@ -588,7 +594,7 @@ internal data class ConstructorData(
           arguments.add(args[parameter])
         }
         parameter.isOptional -> {
-          arguments += defaultPrimitiveValue(parameter.jvm.parameterizedType)
+          arguments += defaultPrimitiveValue(parameter.rawType)
           mask = mask or (1 shl (index % Integer.SIZE))
         }
         else -> {
@@ -635,7 +641,6 @@ internal data class PropertyData(
   val javaType = jvmField?.genericType
       ?: jvmGetter?.genericReturnType
       ?: jvmSetter?.genericReturnType
-      ?: parameter?.jvm?.parameterizedType
       ?: error("No type information available for property '${km.name}' with type '${km.returnType.canonicalName}'.")
 
   val annotations: Set<Annotation> by lazy {
@@ -644,7 +649,7 @@ internal data class PropertyData(
     jvmGetter?.annotations?.let { set += it }
     jvmSetter?.annotations?.let { set += it }
     jvmAnnotationsMethod?.annotations?.let { set += it }
-    parameter?.jvm?.annotations?.let { set += it }
+    parameter?.annotations?.let { set += it }
     set
   }
 }

--- a/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
+++ b/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
@@ -296,7 +296,7 @@ class KotlinJsonAdapterFactory : JsonAdapter.Factory {
         generateSequence(rawType) { it.superclass }
             .mapNotNull { it.toKmClass(false) }
             .flatMap { it.properties.asSequence() }
-            .filterNot { Flag.IS_PRIVATE(it.flags) }
+            .filterNot { Flag.IS_PRIVATE(it.flags) || Flag.IS_PRIVATE_TO_THIS(it.flags) }
             .filter { Flag.Property.IS_VAR(it.flags) }
 
     for (property in allPropertiesSequence.distinctBy { it.name }) {

--- a/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
+++ b/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
@@ -37,6 +37,8 @@ import kotlinx.metadata.KmType
 import kotlinx.metadata.KmTypeProjection
 import kotlinx.metadata.KmValueParameter
 import kotlinx.metadata.isLocal
+import kotlinx.metadata.jvm.JvmFieldSignature
+import kotlinx.metadata.jvm.JvmMethodSignature
 import kotlinx.metadata.jvm.KotlinClassHeader
 import kotlinx.metadata.jvm.KotlinClassMetadata
 import kotlinx.metadata.jvm.fieldSignature
@@ -50,6 +52,7 @@ import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.lang.reflect.Type
 import java.util.AbstractMap.SimpleEntry
+import kotlin.LazyThreadSafetyMode.NONE
 import kotlin.collections.Map.Entry
 
 /** Classes annotated with this are eligible for this adapter. */
@@ -299,11 +302,10 @@ class KotlinJsonAdapterFactory : JsonAdapter.Factory {
             .filterNot { Flag.IS_PRIVATE(it.flags) || Flag.IS_PRIVATE_TO_THIS(it.flags) }
             .filter { Flag.Property.IS_VAR(it.flags) }
 
+    val signatureSearcher = JvmSignatureSearcher(rawType)
+
     for (property in allPropertiesSequence.distinctBy { it.name }) {
-      val propertyField = property.fieldSignature?.let { signature ->
-        val signatureString = signature.asString()
-        rawType.allFields().find { it.jvmFieldSignature == signatureString }
-      }
+      val propertyField = property.fieldSignature?.let(signatureSearcher::findField)
       val parameterData = parametersByName[property.name]
 
       if (Modifier.isTransient(propertyField?.modifiers ?: 0)) {
@@ -324,18 +326,9 @@ class KotlinJsonAdapterFactory : JsonAdapter.Factory {
 
       if (!Flag.Property.IS_VAR(property.flags) && parameterData == null) continue
 
-      val getterMethod = property.getterSignature?.let { signature ->
-        val signatureString = signature.asString()
-        rawType.allMethods().find { it.jvmMethodSignature == signatureString }
-      }
-      val setterMethod = property.setterSignature?.let { signature ->
-        val signatureString = signature.asString()
-        rawType.allMethods().find { it.jvmMethodSignature == signatureString }
-      }
-      val annotationsMethod = property.syntheticMethodForAnnotations?.let { signature ->
-        val signatureString = signature.asString()
-        rawType.allMethods().find { it.jvmMethodSignature == signatureString }
-      }
+      val getterMethod = property.getterSignature?.let(signatureSearcher::findMethod)
+      val setterMethod = property.setterSignature?.let(signatureSearcher::findMethod)
+      val annotationsMethod = property.syntheticMethodForAnnotations?.let(signatureSearcher::findMethod)
 
       val propertyData = PropertyData(
           km = property,
@@ -549,12 +542,54 @@ private fun Class<*>.toKmClass(throwOnNotClass: Boolean): KmClass? {
   return classMetadata.toKmClass()
 }
 
-private fun Class<*>.allMethods(): Sequence<Method> {
-  return declaredMethods.asSequence() + methods.asSequence()
-}
+private class JvmSignatureSearcher(clazz: Class<*>) {
 
-private fun Class<*>.allFields(): Sequence<Field> {
-  return declaredFields.asSequence() + fields.asSequence()
+  private val methodSignatureCache = mutableMapOf<String, Method>()
+  private val fieldSignatureCache = mutableMapOf<String, Field>()
+  private val methodIterator by lazy(NONE) { clazz.allMethods().iterator() }
+  private val fieldIterator by lazy(NONE) { clazz.allFields().iterator() }
+
+  fun findMethod(signature: JvmMethodSignature): Method? {
+    val signatureString = signature.asString()
+    val cached = methodSignatureCache[signatureString]
+    if (cached != null) return cached
+
+    while (methodIterator.hasNext()) {
+      val next = methodIterator.next()
+      val nextSignature = next.jvmMethodSignature
+      methodSignatureCache[nextSignature] = next
+      if (nextSignature == signatureString) {
+        return next
+      }
+    }
+
+    return null
+  }
+
+  fun findField(signature: JvmFieldSignature): Field? {
+    val signatureString = signature.asString()
+    val cached = fieldSignatureCache[signatureString]
+    if (cached != null) return cached
+
+    while (fieldIterator.hasNext()) {
+      val next = fieldIterator.next()
+      val nextSignature = next.jvmFieldSignature
+      fieldSignatureCache[nextSignature] = next
+      if (nextSignature == signatureString) {
+        return next
+      }
+    }
+
+    return null
+  }
+
+  private fun Class<*>.allMethods(): Sequence<Method> {
+    return declaredMethods.asSequence() + methods.asSequence()
+  }
+
+  private fun Class<*>.allFields(): Sequence<Field> {
+    return declaredFields.asSequence() + fields.asSequence()
+  }
 }
 
 internal data class ParameterData(

--- a/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
+++ b/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
@@ -302,7 +302,7 @@ class KotlinJsonAdapterFactory : JsonAdapter.Factory {
     for (property in allPropertiesSequence.distinctBy { it.name }) {
       val propertyField = property.fieldSignature?.let { signature ->
         val signatureString = signature.asString()
-        rawType.declaredFields.find { it.jvmFieldSignature == signatureString }
+        rawType.allFields().find { it.jvmFieldSignature == signatureString }
       }
       val parameterData = parametersByName[property.name]
 
@@ -551,6 +551,10 @@ private fun Class<*>.toKmClass(throwOnNotClass: Boolean): KmClass? {
 
 private fun Class<*>.allMethods(): Sequence<Method> {
   return declaredMethods.asSequence() + methods.asSequence()
+}
+
+private fun Class<*>.allFields(): Sequence<Field> {
+  return declaredFields.asSequence() + fields.asSequence()
 }
 
 internal data class ParameterData(

--- a/kotlin/reflect/src/main/resources/META-INF/com.android.tools/proguard/moshi-kotlin.pro
+++ b/kotlin/reflect/src/main/resources/META-INF/com.android.tools/proguard/moshi-kotlin.pro
@@ -8,16 +8,6 @@
 # Keep default constructor marker name for lookup in signatures.
 -keepnames class kotlin.jvm.internal.DefaultConstructorMarker
 
-# Keep names of Kotlin classes but allow shrinking if unused
--keepnames @kotlin.Metadata class *
-
-# Keep fields, constructors, and methods in Kotlin classes.
--keepclassmembers @kotlin.Metadata class * {
-  <fields>;
-  <init>(...);
-  <methods>;
-}
-
 # Keep implementations of service loaded interfaces
 -keep interface com.squareup.moshi.kotlin.kotlinx.metadata.impl.extensions.MetadataExtensions
 -keep class * implements com.squareup.moshi.kotlin.kotlinx.metadata.impl.extensions.MetadataExtensions { public protected *; }

--- a/kotlin/reflect/src/main/resources/META-INF/com.android.tools/proguard/moshi-kotlin.pro
+++ b/kotlin/reflect/src/main/resources/META-INF/com.android.tools/proguard/moshi-kotlin.pro
@@ -1,7 +1,7 @@
 # When editing this file, update the following files as well:
 # - META-INF/com.android.tools/r8-from-1.6.0/moshi-kotlin.pro
 # - META-INF/com.android.tools/r8-upto-1.6.0/moshi-kotlin.pro
-# - META-INF/com.android.tools/proguard/moshi-kotlin.pro
+# - META-INF/proguard/moshi-kotlin.pro
 # Keep Metadata annotations so they can be parsed at runtime.
 -keep class kotlin.Metadata { *; }
 
@@ -19,7 +19,6 @@
 }
 
 # Keep implementations of service loaded interfaces
-# R8 will automatically handle these these in 1.6+
 -keep interface com.squareup.moshi.kotlin.kotlinx.metadata.impl.extensions.MetadataExtensions
 -keep class * implements com.squareup.moshi.kotlin.kotlinx.metadata.impl.extensions.MetadataExtensions { public protected *; }
 

--- a/kotlin/reflect/src/main/resources/META-INF/com.android.tools/r8-from-1.6.0/moshi-kotlin.pro
+++ b/kotlin/reflect/src/main/resources/META-INF/com.android.tools/r8-from-1.6.0/moshi-kotlin.pro
@@ -8,16 +8,6 @@
 # Keep default constructor marker name for lookup in signatures.
 -keepnames class kotlin.jvm.internal.DefaultConstructorMarker
 
-# Keep names of Kotlin classes but allow shrinking if unused
--keepnames @kotlin.Metadata class *
-
-# Keep fields, constructors, and methods in Kotlin classes.
--keepclassmembers @kotlin.Metadata class * {
-  <fields>;
-  <init>(...);
-  <methods>;
-}
-
 # Keep generic signatures and annotations at runtime.
 # R8 requires InnerClasses and EnclosingMethod if you keepattributes Signature.
 -keepattributes InnerClasses,Signature,RuntimeVisible*Annotations,EnclosingMethod

--- a/kotlin/reflect/src/main/resources/META-INF/com.android.tools/r8-from-1.6.0/moshi-kotlin.pro
+++ b/kotlin/reflect/src/main/resources/META-INF/com.android.tools/r8-from-1.6.0/moshi-kotlin.pro
@@ -1,7 +1,7 @@
 # When editing this file, update the following files as well:
-# - META-INF/com.android.tools/r8-from-1.6.0/moshi-kotlin.pro
-# - META-INF/com.android.tools/r8-upto-1.6.0/moshi-kotlin.pro
 # - META-INF/com.android.tools/proguard/moshi-kotlin.pro
+# - META-INF/com.android.tools/r8-upto-1.6.0/moshi-kotlin.pro
+# - META-INF/proguard/moshi-kotlin.pro
 # Keep Metadata annotations so they can be parsed at runtime.
 -keep class kotlin.Metadata { *; }
 
@@ -18,10 +18,6 @@
   <methods>;
 }
 
-# Keep implementations of service loaded interfaces
-# R8 will automatically handle these these in 1.6+
--keep interface com.squareup.moshi.kotlin.kotlinx.metadata.impl.extensions.MetadataExtensions
--keep class * implements com.squareup.moshi.kotlin.kotlinx.metadata.impl.extensions.MetadataExtensions { public protected *; }
-
 # Keep generic signatures and annotations at runtime.
--keepattributes Signature,RuntimeVisible*Annotations
+# R8 requires InnerClasses and EnclosingMethod if you keepattributes Signature.
+-keepattributes InnerClasses,Signature,RuntimeVisible*Annotations,EnclosingMethod

--- a/kotlin/reflect/src/main/resources/META-INF/com.android.tools/r8-upto-1.6.0/moshi-kotlin.pro
+++ b/kotlin/reflect/src/main/resources/META-INF/com.android.tools/r8-upto-1.6.0/moshi-kotlin.pro
@@ -1,7 +1,7 @@
 # When editing this file, update the following files as well:
-# - META-INF/com.android.tools/r8-from-1.6.0/moshi-kotlin.pro
-# - META-INF/com.android.tools/r8-upto-1.6.0/moshi-kotlin.pro
 # - META-INF/com.android.tools/proguard/moshi-kotlin.pro
+# - META-INF/com.android.tools/r8-from-1.6.0/moshi-kotlin.pro
+# - META-INF/proguard/moshi-kotlin.pro
 # Keep Metadata annotations so they can be parsed at runtime.
 -keep class kotlin.Metadata { *; }
 
@@ -24,4 +24,5 @@
 -keep class * implements com.squareup.moshi.kotlin.kotlinx.metadata.impl.extensions.MetadataExtensions { public protected *; }
 
 # Keep generic signatures and annotations at runtime.
--keepattributes Signature,RuntimeVisible*Annotations
+# R8 requires InnerClasses and EnclosingMethod if you keepattributes Signature.
+-keepattributes InnerClasses,Signature,RuntimeVisible*Annotations,EnclosingMethod

--- a/kotlin/reflect/src/main/resources/META-INF/com.android.tools/r8-upto-1.6.0/moshi-kotlin.pro
+++ b/kotlin/reflect/src/main/resources/META-INF/com.android.tools/r8-upto-1.6.0/moshi-kotlin.pro
@@ -8,16 +8,6 @@
 # Keep default constructor marker name for lookup in signatures.
 -keepnames class kotlin.jvm.internal.DefaultConstructorMarker
 
-# Keep names of Kotlin classes but allow shrinking if unused
--keepnames @kotlin.Metadata class *
-
-# Keep fields, constructors, and methods in Kotlin classes.
--keepclassmembers @kotlin.Metadata class * {
-  <fields>;
-  <init>(...);
-  <methods>;
-}
-
 # Keep implementations of service loaded interfaces
 # R8 will automatically handle these these in 1.6+
 -keep interface com.squareup.moshi.kotlin.kotlinx.metadata.impl.extensions.MetadataExtensions

--- a/kotlin/reflect/src/main/resources/META-INF/proguard/moshi-kotlin.pro
+++ b/kotlin/reflect/src/main/resources/META-INF/proguard/moshi-kotlin.pro
@@ -1,5 +1,3 @@
--keep class kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoaderImpl
-
 -keepclassmembers class kotlin.Metadata {
     public <methods>;
 }

--- a/kotlin/reflect/src/main/resources/META-INF/proguard/moshi-kotlin.pro
+++ b/kotlin/reflect/src/main/resources/META-INF/proguard/moshi-kotlin.pro
@@ -8,16 +8,6 @@
 # Keep default constructor marker name for lookup in signatures.
 -keepnames class kotlin.jvm.internal.DefaultConstructorMarker
 
-# Keep names of Kotlin classes but allow shrinking if unused
--keepnames @kotlin.Metadata class *
-
-# Keep fields, constructors, and methods in Kotlin classes.
--keepclassmembers @kotlin.Metadata class * {
-  <fields>;
-  <init>(...);
-  <methods>;
-}
-
 # Keep implementations of service loaded interfaces
 # R8 will automatically handle these these in 1.6+
 -keep interface com.squareup.moshi.kotlin.kotlinx.metadata.impl.extensions.MetadataExtensions

--- a/kotlin/tests/pom.xml
+++ b/kotlin/tests/pom.xml
@@ -28,6 +28,10 @@
       <artifactId>kotlin-stdlib</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-reflect</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -28,6 +28,7 @@ import com.squareup.moshi.ToJson
 import com.squareup.moshi.Types
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
+import org.junit.Ignore
 import org.junit.Test
 import java.io.ByteArrayOutputStream
 import java.lang.reflect.ParameterizedType
@@ -416,7 +417,9 @@ class KotlinJsonAdapterTest {
 
   internal class ExtendsPlatformClassWithPrivateField(var a: Int) : SimpleTimeZone(0, "C")
 
-  @Test fun extendsPlatformClassWithProtectedField() {
+  @Ignore("Pending review")
+  @Test
+  fun extendsPlatformClassWithProtectedField() {
     val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
     val jsonAdapter = moshi.adapter<ExtendsPlatformClassWithProtectedField>()
 

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -315,9 +315,7 @@ class KotlinJsonAdapterTest {
       moshi.adapter<RequiredTransientConstructorParameter>()
       fail()
     } catch (expected: IllegalArgumentException) {
-      assertThat(expected).hasMessage("No default value for transient constructor parameter #0 " +
-          "a of fun <init>(kotlin.Int): " +
-          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest.RequiredTransientConstructorParameter")
+      assertThat(expected).hasMessage("No default value for transient constructor parameter 'a' on type '${RequiredTransientConstructorParameter::class.qualifiedName}'")
     }
   }
 
@@ -586,8 +584,7 @@ class KotlinJsonAdapterTest {
       fail()
     } catch(expected: IllegalArgumentException) {
       assertThat(expected).hasMessage(
-          "No property for required constructor parameter #0 a of fun <init>(" +
-              "kotlin.Int, kotlin.Int): ${NonPropertyConstructorParameter::class.qualifiedName}")
+          "No property for required constructor parameter 'a' on type '${NonPropertyConstructorParameter::class.qualifiedName}'")
     }
   }
 


### PR DESCRIPTION
Kotlin-reflect has been a long-standing thorn for `KotlinJsonAdapter` for a number of reasons:

- It has a huge impact on binary size, both in terms of the library and the compiler impact. When removing it from the slack code base recently, it saved us nearly 10k methods just by removing it (even though only 2 were used!)
- It's super slow and heavyweight
- It has a number of tricky proguard considerations

This PR replaces kotlin-reflect entirely with kotlinx-metadata-reflect, the low-level metadata library we use in code gen (via kotlinpoet-metadata). It's also what the `kotlinx.reflect.lite` project is in the process of being [migrated to](https://github.com/Kotlin/kotlinx.reflect.lite/pull/12), and used in a number of other major toolchains now (Dagger, R8, etc).

Effectively, this skips past `kotlinx.reflect.lite` and replaces `kotlin-reflect` with something closer to an "ultralight" setup, set up specific to Moshi's needs. It's a significant change to the adapter, but the core logic remains the same with one notable exception (documented at the end).

This supersedes #307, but effectively resolves #307 in spirit.

### Stats

Quick androidx-benchmark on my serialization benchmarks project shows this is ~21.5% faster for buffer reads as well! https://github.com/ZacSweers/json-serialization-benchmarking/pull/10

```
AndroidBenchmark.moshi_kotlin_codegen_buffer_toJson[minified=true]                   5,052,032  ns
AndroidBenchmark.moshi_kotlin_codegen_string_toJson[minified=true]                   7,072,449  ns
AndroidBenchmark.moshi_kotlin_reflective_metadata_buffer_toJson[minified=true]       8,096,823  ns
AndroidBenchmark.moshi_kotlin_reflective_buffer_toJson[minified=true]                9,461,355  ns
AndroidBenchmark.moshi_kotlin_reflective_string_toJson[minified=true]               11,308,542  ns

AndroidBenchmark.moshi_kotlin_codegen_buffer_fromJson[minified=true]                 7,553,282  ns
AndroidBenchmark.moshi_kotlin_codegen_string_fromJson[minified=true]                 8,746,668  ns
AndroidBenchmark.moshi_kotlin_reflective_metadata_buffer_fromJson[minified=true]     9,167,501  ns
AndroidBenchmark.moshi_kotlin_codegen_buffer_fromJson[minified=false]               10,039,950  ns
AndroidBenchmark.moshi_kotlin_reflective_buffer_fromJson[minified=true]             10,454,168  ns
AndroidBenchmark.moshi_kotlin_reflective_metadata_buffer_fromJson[minified=false]   11,691,721  ns
AndroidBenchmark.moshi_kotlin_codegen_string_fromJson[minified=false]               11,716,408  ns
AndroidBenchmark.moshi_kotlin_reflective_string_fromJson[minified=true]             11,734,532  ns
AndroidBenchmark.moshi_kotlin_reflective_buffer_fromJson[minified=false]            12,930,158  ns
AndroidBenchmark.moshi_kotlin_reflective_string_fromJson[minified=false]            14,747,397  ns
```

### Two open questions
* The behavior change is that moshi-kotlin still allowed extending from and encoding non-kotlin superclasses and their properties. I think this was an oversight when we stopped supporting mixing them in Moshi 1.8, as this doesn't match the behavior of code gen.
* ~~What are the appropriate proguard rules for this?~~