### PR TITLE
Introduce the concept of readOnly/writeOnly generated adapters

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessor.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessor.kt
@@ -112,7 +112,14 @@ class JsonClassCodegenProcessor : AbstractProcessor() {
       }
       val jsonClass = type.getAnnotation(annotation)
       if (jsonClass.generateAdapter && jsonClass.generator.isEmpty()) {
-        val generator = adapterGenerator(type, cachedClassInspector) ?: continue
+        if (jsonClass.readOnly && jsonClass.writeOnly) {
+          messager.printMessage(
+            Diagnostic.Kind.ERROR, "@JsonClass can't be both readOnly and writeOnly",
+            type)
+          continue
+        }
+        val generator = adapterGenerator(type, cachedClassInspector,
+                jsonClass.readOnly, jsonClass.writeOnly) ?: continue
         val preparedAdapter = generator
             .prepare { spec ->
               spec.toBuilder()
@@ -141,7 +148,9 @@ class JsonClassCodegenProcessor : AbstractProcessor() {
 
   private fun adapterGenerator(
       element: TypeElement,
-      cachedClassInspector: MoshiCachedClassInspector
+      cachedClassInspector: MoshiCachedClassInspector,
+      readOnly: Boolean,
+      writeOnly: Boolean
   ): AdapterGenerator? {
     val type = targetType(messager, elements, types, element, cachedClassInspector) ?: return null
 
@@ -172,6 +181,6 @@ class JsonClassCodegenProcessor : AbstractProcessor() {
       }
     }
 
-    return AdapterGenerator(type, sortedProperties)
+    return AdapterGenerator(type, sortedProperties, readOnly, writeOnly)
   }
 }

--- a/moshi/src/main/java/com/squareup/moshi/JsonClass.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonClass.java
@@ -46,6 +46,22 @@ public @interface JsonClass {
   boolean generateAdapter();
 
   /**
+   * An optional parameter that replace generated toJson() code of the adapter to simply throw a
+   * {@link JsonDataException}.
+   *
+   * <p>Reduce generated code size when data is never serialized to JSON.
+   */
+  boolean readOnly() default false;
+
+  /**
+   * An optional parameter that replace generated fromJson() code of the adapter to simply throw a
+   * {@link JsonDataException}.
+   *
+   * <p>Reduce generated code size when data is never deserialized from JSON.
+   */
+  boolean writeOnly() default false;
+
+  /**
    * An optional custom generator tag used to indicate which generator should be used. If empty,
    * Moshi's annotation processor will generate an adapter for the annotated type. If not empty,
    * Moshi's processor will skip it and defer to a custom generator. This can be used to allow


### PR DESCRIPTION
This is a proposal for discussion.

I wanted a quick test to evaluate the gains, and open discussion.
My application talks to many different APIs that have many endpoints with many many properties, but 95% of them are only read and never written.

Applying this to my main app, gains 300KB in the final dex size, and 120KB to the APK size, those are not small numbers, so it would be nice to have something to handle this use case.