### PR TITLE
Document thread safety

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
@@ -31,10 +31,10 @@ import okio.BufferedSource;
 /**
  * Converts Java values to JSON, and JSON values to Java.
  *
- * JsonAdapter instances provided by Moshi are thread-safe, meaning multiple threads can safely use a single instance
+ * <p>JsonAdapter instances provided by Moshi are thread-safe, meaning multiple threads can safely use a single instance
  * concurrently.
  *
- * Custom JsonAdapter implementations should be designed to be thread-safe.
+ * <p>Custom JsonAdapter implementations should be designed to be thread-safe.
  */
 public abstract class JsonAdapter<T> {
   @CheckReturnValue public abstract @Nullable T fromJson(JsonReader reader) throws IOException;

--- a/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
@@ -31,8 +31,8 @@ import okio.BufferedSource;
 /**
  * Converts Java values to JSON, and JSON values to Java.
  *
- * <p>JsonAdapter instances provided by Moshi are thread-safe, meaning multiple threads can safely use a single instance
- * concurrently.
+ * <p>JsonAdapter instances provided by Moshi are thread-safe, meaning multiple threads can safely
+ * use a single instance concurrently.
  *
  * <p>Custom JsonAdapter implementations should be designed to be thread-safe.
  */

--- a/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonAdapter.java
@@ -30,6 +30,11 @@ import okio.BufferedSource;
 
 /**
  * Converts Java values to JSON, and JSON values to Java.
+ *
+ * JsonAdapter instances provided by Moshi are thread-safe, meaning multiple threads can safely use a single instance
+ * concurrently.
+ *
+ * Custom JsonAdapter implementations should be designed to be thread-safe.
  */
 public abstract class JsonAdapter<T> {
   @CheckReturnValue public abstract @Nullable T fromJson(JsonReader reader) throws IOException;

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -188,7 +188,7 @@ public final class Moshi {
   }
 
   public static final class Builder {
-    final List<JsonAdapter.Factory> factories = new ArrayList<>();
+    final List<JsonAdapter.Factory> factories = Collections.synchronizedList(new ArrayList<JsonAdapter.Factory>());
 
     public <T> Builder add(final Type type, final JsonAdapter<T> jsonAdapter) {
       if (type == null) throw new IllegalArgumentException("type == null");

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -40,7 +40,8 @@ import static com.squareup.moshi.internal.Util.typeAnnotatedWithAnnotations;
 /**
  * Coordinates binding between JSON values and Java objects.
  *
- * <p>Moshi instances are thread-safe, meaning multiple threads can safely use a single instance concurrently.
+ * <p>Moshi instances are thread-safe, meaning multiple threads can safely use a single instance
+ * concurrently.
  */
 public final class Moshi {
   static final List<JsonAdapter.Factory> BUILT_IN_FACTORIES = new ArrayList<>(5);
@@ -192,10 +193,12 @@ public final class Moshi {
   /**
    * Builder class for preparing instances of Moshi.
    *
-   * <p>Builder instances are thread-safe, meaning multiple threads can safely use a single instance concurrently.
+   * <p>Builder instances are thread-safe, meaning multiple threads can safely use a single
+   * instance concurrently.
    */
   public static final class Builder {
-    final List<JsonAdapter.Factory> factories = Collections.synchronizedList(new ArrayList<JsonAdapter.Factory>());
+    final List<JsonAdapter.Factory> factories =
+        Collections.synchronizedList(new ArrayList<JsonAdapter.Factory>());
 
     public <T> Builder add(final Type type, final JsonAdapter<T> jsonAdapter) {
       if (type == null) throw new IllegalArgumentException("type == null");

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -39,6 +39,8 @@ import static com.squareup.moshi.internal.Util.typeAnnotatedWithAnnotations;
 
 /**
  * Coordinates binding between JSON values and Java objects.
+ *
+ * Moshi instances are thread-safe, meaning multiple threads can safely use a single instance concurrently.
  */
 public final class Moshi {
   static final List<JsonAdapter.Factory> BUILT_IN_FACTORIES = new ArrayList<>(5);
@@ -187,6 +189,11 @@ public final class Moshi {
     return Arrays.asList(type, annotations);
   }
 
+  /**
+   * Builder class for preparing instances of Moshi.
+   *
+   * Builder instances are thread-safe, meaning multiple threads can safely use a single instance concurrently.
+   */
   public static final class Builder {
     final List<JsonAdapter.Factory> factories = Collections.synchronizedList(new ArrayList<JsonAdapter.Factory>());
 

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -190,15 +190,8 @@ public final class Moshi {
     return Arrays.asList(type, annotations);
   }
 
-  /**
-   * Builder class for preparing instances of Moshi.
-   *
-   * <p>Builder instances are thread-safe, meaning multiple threads can safely use a single
-   * instance concurrently.
-   */
   public static final class Builder {
-    final List<JsonAdapter.Factory> factories =
-        Collections.synchronizedList(new ArrayList<JsonAdapter.Factory>());
+    final List<JsonAdapter.Factory> factories = new ArrayList<>();
 
     public <T> Builder add(final Type type, final JsonAdapter<T> jsonAdapter) {
       if (type == null) throw new IllegalArgumentException("type == null");

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -40,7 +40,7 @@ import static com.squareup.moshi.internal.Util.typeAnnotatedWithAnnotations;
 /**
  * Coordinates binding between JSON values and Java objects.
  *
- * Moshi instances are thread-safe, meaning multiple threads can safely use a single instance concurrently.
+ * <p>Moshi instances are thread-safe, meaning multiple threads can safely use a single instance concurrently.
  */
 public final class Moshi {
   static final List<JsonAdapter.Factory> BUILT_IN_FACTORIES = new ArrayList<>(5);
@@ -192,7 +192,7 @@ public final class Moshi {
   /**
    * Builder class for preparing instances of Moshi.
    *
-   * Builder instances are thread-safe, meaning multiple threads can safely use a single instance concurrently.
+   * <p>Builder instances are thread-safe, meaning multiple threads can safely use a single instance concurrently.
    */
   public static final class Builder {
     final List<JsonAdapter.Factory> factories = Collections.synchronizedList(new ArrayList<JsonAdapter.Factory>());


### PR DESCRIPTION
As per #1119.

I've just done Moshi, Moshi.Builder and JsonAdapter. Happy to do more on request.

Note that Moshi.Builder wasn't thread-safe, so I trivially made it so by synchronizing its list of factories.