### PR TITLE
[Using delegation] Introduced DataMappingMismatchLog to track mapping errors

### DIFF
--- a/adapters/src/main/java/com/squareup/moshi/adapters/EnumJsonAdapter.java
+++ b/adapters/src/main/java/com/squareup/moshi/adapters/EnumJsonAdapter.java
@@ -15,8 +15,12 @@
  */
 package com.squareup.moshi.adapters;
 
-import com.squareup.moshi.*;
-
+import com.squareup.moshi.DataMappingAuditor;
+import com.squareup.moshi.Json;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonDataException;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
 import javax.annotation.Nullable;

--- a/adapters/src/main/java/com/squareup/moshi/adapters/EnumJsonAdapter.java
+++ b/adapters/src/main/java/com/squareup/moshi/adapters/EnumJsonAdapter.java
@@ -15,11 +15,8 @@
  */
 package com.squareup.moshi.adapters;
 
-import com.squareup.moshi.Json;
-import com.squareup.moshi.JsonAdapter;
-import com.squareup.moshi.JsonDataException;
-import com.squareup.moshi.JsonReader;
-import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.*;
+
 import java.io.IOException;
 import java.util.Arrays;
 import javax.annotation.Nullable;
@@ -92,7 +89,13 @@ public final class EnumJsonAdapter<T extends Enum<T>> extends JsonAdapter<T> {
       throw new JsonDataException(
           "Expected a string but was " + reader.peek() + " at path " + path);
     }
-    reader.skipValue();
+
+    if (reader instanceof DataMappingAuditor) {
+      ((DataMappingAuditor) reader).addUnknownEnum(
+          new DataMappingAuditor.UnknownEnum(path, reader.nextString()));
+    } else {
+      reader.skipValue();
+    }
     return fallbackValue;
   }
 

--- a/adapters/src/test/java/com/squareup/moshi/adapters/EnumJsonAdapterTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/EnumJsonAdapterTest.java
@@ -15,9 +15,7 @@
  */
 package com.squareup.moshi.adapters;
 
-import com.squareup.moshi.Json;
-import com.squareup.moshi.JsonDataException;
-import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.*;
 import okio.Buffer;
 import org.junit.Test;
 
@@ -57,6 +55,19 @@ public final class EnumJsonAdapterTest {
     JsonReader reader = JsonReader.of(new Buffer().writeUtf8("\"SPOCK\""));
     assertThat(adapter.fromJson(reader)).isEqualTo(Roshambo.ROCK);
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+  }
+
+  @Test public void withFallbackValueAndAuditJsonReader() throws Exception {
+    EnumJsonAdapter<Roshambo> adapter = EnumJsonAdapter.create(Roshambo.class)
+        .withUnknownFallback(Roshambo.ROCK);
+    AuditJsonReader reader = new AuditJsonReader(JsonReader.of(new Buffer().writeUtf8("\"SPOCK\"")));
+    assertThat(adapter.fromJson(reader)).isEqualTo(Roshambo.ROCK);
+    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+
+    assertThat(reader.getUnknownEnums().size()).isEqualTo(1);
+    DataMappingAuditor.UnknownEnum unknownEnumValue = reader.getUnknownEnums().get(0);
+    assertThat(unknownEnumValue.name).isEqualTo("SPOCK");
+    assertThat(unknownEnumValue.path).isEqualTo("$");
   }
 
   @Test public void withNullFallbackValue() throws Exception {

--- a/adapters/src/test/java/com/squareup/moshi/adapters/EnumJsonAdapterTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/EnumJsonAdapterTest.java
@@ -15,7 +15,11 @@
  */
 package com.squareup.moshi.adapters;
 
-import com.squareup.moshi.*;
+import com.squareup.moshi.AuditJsonReader;
+import com.squareup.moshi.DataMappingAuditor;
+import com.squareup.moshi.Json;
+import com.squareup.moshi.JsonDataException;
+import com.squareup.moshi.JsonReader;
 import okio.Buffer;
 import org.junit.Test;
 

--- a/examples/src/main/java/com/squareup/moshi/recipes/FallbackEnum.java
+++ b/examples/src/main/java/com/squareup/moshi/recipes/FallbackEnum.java
@@ -57,7 +57,7 @@ final class FallbackEnum {
           return null;
         }
         Class<Enum> enumType = (Class<Enum>) rawType;
-        Enum<?> fallback = Enum.valueOf(enumType, ((Fallback) annotation).value());
+        Enum fallback = Enum.valueOf(enumType, ((Fallback) annotation).value());
         return new FallbackEnumJsonAdapter<>(enumType, fallback);
       }
     };

--- a/moshi/src/main/java/com/squareup/moshi/AbstractJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/AbstractJsonReader.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright (C) 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.moshi;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+import okio.Buffer;
+import okio.BufferedSource;
+import okio.ByteString;
+
+/**
+ * Reads a JSON (<a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>)
+ * encoded value as a stream of tokens. This stream includes both literal
+ * values (strings, numbers, booleans, and nulls) as well as the begin and
+ * end delimiters of objects and arrays. The tokens are traversed in
+ * depth-first order, the same order that they appear in the JSON document.
+ * Within JSON objects, name/value pairs are represented by a single token.
+ *
+ * <h3>Parsing JSON</h3>
+ * To create a recursive descent parser for your own JSON streams, first create
+ * an entry point method that creates a {@code JsonReader}.
+ *
+ * <p>Next, create handler methods for each structure in your JSON text. You'll
+ * need a method for each object type and for each array type.
+ * <ul>
+ *   <li>Within <strong>array handling</strong> methods, first call {@link
+ *       #beginArray} to consume the array's opening bracket. Then create a
+ *       while loop that accumulates values, terminating when {@link #hasNext}
+ *       is false. Finally, read the array's closing bracket by calling {@link
+ *       #endArray}.
+ *   <li>Within <strong>object handling</strong> methods, first call {@link
+ *       #beginObject} to consume the object's opening brace. Then create a
+ *       while loop that assigns values to local variables based on their name.
+ *       This loop should terminate when {@link #hasNext} is false. Finally,
+ *       read the object's closing brace by calling {@link #endObject}.
+ * </ul>
+ * <p>When a nested object or array is encountered, delegate to the
+ * corresponding handler method.
+ *
+ * <p>When an unknown name is encountered, strict parsers should fail with an
+ * exception. Lenient parsers should call {@link #skipValue()} to recursively
+ * skip the value's nested tokens, which may otherwise conflict.
+ *
+ * <p>If a value may be null, you should first check using {@link #peek()}.
+ * Null literals can be consumed using either {@link #nextNull()} or {@link
+ * #skipValue()}.
+ *
+ * <h3>Example</h3>
+ * Suppose we'd like to parse a stream of messages such as the following: <pre> {@code
+ * [
+ *   {
+ *     "id": 912345678901,
+ *     "text": "How do I read a JSON stream in Java?",
+ *     "geo": null,
+ *     "user": {
+ *       "name": "json_newb",
+ *       "followers_count": 41
+ *      }
+ *   },
+ *   {
+ *     "id": 912345678902,
+ *     "text": "@json_newb just use JsonReader!",
+ *     "geo": [50.454722, -104.606667],
+ *     "user": {
+ *       "name": "jesse",
+ *       "followers_count": 2
+ *     }
+ *   }
+ * ]}</pre>
+ * This code implements the parser for the above structure: <pre>   {@code
+ *
+ *   public List<Message> readJsonStream(BufferedSource source) throws IOException {
+ *     JsonReader reader = JsonReader.of(source);
+ *     try {
+ *       return readMessagesArray(reader);
+ *     } finally {
+ *       reader.close();
+ *     }
+ *   }
+ *
+ *   public List<Message> readMessagesArray(JsonReader reader) throws IOException {
+ *     List<Message> messages = new ArrayList<Message>();
+ *
+ *     reader.beginArray();
+ *     while (reader.hasNext()) {
+ *       messages.add(readMessage(reader));
+ *     }
+ *     reader.endArray();
+ *     return messages;
+ *   }
+ *
+ *   public Message readMessage(JsonReader reader) throws IOException {
+ *     long id = -1;
+ *     String text = null;
+ *     User user = null;
+ *     List<Double> geo = null;
+ *
+ *     reader.beginObject();
+ *     while (reader.hasNext()) {
+ *       String name = reader.nextName();
+ *       if (name.equals("id")) {
+ *         id = reader.nextLong();
+ *       } else if (name.equals("text")) {
+ *         text = reader.nextString();
+ *       } else if (name.equals("geo") && reader.peek() != Token.NULL) {
+ *         geo = readDoublesArray(reader);
+ *       } else if (name.equals("user")) {
+ *         user = readUser(reader);
+ *       } else {
+ *         reader.skipValue();
+ *       }
+ *     }
+ *     reader.endObject();
+ *     return new Message(id, text, user, geo);
+ *   }
+ *
+ *   public List<Double> readDoublesArray(JsonReader reader) throws IOException {
+ *     List<Double> doubles = new ArrayList<Double>();
+ *
+ *     reader.beginArray();
+ *     while (reader.hasNext()) {
+ *       doubles.add(reader.nextDouble());
+ *     }
+ *     reader.endArray();
+ *     return doubles;
+ *   }
+ *
+ *   public User readUser(JsonReader reader) throws IOException {
+ *     String username = null;
+ *     int followersCount = -1;
+ *
+ *     reader.beginObject();
+ *     while (reader.hasNext()) {
+ *       String name = reader.nextName();
+ *       if (name.equals("name")) {
+ *         username = reader.nextString();
+ *       } else if (name.equals("followers_count")) {
+ *         followersCount = reader.nextInt();
+ *       } else {
+ *         reader.skipValue();
+ *       }
+ *     }
+ *     reader.endObject();
+ *     return new User(username, followersCount);
+ *   }}</pre>
+ *
+ * <h3>Number Handling</h3>
+ * This reader permits numeric values to be read as strings and string values to
+ * be read as numbers. For example, both elements of the JSON array {@code
+ * [1, "1"]} may be read using either {@link #nextInt} or {@link #nextString}.
+ * This behavior is intended to prevent lossy numeric conversions: double is
+ * JavaScript's only numeric type and very large values like {@code
+ * 9007199254740993} cannot be represented exactly on that platform. To minimize
+ * precision loss, extremely large values should be written and read as strings
+ * in JSON.
+ *
+ * <p>Each {@code JsonReader} may be used to read a single JSON stream. Instances
+ * of this class are not thread safe.
+ */
+public abstract class AbstractJsonReader implements JsonReader {
+  // The nesting stack. Using a manual array rather than an ArrayList saves 20%. This stack will
+  // grow itself up to 256 levels of nesting including the top-level document. Deeper nesting is
+  // prone to trigger StackOverflowErrors.
+  int stackSize;
+  int[] scopes;
+  String[] pathNames;
+  int[] pathIndices;
+
+  /** True to accept non-spec compliant JSON. */
+  boolean lenient;
+
+  /** True to throw a {@link JsonDataException} on any attempt to call {@link #skipValue()}. */
+  boolean failOnUnknown;
+
+  // Package-private to control subclasses.
+  AbstractJsonReader() {
+    scopes = new int[32];
+    pathNames = new String[32];
+    pathIndices = new int[32];
+  }
+
+  // Package-private to control subclasses.
+  AbstractJsonReader(AbstractJsonReader copyFrom) {
+    this.stackSize = copyFrom.stackSize;
+    this.scopes = copyFrom.scopes.clone();
+    this.pathNames = copyFrom.pathNames.clone();
+    this.pathIndices = copyFrom.pathIndices.clone();
+    this.lenient = copyFrom.lenient;
+    this.failOnUnknown = copyFrom.failOnUnknown;
+  }
+
+  final void pushScope(int newTop) {
+    if (stackSize == scopes.length) {
+      if (stackSize == 256) {
+        throw new JsonDataException("Nesting too deep at " + getPath());
+      }
+      scopes = Arrays.copyOf(scopes, scopes.length * 2);
+      pathNames = Arrays.copyOf(pathNames, pathNames.length * 2);
+      pathIndices = Arrays.copyOf(pathIndices, pathIndices.length * 2);
+    }
+    scopes[stackSize++] = newTop;
+  }
+
+  /**
+   * Throws a new IO exception with the given message and a context snippet
+   * with this reader's content.
+   */
+  final JsonEncodingException syntaxError(String message) throws JsonEncodingException {
+    throw new JsonEncodingException(message + " at path " + getPath());
+  }
+
+  final JsonDataException typeMismatch(@Nullable Object value, Object expected) {
+    if (value == null) {
+      return new JsonDataException(
+          "Expected " + expected + " but was null at path " + getPath());
+    } else {
+      return new JsonDataException("Expected " + expected + " but was " + value + ", a "
+          + value.getClass().getName() + ", at path " + getPath());
+    }
+  }
+
+  /**
+   * Configure this parser to be liberal in what it accepts. By default
+   * this parser is strict and only accepts JSON as specified by <a
+   * href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>. Setting the
+   * parser to lenient causes it to ignore the following syntax errors:
+   *
+   * <ul>
+   *   <li>Streams that include multiple top-level values. With strict parsing,
+   *       each stream must contain exactly one top-level value.
+   *   <li>Numbers may be {@linkplain Double#isNaN() NaNs} or {@link
+   *       Double#isInfinite() infinities}.
+   *   <li>End of line comments starting with {@code //} or {@code #} and
+   *       ending with a newline character.
+   *   <li>C-style comments starting with {@code /*} and ending with
+   *       {@code *}{@code /}. Such comments may not be nested.
+   *   <li>Names that are unquoted or {@code 'single quoted'}.
+   *   <li>Strings that are unquoted or {@code 'single quoted'}.
+   *   <li>Array elements separated by {@code ;} instead of {@code ,}.
+   *   <li>Unnecessary array separators. These are interpreted as if null
+   *       was the omitted value.
+   *   <li>Names and values separated by {@code =} or {@code =>} instead of
+   *       {@code :}.
+   *   <li>Name/value pairs separated by {@code ;} instead of {@code ,}.
+   * </ul>
+   */
+  @Override
+  public final void setLenient(boolean lenient) {
+    this.lenient = lenient;
+  }
+
+  /**
+   * Returns true if this parser is liberal in what it accepts.
+   */
+  @Override
+  @CheckReturnValue public final boolean isLenient() {
+    return lenient;
+  }
+
+  /**
+   * Configure whether this parser throws a {@link JsonDataException} when {@link #skipValue} is
+   * called. By default this parser permits values to be skipped.
+   *
+   * <p>Forbid skipping to prevent unrecognized values from being silently ignored. This option is
+   * useful in development and debugging because it means a typo like "locatiom" will be detected
+   * early. It's potentially harmful in production because it complicates revising a JSON schema.
+   */
+  @Override
+  public final void setFailOnUnknown(boolean failOnUnknown) {
+    this.failOnUnknown = failOnUnknown;
+  }
+
+  /**
+   * Returns true if this parser forbids skipping names and values.
+   */
+  @Override
+  @CheckReturnValue public final boolean failOnUnknown() {
+    return failOnUnknown;
+  }
+
+  /**
+   * Returns the value of the next token, consuming it. The result may be a string, number, boolean,
+   * null, map, or list, according to the JSON structure.
+   *
+   * @throws JsonDataException if the next token is not a literal value, if a JSON object has a
+   * duplicate key.
+   * @see JsonWriter#jsonValue(Object)
+   */
+  @Override
+  public final @Nullable Object readJsonValue() throws IOException {
+    switch (peek()) {
+      case BEGIN_ARRAY:
+        List<Object> list = new ArrayList<>();
+        beginArray();
+        while (hasNext()) {
+          list.add(readJsonValue());
+        }
+        endArray();
+        return list;
+
+      case BEGIN_OBJECT:
+        Map<String, Object> map = new LinkedHashTreeMap<>();
+        beginObject();
+        while (hasNext()) {
+          String name = nextName();
+          Object value = readJsonValue();
+          Object replaced = map.put(name, value);
+          if (replaced != null) {
+            throw new JsonDataException("Map key '" + name + "' has multiple values at path "
+                + getPath() + ": " + replaced + " and " + value);
+          }
+        }
+        endObject();
+        return map;
+
+      case STRING:
+        return nextString();
+
+      case NUMBER:
+        return nextDouble();
+
+      case BOOLEAN:
+        return nextBoolean();
+
+      case NULL:
+        return nextNull();
+
+      default:
+        throw new IllegalStateException(
+            "Expected a value but was " + peek() + " at path " + getPath());
+    }
+  }
+
+  /**
+   * Returns a <a href="http://goessner.net/articles/JsonPath/">JsonPath</a> to
+   * the current location in the JSON value.
+   */
+  @Override
+  @CheckReturnValue public final String getPath() {
+    return JsonScope.getPath(stackSize, scopes, pathNames, pathIndices);
+  }
+}

--- a/moshi/src/main/java/com/squareup/moshi/AbstractJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/AbstractJsonReader.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.moshi;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,9 +22,6 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
-import okio.Buffer;
-import okio.BufferedSource;
-import okio.ByteString;
 
 /**
  * Reads a JSON (<a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>)

--- a/moshi/src/main/java/com/squareup/moshi/AbstractJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/AbstractJsonReader.java
@@ -23,155 +23,6 @@ import java.util.Map;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 
-/**
- * Reads a JSON (<a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>)
- * encoded value as a stream of tokens. This stream includes both literal
- * values (strings, numbers, booleans, and nulls) as well as the begin and
- * end delimiters of objects and arrays. The tokens are traversed in
- * depth-first order, the same order that they appear in the JSON document.
- * Within JSON objects, name/value pairs are represented by a single token.
- *
- * <h3>Parsing JSON</h3>
- * To create a recursive descent parser for your own JSON streams, first create
- * an entry point method that creates a {@code JsonReader}.
- *
- * <p>Next, create handler methods for each structure in your JSON text. You'll
- * need a method for each object type and for each array type.
- * <ul>
- *   <li>Within <strong>array handling</strong> methods, first call {@link
- *       #beginArray} to consume the array's opening bracket. Then create a
- *       while loop that accumulates values, terminating when {@link #hasNext}
- *       is false. Finally, read the array's closing bracket by calling {@link
- *       #endArray}.
- *   <li>Within <strong>object handling</strong> methods, first call {@link
- *       #beginObject} to consume the object's opening brace. Then create a
- *       while loop that assigns values to local variables based on their name.
- *       This loop should terminate when {@link #hasNext} is false. Finally,
- *       read the object's closing brace by calling {@link #endObject}.
- * </ul>
- * <p>When a nested object or array is encountered, delegate to the
- * corresponding handler method.
- *
- * <p>When an unknown name is encountered, strict parsers should fail with an
- * exception. Lenient parsers should call {@link #skipValue()} to recursively
- * skip the value's nested tokens, which may otherwise conflict.
- *
- * <p>If a value may be null, you should first check using {@link #peek()}.
- * Null literals can be consumed using either {@link #nextNull()} or {@link
- * #skipValue()}.
- *
- * <h3>Example</h3>
- * Suppose we'd like to parse a stream of messages such as the following: <pre> {@code
- * [
- *   {
- *     "id": 912345678901,
- *     "text": "How do I read a JSON stream in Java?",
- *     "geo": null,
- *     "user": {
- *       "name": "json_newb",
- *       "followers_count": 41
- *      }
- *   },
- *   {
- *     "id": 912345678902,
- *     "text": "@json_newb just use JsonReader!",
- *     "geo": [50.454722, -104.606667],
- *     "user": {
- *       "name": "jesse",
- *       "followers_count": 2
- *     }
- *   }
- * ]}</pre>
- * This code implements the parser for the above structure: <pre>   {@code
- *
- *   public List<Message> readJsonStream(BufferedSource source) throws IOException {
- *     JsonReader reader = JsonReader.of(source);
- *     try {
- *       return readMessagesArray(reader);
- *     } finally {
- *       reader.close();
- *     }
- *   }
- *
- *   public List<Message> readMessagesArray(JsonReader reader) throws IOException {
- *     List<Message> messages = new ArrayList<Message>();
- *
- *     reader.beginArray();
- *     while (reader.hasNext()) {
- *       messages.add(readMessage(reader));
- *     }
- *     reader.endArray();
- *     return messages;
- *   }
- *
- *   public Message readMessage(JsonReader reader) throws IOException {
- *     long id = -1;
- *     String text = null;
- *     User user = null;
- *     List<Double> geo = null;
- *
- *     reader.beginObject();
- *     while (reader.hasNext()) {
- *       String name = reader.nextName();
- *       if (name.equals("id")) {
- *         id = reader.nextLong();
- *       } else if (name.equals("text")) {
- *         text = reader.nextString();
- *       } else if (name.equals("geo") && reader.peek() != Token.NULL) {
- *         geo = readDoublesArray(reader);
- *       } else if (name.equals("user")) {
- *         user = readUser(reader);
- *       } else {
- *         reader.skipValue();
- *       }
- *     }
- *     reader.endObject();
- *     return new Message(id, text, user, geo);
- *   }
- *
- *   public List<Double> readDoublesArray(JsonReader reader) throws IOException {
- *     List<Double> doubles = new ArrayList<Double>();
- *
- *     reader.beginArray();
- *     while (reader.hasNext()) {
- *       doubles.add(reader.nextDouble());
- *     }
- *     reader.endArray();
- *     return doubles;
- *   }
- *
- *   public User readUser(JsonReader reader) throws IOException {
- *     String username = null;
- *     int followersCount = -1;
- *
- *     reader.beginObject();
- *     while (reader.hasNext()) {
- *       String name = reader.nextName();
- *       if (name.equals("name")) {
- *         username = reader.nextString();
- *       } else if (name.equals("followers_count")) {
- *         followersCount = reader.nextInt();
- *       } else {
- *         reader.skipValue();
- *       }
- *     }
- *     reader.endObject();
- *     return new User(username, followersCount);
- *   }}</pre>
- *
- * <h3>Number Handling</h3>
- * This reader permits numeric values to be read as strings and string values to
- * be read as numbers. For example, both elements of the JSON array {@code
- * [1, "1"]} may be read using either {@link #nextInt} or {@link #nextString}.
- * This behavior is intended to prevent lossy numeric conversions: double is
- * JavaScript's only numeric type and very large values like {@code
- * 9007199254740993} cannot be represented exactly on that platform. To minimize
- * precision loss, extremely large values should be written and read as strings
- * in JSON.
- *
- * <p>Each {@code JsonReader} may be used to read a single JSON stream. Instances
- * of this class are not thread safe.
- */
 public abstract class AbstractJsonReader implements JsonReader {
   // The nesting stack. Using a manual array rather than an ArrayList saves 20%. This stack will
   // grow itself up to 256 levels of nesting including the top-level document. Deeper nesting is
@@ -234,73 +85,26 @@ public abstract class AbstractJsonReader implements JsonReader {
     }
   }
 
-  /**
-   * Configure this parser to be liberal in what it accepts. By default
-   * this parser is strict and only accepts JSON as specified by <a
-   * href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>. Setting the
-   * parser to lenient causes it to ignore the following syntax errors:
-   *
-   * <ul>
-   *   <li>Streams that include multiple top-level values. With strict parsing,
-   *       each stream must contain exactly one top-level value.
-   *   <li>Numbers may be {@linkplain Double#isNaN() NaNs} or {@link
-   *       Double#isInfinite() infinities}.
-   *   <li>End of line comments starting with {@code //} or {@code #} and
-   *       ending with a newline character.
-   *   <li>C-style comments starting with {@code /*} and ending with
-   *       {@code *}{@code /}. Such comments may not be nested.
-   *   <li>Names that are unquoted or {@code 'single quoted'}.
-   *   <li>Strings that are unquoted or {@code 'single quoted'}.
-   *   <li>Array elements separated by {@code ;} instead of {@code ,}.
-   *   <li>Unnecessary array separators. These are interpreted as if null
-   *       was the omitted value.
-   *   <li>Names and values separated by {@code =} or {@code =>} instead of
-   *       {@code :}.
-   *   <li>Name/value pairs separated by {@code ;} instead of {@code ,}.
-   * </ul>
-   */
   @Override
   public final void setLenient(boolean lenient) {
     this.lenient = lenient;
   }
 
-  /**
-   * Returns true if this parser is liberal in what it accepts.
-   */
   @Override
   @CheckReturnValue public final boolean isLenient() {
     return lenient;
   }
 
-  /**
-   * Configure whether this parser throws a {@link JsonDataException} when {@link #skipValue} is
-   * called. By default this parser permits values to be skipped.
-   *
-   * <p>Forbid skipping to prevent unrecognized values from being silently ignored. This option is
-   * useful in development and debugging because it means a typo like "locatiom" will be detected
-   * early. It's potentially harmful in production because it complicates revising a JSON schema.
-   */
   @Override
   public final void setFailOnUnknown(boolean failOnUnknown) {
     this.failOnUnknown = failOnUnknown;
   }
 
-  /**
-   * Returns true if this parser forbids skipping names and values.
-   */
   @Override
   @CheckReturnValue public final boolean failOnUnknown() {
     return failOnUnknown;
   }
 
-  /**
-   * Returns the value of the next token, consuming it. The result may be a string, number, boolean,
-   * null, map, or list, according to the JSON structure.
-   *
-   * @throws JsonDataException if the next token is not a literal value, if a JSON object has a
-   * duplicate key.
-   * @see JsonWriter#jsonValue(Object)
-   */
   @Override
   public final @Nullable Object readJsonValue() throws IOException {
     switch (peek()) {
@@ -346,10 +150,6 @@ public abstract class AbstractJsonReader implements JsonReader {
     }
   }
 
-  /**
-   * Returns a <a href="http://goessner.net/articles/JsonPath/">JsonPath</a> to
-   * the current location in the JSON value.
-   */
   @Override
   @CheckReturnValue public final String getPath() {
     return JsonScope.getPath(stackSize, scopes, pathNames, pathIndices);

--- a/moshi/src/main/java/com/squareup/moshi/AuditJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/AuditJsonReader.java
@@ -8,22 +8,22 @@ import java.util.List;
  * and delegates to the underlying {@link JsonReader}.
  */
 public class AuditJsonReader extends DelegatingJsonReader implements DataMappingAuditor {
-    private List<UnknownEnum> unknownEnums;
+  private List<UnknownEnum> unknownEnums;
 
-    public AuditJsonReader(JsonReader delegate) {
-        super(delegate);
-    }
+  public AuditJsonReader(JsonReader delegate) {
+    super(delegate);
+  }
 
-    @Override
-    public void addUnknownEnum(UnknownEnum unknownEnum) {
-        if (unknownEnums == null) {
-            unknownEnums = new ArrayList<>();
-        }
-        unknownEnums.add(unknownEnum);
+  @Override
+  public void addUnknownEnum(UnknownEnum unknownEnum) {
+    if (unknownEnums == null) {
+      unknownEnums = new ArrayList<>();
     }
+    unknownEnums.add(unknownEnum);
+  }
 
-    @Override
-    public List<UnknownEnum> getUnknownEnums() {
-        return unknownEnums;
-    }
+  @Override
+  public List<UnknownEnum> getUnknownEnums() {
+    return unknownEnums;
+  }
 }

--- a/moshi/src/main/java/com/squareup/moshi/AuditJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/AuditJsonReader.java
@@ -1,0 +1,29 @@
+package com.squareup.moshi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A {@link JsonReader} that keeps an audit trail of any mapping issues,
+ * and delegates to the underlying {@link JsonReader}.
+ */
+public class AuditJsonReader extends DelegatingJsonReader implements DataMappingAuditor {
+    private List<UnknownEnum> unknownEnums;
+
+    public AuditJsonReader(JsonReader delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public void addUnknownEnum(UnknownEnum unknownEnum) {
+        if (unknownEnums == null) {
+            unknownEnums = new ArrayList<>();
+        }
+        unknownEnums.add(unknownEnum);
+    }
+
+    @Override
+    public List<UnknownEnum> getUnknownEnums() {
+        return unknownEnums;
+    }
+}

--- a/moshi/src/main/java/com/squareup/moshi/AuditJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/AuditJsonReader.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.moshi;
 
 import java.util.ArrayList;

--- a/moshi/src/main/java/com/squareup/moshi/DataMappingAuditor.java
+++ b/moshi/src/main/java/com/squareup/moshi/DataMappingAuditor.java
@@ -6,26 +6,26 @@ import java.util.List;
  * Keeps track of any data mapping mismatches that occur during deserialization.
  */
 public interface DataMappingAuditor {
-    /**
-     * Track an unknown enum value.
-     */
-    void addUnknownEnum(UnknownEnum unknownEnum);
+  /**
+   * Track an unknown enum value.
+   */
+  void addUnknownEnum(UnknownEnum unknownEnum);
 
-    /**
-     * Returns a list of any enum data mismatch events that occurred during deserialization.
-     */
-    List<UnknownEnum> getUnknownEnums();
+  /**
+   * Returns a list of any enum data mismatch events that occurred during deserialization.
+   */
+  List<UnknownEnum> getUnknownEnums();
 
-    /**
-     * Metadata associated with an enum data mismatch event that occurred during deserialization.
-     */
-    final class UnknownEnum {
-        public final String path;
-        public final String name;
+  /**
+   * Metadata associated with an enum data mismatch event that occurred during deserialization.
+   */
+  final class UnknownEnum {
+    public final String path;
+    public final String name;
 
-        public UnknownEnum(String path, String name) {
-            this.path = path;
-            this.name = name;
-        }
+    public UnknownEnum(String path, String name) {
+      this.path = path;
+      this.name = name;
     }
+  }
 }

--- a/moshi/src/main/java/com/squareup/moshi/DataMappingAuditor.java
+++ b/moshi/src/main/java/com/squareup/moshi/DataMappingAuditor.java
@@ -1,0 +1,31 @@
+package com.squareup.moshi;
+
+import java.util.List;
+
+/**
+ * Keeps track of any data mapping mismatches that occur during deserialization.
+ */
+public interface DataMappingAuditor {
+    /**
+     * Track an unknown enum value.
+     */
+    void addUnknownEnum(UnknownEnum unknownEnum);
+
+    /**
+     * Returns a list of any enum data mismatch events that occurred during deserialization.
+     */
+    List<UnknownEnum> getUnknownEnums();
+
+    /**
+     * Metadata associated with an enum data mismatch event that occurred during deserialization.
+     */
+    final class UnknownEnum {
+        public final String path;
+        public final String name;
+
+        public UnknownEnum(String path, String name) {
+            this.path = path;
+            this.name = name;
+        }
+    }
+}

--- a/moshi/src/main/java/com/squareup/moshi/DataMappingAuditor.java
+++ b/moshi/src/main/java/com/squareup/moshi/DataMappingAuditor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.moshi;
 
 import java.util.List;

--- a/moshi/src/main/java/com/squareup/moshi/DelegatingJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/DelegatingJsonReader.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.moshi;
 
 import javax.annotation.Nullable;

--- a/moshi/src/main/java/com/squareup/moshi/DelegatingJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/DelegatingJsonReader.java
@@ -1,0 +1,144 @@
+package com.squareup.moshi;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+public abstract class DelegatingJsonReader implements JsonReader {
+    public final JsonReader delegate;
+
+    public DelegatingJsonReader(JsonReader delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public final void setLenient(boolean lenient) {
+        delegate.setLenient(lenient);
+    }
+
+    @Override
+    public final boolean isLenient() {
+        return delegate.isLenient();
+    }
+
+    @Override
+    public final void setFailOnUnknown(boolean failOnUnknown) {
+        delegate.setFailOnUnknown(failOnUnknown);
+    }
+
+    @Override
+    public final boolean failOnUnknown() {
+        return delegate.failOnUnknown();
+    }
+
+    @Override
+    public final void beginArray() throws IOException {
+        delegate.beginArray();
+    }
+
+    @Override
+    public final void endArray() throws IOException {
+        delegate.endArray();
+    }
+
+    @Override
+    public final void beginObject() throws IOException {
+        delegate.beginObject();
+    }
+
+    @Override
+    public final void endObject() throws IOException {
+        delegate.endObject();
+    }
+
+    @Override
+    public final boolean hasNext() throws IOException {
+        return delegate.hasNext();
+    }
+
+    @Override
+    public final Token peek() throws IOException {
+        return delegate.peek();
+    }
+
+    @Override
+    public final String nextName() throws IOException {
+        return delegate.nextName();
+    }
+
+    @Override
+    public final int selectName(Options options) throws IOException {
+        return delegate.selectName(options);
+    }
+
+    @Override
+    public final void skipName() throws IOException {
+        delegate.skipName();
+    }
+
+    @Override
+    public final String nextString() throws IOException {
+        return delegate.nextString();
+    }
+
+    @Override
+    public final int selectString(Options options) throws IOException {
+        return delegate.selectString(options);
+    }
+
+    @Override
+    public final boolean nextBoolean() throws IOException {
+        return delegate.nextBoolean();
+    }
+
+    @Nullable
+    @Override
+    public final <T> T nextNull() throws IOException {
+        return delegate.nextNull();
+    }
+
+    @Override
+    public final double nextDouble() throws IOException {
+        return delegate.nextDouble();
+    }
+
+    @Override
+    public final long nextLong() throws IOException {
+        return delegate.nextLong();
+    }
+
+    @Override
+    public final int nextInt() throws IOException {
+        return delegate.nextInt();
+    }
+
+    @Override
+    public final void skipValue() throws IOException {
+        delegate.skipValue();
+    }
+
+    @Override
+    public final void promoteNameToValue() throws IOException {
+        delegate.promoteNameToValue();
+    }
+
+    @Nullable
+    @Override
+    public final Object readJsonValue() throws IOException {
+        return delegate.readJsonValue();
+    }
+
+    @Override
+    public final JsonReader peekJson() {
+        return delegate.peekJson();
+    }
+
+    @Override
+    public final String getPath() {
+        return delegate.getPath();
+    }
+
+    @Override
+    public final void close() throws IOException {
+        delegate.close();
+    }
+}

--- a/moshi/src/main/java/com/squareup/moshi/DelegatingJsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/DelegatingJsonReader.java
@@ -4,141 +4,141 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 
 public abstract class DelegatingJsonReader implements JsonReader {
-    public final JsonReader delegate;
+  public final JsonReader delegate;
 
-    public DelegatingJsonReader(JsonReader delegate) {
-        this.delegate = delegate;
-    }
+  public DelegatingJsonReader(JsonReader delegate) {
+    this.delegate = delegate;
+  }
 
-    @Override
-    public final void setLenient(boolean lenient) {
-        delegate.setLenient(lenient);
-    }
+  @Override
+  public final void setLenient(boolean lenient) {
+    delegate.setLenient(lenient);
+  }
 
-    @Override
-    public final boolean isLenient() {
-        return delegate.isLenient();
-    }
+  @Override
+  public final boolean isLenient() {
+    return delegate.isLenient();
+  }
 
-    @Override
-    public final void setFailOnUnknown(boolean failOnUnknown) {
-        delegate.setFailOnUnknown(failOnUnknown);
-    }
+  @Override
+  public final void setFailOnUnknown(boolean failOnUnknown) {
+    delegate.setFailOnUnknown(failOnUnknown);
+  }
 
-    @Override
-    public final boolean failOnUnknown() {
-        return delegate.failOnUnknown();
-    }
+  @Override
+  public final boolean failOnUnknown() {
+    return delegate.failOnUnknown();
+  }
 
-    @Override
-    public final void beginArray() throws IOException {
-        delegate.beginArray();
-    }
+  @Override
+  public final void beginArray() throws IOException {
+    delegate.beginArray();
+  }
 
-    @Override
-    public final void endArray() throws IOException {
-        delegate.endArray();
-    }
+  @Override
+  public final void endArray() throws IOException {
+    delegate.endArray();
+  }
 
-    @Override
-    public final void beginObject() throws IOException {
-        delegate.beginObject();
-    }
+  @Override
+  public final void beginObject() throws IOException {
+    delegate.beginObject();
+  }
 
-    @Override
-    public final void endObject() throws IOException {
-        delegate.endObject();
-    }
+  @Override
+  public final void endObject() throws IOException {
+    delegate.endObject();
+  }
 
-    @Override
-    public final boolean hasNext() throws IOException {
-        return delegate.hasNext();
-    }
+  @Override
+  public final boolean hasNext() throws IOException {
+    return delegate.hasNext();
+  }
 
-    @Override
-    public final Token peek() throws IOException {
-        return delegate.peek();
-    }
+  @Override
+  public final Token peek() throws IOException {
+    return delegate.peek();
+  }
 
-    @Override
-    public final String nextName() throws IOException {
-        return delegate.nextName();
-    }
+  @Override
+  public final String nextName() throws IOException {
+    return delegate.nextName();
+  }
 
-    @Override
-    public final int selectName(Options options) throws IOException {
-        return delegate.selectName(options);
-    }
+  @Override
+  public final int selectName(Options options) throws IOException {
+    return delegate.selectName(options);
+  }
 
-    @Override
-    public final void skipName() throws IOException {
-        delegate.skipName();
-    }
+  @Override
+  public final void skipName() throws IOException {
+    delegate.skipName();
+  }
 
-    @Override
-    public final String nextString() throws IOException {
-        return delegate.nextString();
-    }
+  @Override
+  public final String nextString() throws IOException {
+    return delegate.nextString();
+  }
 
-    @Override
-    public final int selectString(Options options) throws IOException {
-        return delegate.selectString(options);
-    }
+  @Override
+  public final int selectString(Options options) throws IOException {
+    return delegate.selectString(options);
+  }
 
-    @Override
-    public final boolean nextBoolean() throws IOException {
-        return delegate.nextBoolean();
-    }
+  @Override
+  public final boolean nextBoolean() throws IOException {
+    return delegate.nextBoolean();
+  }
 
-    @Nullable
-    @Override
-    public final <T> T nextNull() throws IOException {
-        return delegate.nextNull();
-    }
+  @Nullable
+  @Override
+  public final <T> T nextNull() throws IOException {
+    return delegate.nextNull();
+  }
 
-    @Override
-    public final double nextDouble() throws IOException {
-        return delegate.nextDouble();
-    }
+  @Override
+  public final double nextDouble() throws IOException {
+    return delegate.nextDouble();
+  }
 
-    @Override
-    public final long nextLong() throws IOException {
-        return delegate.nextLong();
-    }
+  @Override
+  public final long nextLong() throws IOException {
+    return delegate.nextLong();
+  }
 
-    @Override
-    public final int nextInt() throws IOException {
-        return delegate.nextInt();
-    }
+  @Override
+  public final int nextInt() throws IOException {
+    return delegate.nextInt();
+  }
 
-    @Override
-    public final void skipValue() throws IOException {
-        delegate.skipValue();
-    }
+  @Override
+  public final void skipValue() throws IOException {
+    delegate.skipValue();
+  }
 
-    @Override
-    public final void promoteNameToValue() throws IOException {
-        delegate.promoteNameToValue();
-    }
+  @Override
+  public final void promoteNameToValue() throws IOException {
+    delegate.promoteNameToValue();
+  }
 
-    @Nullable
-    @Override
-    public final Object readJsonValue() throws IOException {
-        return delegate.readJsonValue();
-    }
+  @Nullable
+  @Override
+  public final Object readJsonValue() throws IOException {
+    return delegate.readJsonValue();
+  }
 
-    @Override
-    public final JsonReader peekJson() {
-        return delegate.peekJson();
-    }
+  @Override
+  public final JsonReader peekJson() {
+    return delegate.peekJson();
+  }
 
-    @Override
-    public final String getPath() {
-        return delegate.getPath();
-    }
+  @Override
+  public final String getPath() {
+    return delegate.getPath();
+  }
 
-    @Override
-    public final void close() throws IOException {
-        delegate.close();
-    }
+  @Override
+  public final void close() throws IOException {
+    delegate.close();
+  }
 }

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -1,611 +1,291 @@
-/*
- * Copyright (C) 2010 Google Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.squareup.moshi;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nullable;
 import okio.Buffer;
 import okio.BufferedSource;
 import okio.ByteString;
 
-/**
- * Reads a JSON (<a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>)
- * encoded value as a stream of tokens. This stream includes both literal
- * values (strings, numbers, booleans, and nulls) as well as the begin and
- * end delimiters of objects and arrays. The tokens are traversed in
- * depth-first order, the same order that they appear in the JSON document.
- * Within JSON objects, name/value pairs are represented by a single token.
- *
- * <h3>Parsing JSON</h3>
- * To create a recursive descent parser for your own JSON streams, first create
- * an entry point method that creates a {@code JsonReader}.
- *
- * <p>Next, create handler methods for each structure in your JSON text. You'll
- * need a method for each object type and for each array type.
- * <ul>
- *   <li>Within <strong>array handling</strong> methods, first call {@link
- *       #beginArray} to consume the array's opening bracket. Then create a
- *       while loop that accumulates values, terminating when {@link #hasNext}
- *       is false. Finally, read the array's closing bracket by calling {@link
- *       #endArray}.
- *   <li>Within <strong>object handling</strong> methods, first call {@link
- *       #beginObject} to consume the object's opening brace. Then create a
- *       while loop that assigns values to local variables based on their name.
- *       This loop should terminate when {@link #hasNext} is false. Finally,
- *       read the object's closing brace by calling {@link #endObject}.
- * </ul>
- * <p>When a nested object or array is encountered, delegate to the
- * corresponding handler method.
- *
- * <p>When an unknown name is encountered, strict parsers should fail with an
- * exception. Lenient parsers should call {@link #skipValue()} to recursively
- * skip the value's nested tokens, which may otherwise conflict.
- *
- * <p>If a value may be null, you should first check using {@link #peek()}.
- * Null literals can be consumed using either {@link #nextNull()} or {@link
- * #skipValue()}.
- *
- * <h3>Example</h3>
- * Suppose we'd like to parse a stream of messages such as the following: <pre> {@code
- * [
- *   {
- *     "id": 912345678901,
- *     "text": "How do I read a JSON stream in Java?",
- *     "geo": null,
- *     "user": {
- *       "name": "json_newb",
- *       "followers_count": 41
- *      }
- *   },
- *   {
- *     "id": 912345678902,
- *     "text": "@json_newb just use JsonReader!",
- *     "geo": [50.454722, -104.606667],
- *     "user": {
- *       "name": "jesse",
- *       "followers_count": 2
- *     }
- *   }
- * ]}</pre>
- * This code implements the parser for the above structure: <pre>   {@code
- *
- *   public List<Message> readJsonStream(BufferedSource source) throws IOException {
- *     JsonReader reader = JsonReader.of(source);
- *     try {
- *       return readMessagesArray(reader);
- *     } finally {
- *       reader.close();
- *     }
- *   }
- *
- *   public List<Message> readMessagesArray(JsonReader reader) throws IOException {
- *     List<Message> messages = new ArrayList<Message>();
- *
- *     reader.beginArray();
- *     while (reader.hasNext()) {
- *       messages.add(readMessage(reader));
- *     }
- *     reader.endArray();
- *     return messages;
- *   }
- *
- *   public Message readMessage(JsonReader reader) throws IOException {
- *     long id = -1;
- *     String text = null;
- *     User user = null;
- *     List<Double> geo = null;
- *
- *     reader.beginObject();
- *     while (reader.hasNext()) {
- *       String name = reader.nextName();
- *       if (name.equals("id")) {
- *         id = reader.nextLong();
- *       } else if (name.equals("text")) {
- *         text = reader.nextString();
- *       } else if (name.equals("geo") && reader.peek() != Token.NULL) {
- *         geo = readDoublesArray(reader);
- *       } else if (name.equals("user")) {
- *         user = readUser(reader);
- *       } else {
- *         reader.skipValue();
- *       }
- *     }
- *     reader.endObject();
- *     return new Message(id, text, user, geo);
- *   }
- *
- *   public List<Double> readDoublesArray(JsonReader reader) throws IOException {
- *     List<Double> doubles = new ArrayList<Double>();
- *
- *     reader.beginArray();
- *     while (reader.hasNext()) {
- *       doubles.add(reader.nextDouble());
- *     }
- *     reader.endArray();
- *     return doubles;
- *   }
- *
- *   public User readUser(JsonReader reader) throws IOException {
- *     String username = null;
- *     int followersCount = -1;
- *
- *     reader.beginObject();
- *     while (reader.hasNext()) {
- *       String name = reader.nextName();
- *       if (name.equals("name")) {
- *         username = reader.nextString();
- *       } else if (name.equals("followers_count")) {
- *         followersCount = reader.nextInt();
- *       } else {
- *         reader.skipValue();
- *       }
- *     }
- *     reader.endObject();
- *     return new User(username, followersCount);
- *   }}</pre>
- *
- * <h3>Number Handling</h3>
- * This reader permits numeric values to be read as strings and string values to
- * be read as numbers. For example, both elements of the JSON array {@code
- * [1, "1"]} may be read using either {@link #nextInt} or {@link #nextString}.
- * This behavior is intended to prevent lossy numeric conversions: double is
- * JavaScript's only numeric type and very large values like {@code
- * 9007199254740993} cannot be represented exactly on that platform. To minimize
- * precision loss, extremely large values should be written and read as strings
- * in JSON.
- *
- * <p>Each {@code JsonReader} may be used to read a single JSON stream. Instances
- * of this class are not thread safe.
- */
-public abstract class JsonReader implements Closeable {
-  // The nesting stack. Using a manual array rather than an ArrayList saves 20%. This stack will
-  // grow itself up to 256 levels of nesting including the top-level document. Deeper nesting is
-  // prone to trigger StackOverflowErrors.
-  int stackSize;
-  int[] scopes;
-  String[] pathNames;
-  int[] pathIndices;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.io.IOException;
 
-  /** True to accept non-spec compliant JSON. */
-  boolean lenient;
+public interface JsonReader extends Closeable {
+    void setLenient(boolean lenient);
 
-  /** True to throw a {@link JsonDataException} on any attempt to call {@link #skipValue()}. */
-  boolean failOnUnknown;
+    @CheckReturnValue
+    boolean isLenient();
 
-  /** Returns a new instance that reads UTF-8 encoded JSON from {@code source}. */
-  @CheckReturnValue public static JsonReader of(BufferedSource source) {
-    return new JsonUtf8Reader(source);
-  }
+    void setFailOnUnknown(boolean failOnUnknown);
 
-  // Package-private to control subclasses.
-  JsonReader() {
-    scopes = new int[32];
-    pathNames = new String[32];
-    pathIndices = new int[32];
-  }
+    @CheckReturnValue
+    boolean failOnUnknown();
 
-  // Package-private to control subclasses.
-  JsonReader(JsonReader copyFrom) {
-    this.stackSize = copyFrom.stackSize;
-    this.scopes = copyFrom.scopes.clone();
-    this.pathNames = copyFrom.pathNames.clone();
-    this.pathIndices = copyFrom.pathIndices.clone();
-    this.lenient = copyFrom.lenient;
-    this.failOnUnknown = copyFrom.failOnUnknown;
-  }
+    /**
+     * Consumes the next token from the JSON stream and asserts that it is the beginning of a new
+     * array.
+     */
+    void beginArray() throws IOException;
 
-  final void pushScope(int newTop) {
-    if (stackSize == scopes.length) {
-      if (stackSize == 256) {
-        throw new JsonDataException("Nesting too deep at " + getPath());
+    /**
+     * Consumes the next token from the JSON stream and asserts that it is the
+     * end of the current array.
+     */
+    void endArray() throws IOException;
+
+    /**
+     * Consumes the next token from the JSON stream and asserts that it is the beginning of a new
+     * object.
+     */
+    void beginObject() throws IOException;
+
+    /**
+     * Consumes the next token from the JSON stream and asserts that it is the end of the current
+     * object.
+     */
+    void endObject() throws IOException;
+
+    /**
+     * Returns true if the current array or object has another element.
+     */
+    @CheckReturnValue
+    boolean hasNext() throws IOException;
+
+    /**
+     * Returns the type of the next token without consuming it.
+     */
+    @CheckReturnValue
+    Token peek() throws IOException;
+
+    /**
+     * Returns the next token, a {@linkplain Token#NAME property name}, and consumes it.
+     *
+     * @throws JsonDataException if the next token in the stream is not a property name.
+     */
+    @CheckReturnValue
+    String nextName() throws IOException;
+
+    /**
+     * If the next token is a {@linkplain Token#NAME property name} that's in {@code options}, this
+     * consumes it and returns its index. Otherwise this returns -1 and no name is consumed.
+     */
+    @CheckReturnValue
+    int selectName(Options options) throws IOException;
+
+    /**
+     * Skips the next token, consuming it. This method is intended for use when the JSON token stream
+     * contains unrecognized or unhandled names.
+     *
+     * <p>This throws a {@link JsonDataException} if this parser has been configured to {@linkplain
+     * #failOnUnknown fail on unknown} names.
+     */
+    void skipName() throws IOException;
+
+    /**
+     * Returns the {@linkplain Token#STRING string} value of the next token, consuming it. If the next
+     * token is a number, this method will return its string form.
+     *
+     * @throws JsonDataException if the next token is not a string or if this reader is closed.
+     */
+    String nextString() throws IOException;
+
+    /**
+     * If the next token is a {@linkplain Token#STRING string} that's in {@code options}, this
+     * consumes it and returns its index. Otherwise this returns -1 and no string is consumed.
+     */
+    @CheckReturnValue
+    int selectString(Options options) throws IOException;
+
+    /**
+     * Returns the {@linkplain Token#BOOLEAN boolean} value of the next token, consuming it.
+     *
+     * @throws JsonDataException if the next token is not a boolean or if this reader is closed.
+     */
+    boolean nextBoolean() throws IOException;
+
+    /**
+     * Consumes the next token from the JSON stream and asserts that it is a literal null. Returns
+     * null.
+     *
+     * @throws JsonDataException if the next token is not null or if this reader is closed.
+     */
+    @Nullable
+    <T> T nextNull() throws IOException;
+
+    /**
+     * Returns the {@linkplain Token#NUMBER double} value of the next token, consuming it. If the next
+     * token is a string, this method will attempt to parse it as a double using {@link
+     * Double#parseDouble(String)}.
+     *
+     * @throws JsonDataException if the next token is not a literal value, or if the next literal
+     *     value cannot be parsed as a double, or is non-finite.
+     */
+    double nextDouble() throws IOException;
+
+    /**
+     * Returns the {@linkplain Token#NUMBER long} value of the next token, consuming it. If the next
+     * token is a string, this method will attempt to parse it as a long. If the next token's numeric
+     * value cannot be exactly represented by a Java {@code long}, this method throws.
+     *
+     * @throws JsonDataException if the next token is not a literal value, if the next literal value
+     *     cannot be parsed as a number, or exactly represented as a long.
+     */
+    long nextLong() throws IOException;
+
+    /**
+     * Returns the {@linkplain Token#NUMBER int} value of the next token, consuming it. If the next
+     * token is a string, this method will attempt to parse it as an int. If the next token's numeric
+     * value cannot be exactly represented by a Java {@code int}, this method throws.
+     *
+     * @throws JsonDataException if the next token is not a literal value, if the next literal value
+     *     cannot be parsed as a number, or exactly represented as an int.
+     */
+    int nextInt() throws IOException;
+
+    /**
+     * Skips the next value recursively. If it is an object or array, all nested elements are skipped.
+     * This method is intended for use when the JSON token stream contains unrecognized or unhandled
+     * values.
+     *
+     * <p>This throws a {@link JsonDataException} if this parser has been configured to {@linkplain
+     * #failOnUnknown fail on unknown} values.
+     */
+    void skipValue() throws IOException;
+
+    /**
+     * Changes the reader to treat the next name as a string value. This is useful for map adapters so
+     * that arbitrary type adapters can use {@link #nextString} to read a name value.
+     */
+    void promoteNameToValue() throws IOException;
+
+    /** Returns a new instance that reads UTF-8 encoded JSON from {@code source}. */
+    @CheckReturnValue static JsonReader of(BufferedSource source) {
+        return new JsonUtf8Reader(source);
+    }
+
+    @Nullable Object readJsonValue() throws IOException;
+
+    /**
+     * Returns a new {@code JsonReader} that can read data from this {@code JsonReader} without
+     * consuming it. The returned reader becomes invalid once this one is next read or closed.
+     *
+     * <p>For example, we can use {@code peekJson()} to lookahead and read the same data multiple
+     * times.
+     *
+     * <pre> {@code
+     *
+     *   Buffer buffer = new Buffer();
+     *   buffer.writeUtf8("[123, 456, 789]")
+     *
+     *   JsonReader jsonReader = JsonReader.of(buffer);
+     *   jsonReader.beginArray();
+     *   jsonReader.nextInt(); // Returns 123, reader contains 456, 789 and ].
+     *
+     *   JsonReader peek = reader.peekJson();
+     *   peek.nextInt() // Returns 456.
+     *   peek.nextInt() // Returns 789.
+     *   peek.endArray()
+     *
+     *   jsonReader.nextInt() // Returns 456, reader contains 789 and ].
+     * }</pre>
+     */
+    @CheckReturnValue
+    JsonReader peekJson();
+
+    @CheckReturnValue
+    String getPath();
+
+    /**
+     * A structure, name, or value type in a JSON-encoded string.
+     */
+    enum Token {
+
+      /**
+       * The opening of a JSON array. Written using {@link JsonWriter#beginArray}
+       * and read using {@link JsonReader#beginArray}.
+       */
+      BEGIN_ARRAY,
+
+      /**
+       * The closing of a JSON array. Written using {@link JsonWriter#endArray}
+       * and read using {@link JsonReader#endArray}.
+       */
+      END_ARRAY,
+
+      /**
+       * The opening of a JSON object. Written using {@link JsonWriter#beginObject}
+       * and read using {@link JsonReader#beginObject}.
+       */
+      BEGIN_OBJECT,
+
+      /**
+       * The closing of a JSON object. Written using {@link JsonWriter#endObject}
+       * and read using {@link JsonReader#endObject}.
+       */
+      END_OBJECT,
+
+      /**
+       * A JSON property name. Within objects, tokens alternate between names and
+       * their values. Written using {@link JsonWriter#name} and read using {@link
+       * JsonReader#nextName}
+       */
+      NAME,
+
+      /**
+       * A JSON string.
+       */
+      STRING,
+
+      /**
+       * A JSON number represented in this API by a Java {@code double}, {@code
+       * long}, or {@code int}.
+       */
+      NUMBER,
+
+      /**
+       * A JSON {@code true} or {@code false}.
+       */
+      BOOLEAN,
+
+      /**
+       * A JSON {@code null}.
+       */
+      NULL,
+
+      /**
+       * The end of the JSON stream. This sentinel value is returned by {@link
+       * JsonReader#peek()} to signal that the JSON-encoded value has no more
+       * tokens.
+       */
+      END_DOCUMENT
+    }
+
+    /**
+     * A set of strings to be chosen with {@link #selectName} or {@link #selectString}. This prepares
+     * the encoded values of the strings so they can be read directly from the input source.
+     */
+    final class Options {
+      final String[] strings;
+      final okio.Options doubleQuoteSuffix;
+
+      private Options(String[] strings, okio.Options doubleQuoteSuffix) {
+        this.strings = strings;
+        this.doubleQuoteSuffix = doubleQuoteSuffix;
       }
-      scopes = Arrays.copyOf(scopes, scopes.length * 2);
-      pathNames = Arrays.copyOf(pathNames, pathNames.length * 2);
-      pathIndices = Arrays.copyOf(pathIndices, pathIndices.length * 2);
-    }
-    scopes[stackSize++] = newTop;
-  }
 
-  /**
-   * Throws a new IO exception with the given message and a context snippet
-   * with this reader's content.
-   */
-  final JsonEncodingException syntaxError(String message) throws JsonEncodingException {
-    throw new JsonEncodingException(message + " at path " + getPath());
-  }
-
-  final JsonDataException typeMismatch(@Nullable Object value, Object expected) {
-    if (value == null) {
-      return new JsonDataException(
-          "Expected " + expected + " but was null at path " + getPath());
-    } else {
-      return new JsonDataException("Expected " + expected + " but was " + value + ", a "
-          + value.getClass().getName() + ", at path " + getPath());
-    }
-  }
-
-  /**
-   * Configure this parser to be liberal in what it accepts. By default
-   * this parser is strict and only accepts JSON as specified by <a
-   * href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>. Setting the
-   * parser to lenient causes it to ignore the following syntax errors:
-   *
-   * <ul>
-   *   <li>Streams that include multiple top-level values. With strict parsing,
-   *       each stream must contain exactly one top-level value.
-   *   <li>Numbers may be {@linkplain Double#isNaN() NaNs} or {@link
-   *       Double#isInfinite() infinities}.
-   *   <li>End of line comments starting with {@code //} or {@code #} and
-   *       ending with a newline character.
-   *   <li>C-style comments starting with {@code /*} and ending with
-   *       {@code *}{@code /}. Such comments may not be nested.
-   *   <li>Names that are unquoted or {@code 'single quoted'}.
-   *   <li>Strings that are unquoted or {@code 'single quoted'}.
-   *   <li>Array elements separated by {@code ;} instead of {@code ,}.
-   *   <li>Unnecessary array separators. These are interpreted as if null
-   *       was the omitted value.
-   *   <li>Names and values separated by {@code =} or {@code =>} instead of
-   *       {@code :}.
-   *   <li>Name/value pairs separated by {@code ;} instead of {@code ,}.
-   * </ul>
-   */
-  public final void setLenient(boolean lenient) {
-    this.lenient = lenient;
-  }
-
-  /**
-   * Returns true if this parser is liberal in what it accepts.
-   */
-  @CheckReturnValue public final boolean isLenient() {
-    return lenient;
-  }
-
-  /**
-   * Configure whether this parser throws a {@link JsonDataException} when {@link #skipValue} is
-   * called. By default this parser permits values to be skipped.
-   *
-   * <p>Forbid skipping to prevent unrecognized values from being silently ignored. This option is
-   * useful in development and debugging because it means a typo like "locatiom" will be detected
-   * early. It's potentially harmful in production because it complicates revising a JSON schema.
-   */
-  public final void setFailOnUnknown(boolean failOnUnknown) {
-    this.failOnUnknown = failOnUnknown;
-  }
-
-  /**
-   * Returns true if this parser forbids skipping names and values.
-   */
-  @CheckReturnValue public final boolean failOnUnknown() {
-    return failOnUnknown;
-  }
-
-  /**
-   * Consumes the next token from the JSON stream and asserts that it is the beginning of a new
-   * array.
-   */
-  public abstract void beginArray() throws IOException;
-
-  /**
-   * Consumes the next token from the JSON stream and asserts that it is the
-   * end of the current array.
-   */
-  public abstract void endArray() throws IOException;
-
-  /**
-   * Consumes the next token from the JSON stream and asserts that it is the beginning of a new
-   * object.
-   */
-  public abstract void beginObject() throws IOException;
-
-  /**
-   * Consumes the next token from the JSON stream and asserts that it is the end of the current
-   * object.
-   */
-  public abstract void endObject() throws IOException;
-
-  /**
-   * Returns true if the current array or object has another element.
-   */
-  @CheckReturnValue public abstract boolean hasNext() throws IOException;
-
-  /**
-   * Returns the type of the next token without consuming it.
-   */
-  @CheckReturnValue public abstract Token peek() throws IOException;
-
-  /**
-   * Returns the next token, a {@linkplain Token#NAME property name}, and consumes it.
-   *
-   * @throws JsonDataException if the next token in the stream is not a property name.
-   */
-  @CheckReturnValue public abstract String nextName() throws IOException;
-
-  /**
-   * If the next token is a {@linkplain Token#NAME property name} that's in {@code options}, this
-   * consumes it and returns its index. Otherwise this returns -1 and no name is consumed.
-   */
-  @CheckReturnValue public abstract int selectName(Options options) throws IOException;
-
-  /**
-   * Skips the next token, consuming it. This method is intended for use when the JSON token stream
-   * contains unrecognized or unhandled names.
-   *
-   * <p>This throws a {@link JsonDataException} if this parser has been configured to {@linkplain
-   * #failOnUnknown fail on unknown} names.
-   */
-  public abstract void skipName() throws IOException;
-
-  /**
-   * Returns the {@linkplain Token#STRING string} value of the next token, consuming it. If the next
-   * token is a number, this method will return its string form.
-   *
-   * @throws JsonDataException if the next token is not a string or if this reader is closed.
-   */
-  public abstract String nextString() throws IOException;
-
-  /**
-   * If the next token is a {@linkplain Token#STRING string} that's in {@code options}, this
-   * consumes it and returns its index. Otherwise this returns -1 and no string is consumed.
-   */
-  @CheckReturnValue public abstract int selectString(Options options) throws IOException;
-
-  /**
-   * Returns the {@linkplain Token#BOOLEAN boolean} value of the next token, consuming it.
-   *
-   * @throws JsonDataException if the next token is not a boolean or if this reader is closed.
-   */
-  public abstract boolean nextBoolean() throws IOException;
-
-  /**
-   * Consumes the next token from the JSON stream and asserts that it is a literal null. Returns
-   * null.
-   *
-   * @throws JsonDataException if the next token is not null or if this reader is closed.
-   */
-  public abstract @Nullable <T> T nextNull() throws IOException;
-
-  /**
-   * Returns the {@linkplain Token#NUMBER double} value of the next token, consuming it. If the next
-   * token is a string, this method will attempt to parse it as a double using {@link
-   * Double#parseDouble(String)}.
-   *
-   * @throws JsonDataException if the next token is not a literal value, or if the next literal
-   *     value cannot be parsed as a double, or is non-finite.
-   */
-  public abstract double nextDouble() throws IOException;
-
-  /**
-   * Returns the {@linkplain Token#NUMBER long} value of the next token, consuming it. If the next
-   * token is a string, this method will attempt to parse it as a long. If the next token's numeric
-   * value cannot be exactly represented by a Java {@code long}, this method throws.
-   *
-   * @throws JsonDataException if the next token is not a literal value, if the next literal value
-   *     cannot be parsed as a number, or exactly represented as a long.
-   */
-  public abstract long nextLong() throws IOException;
-
-  /**
-   * Returns the {@linkplain Token#NUMBER int} value of the next token, consuming it. If the next
-   * token is a string, this method will attempt to parse it as an int. If the next token's numeric
-   * value cannot be exactly represented by a Java {@code int}, this method throws.
-   *
-   * @throws JsonDataException if the next token is not a literal value, if the next literal value
-   *     cannot be parsed as a number, or exactly represented as an int.
-   */
-  public abstract int nextInt() throws IOException;
-
-  /**
-   * Skips the next value recursively. If it is an object or array, all nested elements are skipped.
-   * This method is intended for use when the JSON token stream contains unrecognized or unhandled
-   * values.
-   *
-   * <p>This throws a {@link JsonDataException} if this parser has been configured to {@linkplain
-   * #failOnUnknown fail on unknown} values.
-   */
-  public abstract void skipValue() throws IOException;
-
-  /**
-   * Returns the value of the next token, consuming it. The result may be a string, number, boolean,
-   * null, map, or list, according to the JSON structure.
-   *
-   * @throws JsonDataException if the next token is not a literal value, if a JSON object has a
-   * duplicate key.
-   * @see JsonWriter#jsonValue(Object)
-   */
-  public final @Nullable Object readJsonValue() throws IOException {
-    switch (peek()) {
-      case BEGIN_ARRAY:
-        List<Object> list = new ArrayList<>();
-        beginArray();
-        while (hasNext()) {
-          list.add(readJsonValue());
-        }
-        endArray();
-        return list;
-
-      case BEGIN_OBJECT:
-        Map<String, Object> map = new LinkedHashTreeMap<>();
-        beginObject();
-        while (hasNext()) {
-          String name = nextName();
-          Object value = readJsonValue();
-          Object replaced = map.put(name, value);
-          if (replaced != null) {
-            throw new JsonDataException("Map key '" + name + "' has multiple values at path "
-                + getPath() + ": " + replaced + " and " + value);
+      @CheckReturnValue
+      public static Options of(String... strings) {
+        try {
+          ByteString[] result = new ByteString[strings.length];
+          Buffer buffer = new Buffer();
+          for (int i = 0; i < strings.length; i++) {
+            JsonUtf8Writer.string(buffer, strings[i]);
+            buffer.readByte(); // Skip the leading double quote (but leave the trailing one).
+            result[i] = buffer.readByteString();
           }
+          return new Options(strings.clone(), okio.Options.of(result));
+        } catch (IOException e) {
+          throw new AssertionError(e);
         }
-        endObject();
-        return map;
-
-      case STRING:
-        return nextString();
-
-      case NUMBER:
-        return nextDouble();
-
-      case BOOLEAN:
-        return nextBoolean();
-
-      case NULL:
-        return nextNull();
-
-      default:
-        throw new IllegalStateException(
-            "Expected a value but was " + peek() + " at path " + getPath());
-    }
-  }
-
-  /**
-   * Returns a new {@code JsonReader} that can read data from this {@code JsonReader} without
-   * consuming it. The returned reader becomes invalid once this one is next read or closed.
-   *
-   * <p>For example, we can use {@code peekJson()} to lookahead and read the same data multiple
-   * times.
-   *
-   * <pre> {@code
-   *
-   *   Buffer buffer = new Buffer();
-   *   buffer.writeUtf8("[123, 456, 789]")
-   *
-   *   JsonReader jsonReader = JsonReader.of(buffer);
-   *   jsonReader.beginArray();
-   *   jsonReader.nextInt(); // Returns 123, reader contains 456, 789 and ].
-   *
-   *   JsonReader peek = reader.peekJson();
-   *   peek.nextInt() // Returns 456.
-   *   peek.nextInt() // Returns 789.
-   *   peek.endArray()
-   *
-   *   jsonReader.nextInt() // Returns 456, reader contains 789 and ].
-   * }</pre>
-   */
-  @CheckReturnValue public abstract JsonReader peekJson();
-
-  /**
-   * Returns a <a href="http://goessner.net/articles/JsonPath/">JsonPath</a> to
-   * the current location in the JSON value.
-   */
-  @CheckReturnValue public final String getPath() {
-    return JsonScope.getPath(stackSize, scopes, pathNames, pathIndices);
-  }
-
-  /**
-   * Changes the reader to treat the next name as a string value. This is useful for map adapters so
-   * that arbitrary type adapters can use {@link #nextString} to read a name value.
-   */
-  abstract void promoteNameToValue() throws IOException;
-
-  /**
-   * A set of strings to be chosen with {@link #selectName} or {@link #selectString}. This prepares
-   * the encoded values of the strings so they can be read directly from the input source.
-   */
-  public static final class Options {
-    final String[] strings;
-    final okio.Options doubleQuoteSuffix;
-
-    private Options(String[] strings, okio.Options doubleQuoteSuffix) {
-      this.strings = strings;
-      this.doubleQuoteSuffix = doubleQuoteSuffix;
-    }
-
-    @CheckReturnValue public static Options of(String... strings) {
-      try {
-        ByteString[] result = new ByteString[strings.length];
-        Buffer buffer = new Buffer();
-        for (int i = 0; i < strings.length; i++) {
-          JsonUtf8Writer.string(buffer, strings[i]);
-          buffer.readByte(); // Skip the leading double quote (but leave the trailing one).
-          result[i] = buffer.readByteString();
-        }
-        return new Options(strings.clone(), okio.Options.of(result));
-      } catch (IOException e) {
-        throw new AssertionError(e);
       }
     }
-  }
-
-  /**
-   * A structure, name, or value type in a JSON-encoded string.
-   */
-  public enum Token {
-
-    /**
-     * The opening of a JSON array. Written using {@link JsonWriter#beginArray}
-     * and read using {@link JsonReader#beginArray}.
-     */
-    BEGIN_ARRAY,
-
-    /**
-     * The closing of a JSON array. Written using {@link JsonWriter#endArray}
-     * and read using {@link JsonReader#endArray}.
-     */
-    END_ARRAY,
-
-    /**
-     * The opening of a JSON object. Written using {@link JsonWriter#beginObject}
-     * and read using {@link JsonReader#beginObject}.
-     */
-    BEGIN_OBJECT,
-
-    /**
-     * The closing of a JSON object. Written using {@link JsonWriter#endObject}
-     * and read using {@link JsonReader#endObject}.
-     */
-    END_OBJECT,
-
-    /**
-     * A JSON property name. Within objects, tokens alternate between names and
-     * their values. Written using {@link JsonWriter#name} and read using {@link
-     * JsonReader#nextName}
-     */
-    NAME,
-
-    /**
-     * A JSON string.
-     */
-    STRING,
-
-    /**
-     * A JSON number represented in this API by a Java {@code double}, {@code
-     * long}, or {@code int}.
-     */
-    NUMBER,
-
-    /**
-     * A JSON {@code true} or {@code false}.
-     */
-    BOOLEAN,
-
-    /**
-     * A JSON {@code null}.
-     */
-    NULL,
-
-    /**
-     * The end of the JSON stream. This sentinel value is returned by {@link
-     * JsonReader#peek()} to signal that the JSON-encoded value has no more
-     * tokens.
-     */
-    END_DOCUMENT
-  }
 }

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -10,282 +10,282 @@ import java.io.Closeable;
 import java.io.IOException;
 
 public interface JsonReader extends Closeable {
-    void setLenient(boolean lenient);
+  void setLenient(boolean lenient);
 
-    @CheckReturnValue
-    boolean isLenient();
+  @CheckReturnValue
+  boolean isLenient();
 
-    void setFailOnUnknown(boolean failOnUnknown);
+  void setFailOnUnknown(boolean failOnUnknown);
 
-    @CheckReturnValue
-    boolean failOnUnknown();
+  @CheckReturnValue
+  boolean failOnUnknown();
+
+  /**
+   * Consumes the next token from the JSON stream and asserts that it is the beginning of a new
+   * array.
+   */
+  void beginArray() throws IOException;
+
+  /**
+   * Consumes the next token from the JSON stream and asserts that it is the
+   * end of the current array.
+   */
+  void endArray() throws IOException;
+
+  /**
+   * Consumes the next token from the JSON stream and asserts that it is the beginning of a new
+   * object.
+   */
+  void beginObject() throws IOException;
+
+  /**
+   * Consumes the next token from the JSON stream and asserts that it is the end of the current
+   * object.
+   */
+  void endObject() throws IOException;
+
+  /**
+   * Returns true if the current array or object has another element.
+   */
+  @CheckReturnValue
+  boolean hasNext() throws IOException;
+
+  /**
+   * Returns the type of the next token without consuming it.
+   */
+  @CheckReturnValue
+  Token peek() throws IOException;
+
+  /**
+   * Returns the next token, a {@linkplain Token#NAME property name}, and consumes it.
+   *
+   * @throws JsonDataException if the next token in the stream is not a property name.
+   */
+  @CheckReturnValue
+  String nextName() throws IOException;
+
+  /**
+   * If the next token is a {@linkplain Token#NAME property name} that's in {@code options}, this
+   * consumes it and returns its index. Otherwise this returns -1 and no name is consumed.
+   */
+  @CheckReturnValue
+  int selectName(Options options) throws IOException;
+
+  /**
+   * Skips the next token, consuming it. This method is intended for use when the JSON token stream
+   * contains unrecognized or unhandled names.
+   *
+   * <p>This throws a {@link JsonDataException} if this parser has been configured to {@linkplain
+   * #failOnUnknown fail on unknown} names.
+   */
+  void skipName() throws IOException;
+
+  /**
+   * Returns the {@linkplain Token#STRING string} value of the next token, consuming it. If the next
+   * token is a number, this method will return its string form.
+   *
+   * @throws JsonDataException if the next token is not a string or if this reader is closed.
+   */
+  String nextString() throws IOException;
+
+  /**
+   * If the next token is a {@linkplain Token#STRING string} that's in {@code options}, this
+   * consumes it and returns its index. Otherwise this returns -1 and no string is consumed.
+   */
+  @CheckReturnValue
+  int selectString(Options options) throws IOException;
+
+  /**
+   * Returns the {@linkplain Token#BOOLEAN boolean} value of the next token, consuming it.
+   *
+   * @throws JsonDataException if the next token is not a boolean or if this reader is closed.
+   */
+  boolean nextBoolean() throws IOException;
+
+  /**
+   * Consumes the next token from the JSON stream and asserts that it is a literal null. Returns
+   * null.
+   *
+   * @throws JsonDataException if the next token is not null or if this reader is closed.
+   */
+  @Nullable
+  <T> T nextNull() throws IOException;
+
+  /**
+   * Returns the {@linkplain Token#NUMBER double} value of the next token, consuming it. If the next
+   * token is a string, this method will attempt to parse it as a double using {@link
+   * Double#parseDouble(String)}.
+   *
+   * @throws JsonDataException if the next token is not a literal value, or if the next literal
+   *   value cannot be parsed as a double, or is non-finite.
+   */
+  double nextDouble() throws IOException;
+
+  /**
+   * Returns the {@linkplain Token#NUMBER long} value of the next token, consuming it. If the next
+   * token is a string, this method will attempt to parse it as a long. If the next token's numeric
+   * value cannot be exactly represented by a Java {@code long}, this method throws.
+   *
+   * @throws JsonDataException if the next token is not a literal value, if the next literal value
+   *   cannot be parsed as a number, or exactly represented as a long.
+   */
+  long nextLong() throws IOException;
+
+  /**
+   * Returns the {@linkplain Token#NUMBER int} value of the next token, consuming it. If the next
+   * token is a string, this method will attempt to parse it as an int. If the next token's numeric
+   * value cannot be exactly represented by a Java {@code int}, this method throws.
+   *
+   * @throws JsonDataException if the next token is not a literal value, if the next literal value
+   *   cannot be parsed as a number, or exactly represented as an int.
+   */
+  int nextInt() throws IOException;
+
+  /**
+   * Skips the next value recursively. If it is an object or array, all nested elements are skipped.
+   * This method is intended for use when the JSON token stream contains unrecognized or unhandled
+   * values.
+   *
+   * <p>This throws a {@link JsonDataException} if this parser has been configured to {@linkplain
+   * #failOnUnknown fail on unknown} values.
+   */
+  void skipValue() throws IOException;
+
+  /**
+   * Changes the reader to treat the next name as a string value. This is useful for map adapters so
+   * that arbitrary type adapters can use {@link #nextString} to read a name value.
+   */
+  void promoteNameToValue() throws IOException;
+
+  /** Returns a new instance that reads UTF-8 encoded JSON from {@code source}. */
+  @CheckReturnValue static JsonReader of(BufferedSource source) {
+    return new JsonUtf8Reader(source);
+  }
+
+  @Nullable Object readJsonValue() throws IOException;
+
+  /**
+   * Returns a new {@code JsonReader} that can read data from this {@code JsonReader} without
+   * consuming it. The returned reader becomes invalid once this one is next read or closed.
+   *
+   * <p>For example, we can use {@code peekJson()} to lookahead and read the same data multiple
+   * times.
+   *
+   * <pre> {@code
+   *
+   *   Buffer buffer = new Buffer();
+   *   buffer.writeUtf8("[123, 456, 789]")
+   *
+   *   JsonReader jsonReader = JsonReader.of(buffer);
+   *   jsonReader.beginArray();
+   *   jsonReader.nextInt(); // Returns 123, reader contains 456, 789 and ].
+   *
+   *   JsonReader peek = reader.peekJson();
+   *   peek.nextInt() // Returns 456.
+   *   peek.nextInt() // Returns 789.
+   *   peek.endArray()
+   *
+   *   jsonReader.nextInt() // Returns 456, reader contains 789 and ].
+   * }</pre>
+   */
+  @CheckReturnValue
+  JsonReader peekJson();
+
+  @CheckReturnValue
+  String getPath();
+
+  /**
+   * A structure, name, or value type in a JSON-encoded string.
+   */
+  enum Token {
 
     /**
-     * Consumes the next token from the JSON stream and asserts that it is the beginning of a new
-     * array.
+     * The opening of a JSON array. Written using {@link JsonWriter#beginArray}
+     * and read using {@link JsonReader#beginArray}.
      */
-    void beginArray() throws IOException;
+    BEGIN_ARRAY,
 
     /**
-     * Consumes the next token from the JSON stream and asserts that it is the
-     * end of the current array.
+     * The closing of a JSON array. Written using {@link JsonWriter#endArray}
+     * and read using {@link JsonReader#endArray}.
      */
-    void endArray() throws IOException;
+    END_ARRAY,
 
     /**
-     * Consumes the next token from the JSON stream and asserts that it is the beginning of a new
-     * object.
+     * The opening of a JSON object. Written using {@link JsonWriter#beginObject}
+     * and read using {@link JsonReader#beginObject}.
      */
-    void beginObject() throws IOException;
+    BEGIN_OBJECT,
 
     /**
-     * Consumes the next token from the JSON stream and asserts that it is the end of the current
-     * object.
+     * The closing of a JSON object. Written using {@link JsonWriter#endObject}
+     * and read using {@link JsonReader#endObject}.
      */
-    void endObject() throws IOException;
+    END_OBJECT,
 
     /**
-     * Returns true if the current array or object has another element.
+     * A JSON property name. Within objects, tokens alternate between names and
+     * their values. Written using {@link JsonWriter#name} and read using {@link
+     * JsonReader#nextName}
      */
-    @CheckReturnValue
-    boolean hasNext() throws IOException;
+    NAME,
 
     /**
-     * Returns the type of the next token without consuming it.
+     * A JSON string.
      */
-    @CheckReturnValue
-    Token peek() throws IOException;
+    STRING,
 
     /**
-     * Returns the next token, a {@linkplain Token#NAME property name}, and consumes it.
-     *
-     * @throws JsonDataException if the next token in the stream is not a property name.
+     * A JSON number represented in this API by a Java {@code double}, {@code
+     * long}, or {@code int}.
      */
-    @CheckReturnValue
-    String nextName() throws IOException;
+    NUMBER,
 
     /**
-     * If the next token is a {@linkplain Token#NAME property name} that's in {@code options}, this
-     * consumes it and returns its index. Otherwise this returns -1 and no name is consumed.
+     * A JSON {@code true} or {@code false}.
      */
-    @CheckReturnValue
-    int selectName(Options options) throws IOException;
+    BOOLEAN,
 
     /**
-     * Skips the next token, consuming it. This method is intended for use when the JSON token stream
-     * contains unrecognized or unhandled names.
-     *
-     * <p>This throws a {@link JsonDataException} if this parser has been configured to {@linkplain
-     * #failOnUnknown fail on unknown} names.
+     * A JSON {@code null}.
      */
-    void skipName() throws IOException;
+    NULL,
 
     /**
-     * Returns the {@linkplain Token#STRING string} value of the next token, consuming it. If the next
-     * token is a number, this method will return its string form.
-     *
-     * @throws JsonDataException if the next token is not a string or if this reader is closed.
+     * The end of the JSON stream. This sentinel value is returned by {@link
+     * JsonReader#peek()} to signal that the JSON-encoded value has no more
+     * tokens.
      */
-    String nextString() throws IOException;
+    END_DOCUMENT
+  }
 
-    /**
-     * If the next token is a {@linkplain Token#STRING string} that's in {@code options}, this
-     * consumes it and returns its index. Otherwise this returns -1 and no string is consumed.
-     */
-    @CheckReturnValue
-    int selectString(Options options) throws IOException;
+  /**
+   * A set of strings to be chosen with {@link #selectName} or {@link #selectString}. This prepares
+   * the encoded values of the strings so they can be read directly from the input source.
+   */
+  final class Options {
+    final String[] strings;
+    final okio.Options doubleQuoteSuffix;
 
-    /**
-     * Returns the {@linkplain Token#BOOLEAN boolean} value of the next token, consuming it.
-     *
-     * @throws JsonDataException if the next token is not a boolean or if this reader is closed.
-     */
-    boolean nextBoolean() throws IOException;
-
-    /**
-     * Consumes the next token from the JSON stream and asserts that it is a literal null. Returns
-     * null.
-     *
-     * @throws JsonDataException if the next token is not null or if this reader is closed.
-     */
-    @Nullable
-    <T> T nextNull() throws IOException;
-
-    /**
-     * Returns the {@linkplain Token#NUMBER double} value of the next token, consuming it. If the next
-     * token is a string, this method will attempt to parse it as a double using {@link
-     * Double#parseDouble(String)}.
-     *
-     * @throws JsonDataException if the next token is not a literal value, or if the next literal
-     *     value cannot be parsed as a double, or is non-finite.
-     */
-    double nextDouble() throws IOException;
-
-    /**
-     * Returns the {@linkplain Token#NUMBER long} value of the next token, consuming it. If the next
-     * token is a string, this method will attempt to parse it as a long. If the next token's numeric
-     * value cannot be exactly represented by a Java {@code long}, this method throws.
-     *
-     * @throws JsonDataException if the next token is not a literal value, if the next literal value
-     *     cannot be parsed as a number, or exactly represented as a long.
-     */
-    long nextLong() throws IOException;
-
-    /**
-     * Returns the {@linkplain Token#NUMBER int} value of the next token, consuming it. If the next
-     * token is a string, this method will attempt to parse it as an int. If the next token's numeric
-     * value cannot be exactly represented by a Java {@code int}, this method throws.
-     *
-     * @throws JsonDataException if the next token is not a literal value, if the next literal value
-     *     cannot be parsed as a number, or exactly represented as an int.
-     */
-    int nextInt() throws IOException;
-
-    /**
-     * Skips the next value recursively. If it is an object or array, all nested elements are skipped.
-     * This method is intended for use when the JSON token stream contains unrecognized or unhandled
-     * values.
-     *
-     * <p>This throws a {@link JsonDataException} if this parser has been configured to {@linkplain
-     * #failOnUnknown fail on unknown} values.
-     */
-    void skipValue() throws IOException;
-
-    /**
-     * Changes the reader to treat the next name as a string value. This is useful for map adapters so
-     * that arbitrary type adapters can use {@link #nextString} to read a name value.
-     */
-    void promoteNameToValue() throws IOException;
-
-    /** Returns a new instance that reads UTF-8 encoded JSON from {@code source}. */
-    @CheckReturnValue static JsonReader of(BufferedSource source) {
-        return new JsonUtf8Reader(source);
+    private Options(String[] strings, okio.Options doubleQuoteSuffix) {
+    this.strings = strings;
+    this.doubleQuoteSuffix = doubleQuoteSuffix;
     }
 
-    @Nullable Object readJsonValue() throws IOException;
-
-    /**
-     * Returns a new {@code JsonReader} that can read data from this {@code JsonReader} without
-     * consuming it. The returned reader becomes invalid once this one is next read or closed.
-     *
-     * <p>For example, we can use {@code peekJson()} to lookahead and read the same data multiple
-     * times.
-     *
-     * <pre> {@code
-     *
-     *   Buffer buffer = new Buffer();
-     *   buffer.writeUtf8("[123, 456, 789]")
-     *
-     *   JsonReader jsonReader = JsonReader.of(buffer);
-     *   jsonReader.beginArray();
-     *   jsonReader.nextInt(); // Returns 123, reader contains 456, 789 and ].
-     *
-     *   JsonReader peek = reader.peekJson();
-     *   peek.nextInt() // Returns 456.
-     *   peek.nextInt() // Returns 789.
-     *   peek.endArray()
-     *
-     *   jsonReader.nextInt() // Returns 456, reader contains 789 and ].
-     * }</pre>
-     */
     @CheckReturnValue
-    JsonReader peekJson();
-
-    @CheckReturnValue
-    String getPath();
-
-    /**
-     * A structure, name, or value type in a JSON-encoded string.
-     */
-    enum Token {
-
-      /**
-       * The opening of a JSON array. Written using {@link JsonWriter#beginArray}
-       * and read using {@link JsonReader#beginArray}.
-       */
-      BEGIN_ARRAY,
-
-      /**
-       * The closing of a JSON array. Written using {@link JsonWriter#endArray}
-       * and read using {@link JsonReader#endArray}.
-       */
-      END_ARRAY,
-
-      /**
-       * The opening of a JSON object. Written using {@link JsonWriter#beginObject}
-       * and read using {@link JsonReader#beginObject}.
-       */
-      BEGIN_OBJECT,
-
-      /**
-       * The closing of a JSON object. Written using {@link JsonWriter#endObject}
-       * and read using {@link JsonReader#endObject}.
-       */
-      END_OBJECT,
-
-      /**
-       * A JSON property name. Within objects, tokens alternate between names and
-       * their values. Written using {@link JsonWriter#name} and read using {@link
-       * JsonReader#nextName}
-       */
-      NAME,
-
-      /**
-       * A JSON string.
-       */
-      STRING,
-
-      /**
-       * A JSON number represented in this API by a Java {@code double}, {@code
-       * long}, or {@code int}.
-       */
-      NUMBER,
-
-      /**
-       * A JSON {@code true} or {@code false}.
-       */
-      BOOLEAN,
-
-      /**
-       * A JSON {@code null}.
-       */
-      NULL,
-
-      /**
-       * The end of the JSON stream. This sentinel value is returned by {@link
-       * JsonReader#peek()} to signal that the JSON-encoded value has no more
-       * tokens.
-       */
-      END_DOCUMENT
-    }
-
-    /**
-     * A set of strings to be chosen with {@link #selectName} or {@link #selectString}. This prepares
-     * the encoded values of the strings so they can be read directly from the input source.
-     */
-    final class Options {
-      final String[] strings;
-      final okio.Options doubleQuoteSuffix;
-
-      private Options(String[] strings, okio.Options doubleQuoteSuffix) {
-        this.strings = strings;
-        this.doubleQuoteSuffix = doubleQuoteSuffix;
+    public static Options of(String... strings) {
+    try {
+      ByteString[] result = new ByteString[strings.length];
+      Buffer buffer = new Buffer();
+      for (int i = 0; i < strings.length; i++) {
+      JsonUtf8Writer.string(buffer, strings[i]);
+      buffer.readByte(); // Skip the leading double quote (but leave the trailing one).
+      result[i] = buffer.readByteString();
       }
-
-      @CheckReturnValue
-      public static Options of(String... strings) {
-        try {
-          ByteString[] result = new ByteString[strings.length];
-          Buffer buffer = new Buffer();
-          for (int i = 0; i < strings.length; i++) {
-            JsonUtf8Writer.string(buffer, strings[i]);
-            buffer.readByte(); // Skip the leading double quote (but leave the trailing one).
-            result[i] = buffer.readByteString();
-          }
-          return new Options(strings.clone(), okio.Options.of(result));
-        } catch (IOException e) {
-          throw new AssertionError(e);
-        }
-      }
+      return new Options(strings.clone(), okio.Options.of(result));
+    } catch (IOException e) {
+      throw new AssertionError(e);
     }
+    }
+  }
 }

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.moshi;
 
 import okio.Buffer;
@@ -9,14 +24,202 @@ import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 
+/**
+ * Reads a JSON (<a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>)
+ * encoded value as a stream of tokens. This stream includes both literal
+ * values (strings, numbers, booleans, and nulls) as well as the begin and
+ * end delimiters of objects and arrays. The tokens are traversed in
+ * depth-first order, the same order that they appear in the JSON document.
+ * Within JSON objects, name/value pairs are represented by a single token.
+ *
+ * <h3>Parsing JSON</h3>
+ * To create a recursive descent parser for your own JSON streams, first create
+ * an entry point method that creates a {@code JsonReader}.
+ *
+ * <p>Next, create handler methods for each structure in your JSON text. You'll
+ * need a method for each object type and for each array type.
+ * <ul>
+ *   <li>Within <strong>array handling</strong> methods, first call {@link
+ *       #beginArray} to consume the array's opening bracket. Then create a
+ *       while loop that accumulates values, terminating when {@link #hasNext}
+ *       is false. Finally, read the array's closing bracket by calling {@link
+ *       #endArray}.
+ *   <li>Within <strong>object handling</strong> methods, first call {@link
+ *       #beginObject} to consume the object's opening brace. Then create a
+ *       while loop that assigns values to local variables based on their name.
+ *       This loop should terminate when {@link #hasNext} is false. Finally,
+ *       read the object's closing brace by calling {@link #endObject}.
+ * </ul>
+ * <p>When a nested object or array is encountered, delegate to the
+ * corresponding handler method.
+ *
+ * <p>When an unknown name is encountered, strict parsers should fail with an
+ * exception. Lenient parsers should call {@link #skipValue()} to recursively
+ * skip the value's nested tokens, which may otherwise conflict.
+ *
+ * <p>If a value may be null, you should first check using {@link #peek()}.
+ * Null literals can be consumed using either {@link #nextNull()} or {@link
+ * #skipValue()}.
+ *
+ * <h3>Example</h3>
+ * Suppose we'd like to parse a stream of messages such as the following: <pre> {@code
+ * [
+ *   {
+ *     "id": 912345678901,
+ *     "text": "How do I read a JSON stream in Java?",
+ *     "geo": null,
+ *     "user": {
+ *       "name": "json_newb",
+ *       "followers_count": 41
+ *      }
+ *   },
+ *   {
+ *     "id": 912345678902,
+ *     "text": "@json_newb just use JsonReader!",
+ *     "geo": [50.454722, -104.606667],
+ *     "user": {
+ *       "name": "jesse",
+ *       "followers_count": 2
+ *     }
+ *   }
+ * ]}</pre>
+ * This code implements the parser for the above structure: <pre>   {@code
+ *
+ *   public List<Message> readJsonStream(BufferedSource source) throws IOException {
+ *     JsonReader reader = JsonReader.of(source);
+ *     try {
+ *       return readMessagesArray(reader);
+ *     } finally {
+ *       reader.close();
+ *     }
+ *   }
+ *
+ *   public List<Message> readMessagesArray(JsonReader reader) throws IOException {
+ *     List<Message> messages = new ArrayList<Message>();
+ *
+ *     reader.beginArray();
+ *     while (reader.hasNext()) {
+ *       messages.add(readMessage(reader));
+ *     }
+ *     reader.endArray();
+ *     return messages;
+ *   }
+ *
+ *   public Message readMessage(JsonReader reader) throws IOException {
+ *     long id = -1;
+ *     String text = null;
+ *     User user = null;
+ *     List<Double> geo = null;
+ *
+ *     reader.beginObject();
+ *     while (reader.hasNext()) {
+ *       String name = reader.nextName();
+ *       if (name.equals("id")) {
+ *         id = reader.nextLong();
+ *       } else if (name.equals("text")) {
+ *         text = reader.nextString();
+ *       } else if (name.equals("geo") && reader.peek() != Token.NULL) {
+ *         geo = readDoublesArray(reader);
+ *       } else if (name.equals("user")) {
+ *         user = readUser(reader);
+ *       } else {
+ *         reader.skipValue();
+ *       }
+ *     }
+ *     reader.endObject();
+ *     return new Message(id, text, user, geo);
+ *   }
+ *
+ *   public List<Double> readDoublesArray(JsonReader reader) throws IOException {
+ *     List<Double> doubles = new ArrayList<Double>();
+ *
+ *     reader.beginArray();
+ *     while (reader.hasNext()) {
+ *       doubles.add(reader.nextDouble());
+ *     }
+ *     reader.endArray();
+ *     return doubles;
+ *   }
+ *
+ *   public User readUser(JsonReader reader) throws IOException {
+ *     String username = null;
+ *     int followersCount = -1;
+ *
+ *     reader.beginObject();
+ *     while (reader.hasNext()) {
+ *       String name = reader.nextName();
+ *       if (name.equals("name")) {
+ *         username = reader.nextString();
+ *       } else if (name.equals("followers_count")) {
+ *         followersCount = reader.nextInt();
+ *       } else {
+ *         reader.skipValue();
+ *       }
+ *     }
+ *     reader.endObject();
+ *     return new User(username, followersCount);
+ *   }}</pre>
+ *
+ * <h3>Number Handling</h3>
+ * This reader permits numeric values to be read as strings and string values to
+ * be read as numbers. For example, both elements of the JSON array {@code
+ * [1, "1"]} may be read using either {@link #nextInt} or {@link #nextString}.
+ * This behavior is intended to prevent lossy numeric conversions: double is
+ * JavaScript's only numeric type and very large values like {@code
+ * 9007199254740993} cannot be represented exactly on that platform. To minimize
+ * precision loss, extremely large values should be written and read as strings
+ * in JSON.
+ *
+ * <p>Each {@code JsonReader} may be used to read a single JSON stream. Instances
+ * of this class are not thread safe.
+ */
 public interface JsonReader extends Closeable {
+  /**
+   * Configure this parser to be liberal in what it accepts. By default
+   * this parser is strict and only accepts JSON as specified by <a
+   * href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>. Setting the
+   * parser to lenient causes it to ignore the following syntax errors:
+   *
+   * <ul>
+   *   <li>Streams that include multiple top-level values. With strict parsing,
+   *       each stream must contain exactly one top-level value.
+   *   <li>Numbers may be {@linkplain Double#isNaN() NaNs} or {@link
+   *       Double#isInfinite() infinities}.
+   *   <li>End of line comments starting with {@code //} or {@code #} and
+   *       ending with a newline character.
+   *   <li>C-style comments starting with {@code /*} and ending with
+   *       {@code *}{@code /}. Such comments may not be nested.
+   *   <li>Names that are unquoted or {@code 'single quoted'}.
+   *   <li>Strings that are unquoted or {@code 'single quoted'}.
+   *   <li>Array elements separated by {@code ;} instead of {@code ,}.
+   *   <li>Unnecessary array separators. These are interpreted as if null
+   *       was the omitted value.
+   *   <li>Names and values separated by {@code =} or {@code =>} instead of
+   *       {@code :}.
+   *   <li>Name/value pairs separated by {@code ;} instead of {@code ,}.
+   * </ul>
+   */
   void setLenient(boolean lenient);
 
+  /**
+   * Returns true if this parser is liberal in what it accepts.
+   */
   @CheckReturnValue
   boolean isLenient();
 
+  /**
+   * Configure whether this parser throws a {@link JsonDataException} when {@link #skipValue} is
+   * called. By default this parser permits values to be skipped.
+   *
+   * <p>Forbid skipping to prevent unrecognized values from being silently ignored. This option is
+   * useful in development and debugging because it means a typo like "locatiom" will be detected
+   * early. It's potentially harmful in production because it complicates revising a JSON schema.
+   */
   void setFailOnUnknown(boolean failOnUnknown);
 
+  /**
+   * Returns true if this parser forbids skipping names and values.
+   */
   @CheckReturnValue
   boolean failOnUnknown();
 
@@ -162,6 +365,14 @@ public interface JsonReader extends Closeable {
     return new JsonUtf8Reader(source);
   }
 
+  /**
+   * Returns the value of the next token, consuming it. The result may be a string, number, boolean,
+   * null, map, or list, according to the JSON structure.
+   *
+   * @throws JsonDataException if the next token is not a literal value, if a JSON object has a
+   * duplicate key.
+   * @see JsonWriter#jsonValue(Object)
+   */
   @Nullable Object readJsonValue() throws IOException;
 
   /**
@@ -191,6 +402,10 @@ public interface JsonReader extends Closeable {
   @CheckReturnValue
   JsonReader peekJson();
 
+  /**
+   * Returns a <a href="http://goessner.net/articles/JsonPath/">JsonPath</a> to
+   * the current location in the JSON value.
+   */
   @CheckReturnValue
   String getPath();
 

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -174,6 +174,11 @@ import java.io.IOException;
  * of this class are not thread safe.
  */
 public interface JsonReader extends Closeable {
+  /** Returns a new instance that reads UTF-8 encoded JSON from {@code source}. */
+  @CheckReturnValue static JsonReader of(BufferedSource source) {
+    return new JsonUtf8Reader(source);
+  }
+
   /**
    * Configure this parser to be liberal in what it accepts. By default
    * this parser is strict and only accepts JSON as specified by <a
@@ -359,11 +364,6 @@ public interface JsonReader extends Closeable {
    * that arbitrary type adapters can use {@link #nextString} to read a name value.
    */
   void promoteNameToValue() throws IOException;
-
-  /** Returns a new instance that reads UTF-8 encoded JSON from {@code source}. */
-  @CheckReturnValue static JsonReader of(BufferedSource source) {
-    return new JsonUtf8Reader(source);
-  }
 
   /**
    * Returns the value of the next token, consuming it. The result may be a string, number, boolean,

--- a/moshi/src/main/java/com/squareup/moshi/JsonReaderInterface.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReaderInterface.java
@@ -1,4 +1,0 @@
-package com.squareup.moshi;
-
-public interface JsonReaderInterface {
-}

--- a/moshi/src/main/java/com/squareup/moshi/JsonReaderInterface.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReaderInterface.java
@@ -1,0 +1,4 @@
+package com.squareup.moshi;
+
+public interface JsonReaderInterface {
+}

--- a/moshi/src/main/java/com/squareup/moshi/JsonUtf8Reader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonUtf8Reader.java
@@ -23,7 +23,7 @@ import okio.Buffer;
 import okio.BufferedSource;
 import okio.ByteString;
 
-final class JsonUtf8Reader extends JsonReader {
+final class JsonUtf8Reader extends AbstractJsonReader {
   private static final long MIN_INCOMPLETE_INTEGER = Long.MIN_VALUE / 10;
 
   private static final ByteString SINGLE_QUOTE_OR_SLASH = ByteString.encodeUtf8("'\\");
@@ -1158,7 +1158,7 @@ final class JsonUtf8Reader extends JsonReader {
     }
   }
 
-  @Override void promoteNameToValue() throws IOException {
+  @Override public void promoteNameToValue() throws IOException {
     if (hasNext()) {
       peekedString = nextName();
       peeked = PEEKED_BUFFERED;

--- a/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
@@ -46,7 +46,7 @@ import static com.squareup.moshi.JsonScope.CLOSED;
  *       #endObject} will pop it.
  * </ul>
  */
-final class JsonValueReader extends JsonReader {
+final class JsonValueReader extends AbstractJsonReader {
   /** Sentinel object pushed on {@link #stack} when the reader is closed. */
   private static final Object JSON_READER_CLOSED = new Object();
 
@@ -330,7 +330,7 @@ final class JsonValueReader extends JsonReader {
     return new JsonValueReader(this);
   }
 
-  @Override void promoteNameToValue() throws IOException {
+  @Override public void promoteNameToValue() throws IOException {
     if (hasNext()) {
       String name = nextName();
       push(name);

--- a/moshi/src/test/java/com/squareup/moshi/JsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonAdapterTest.java
@@ -114,7 +114,7 @@ public final class JsonAdapterTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected).hasMessage("Unexpected null at $[1]");
-      assertThat(reader.nextNull()).isNull();
+      assertThat((Object) reader.nextNull()).isNull();
     }
     assertThat(toUpperCase.fromJson(reader)).isEqualTo("C");
     reader.endArray();

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
@@ -533,7 +533,7 @@ public final class JsonReaderTest {
     assertThat(reader2.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
 
     JsonReader reader3 = newReader("null");
-    assertThat(reader3.nextNull()).isNull();
+    assertThat((Object) reader3.nextNull()).isNull();
     assertThat(reader3.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
 
     JsonReader reader4 = newReader("123");

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
-
 import org.junit.Test;
 
 import static com.squareup.moshi.TestUtil.MAX_DEPTH;

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
+
 import org.junit.Test;
 
 import static com.squareup.moshi.TestUtil.MAX_DEPTH;
@@ -58,7 +60,7 @@ public final class JsonValueReaderTest {
 
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.NULL);
-    assertThat(reader.nextNull()).isNull();
+    assertThat((Object) reader.nextNull()).isNull();
 
     assertThat(reader.hasNext()).isFalse();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_ARRAY);
@@ -101,7 +103,7 @@ public final class JsonValueReaderTest {
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.NAME);
     assertThat(reader.nextName()).isEqualTo("d");
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.NULL);
-    assertThat(reader.nextNull()).isNull();
+    assertThat((Object) reader.nextNull()).isNull();
 
     assertThat(reader.hasNext()).isFalse();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_OBJECT);

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.7</java.version>
+    <java.version>1.8</java.version>
 
     <!-- Dependencies -->
     <auto-service.version>1.0-rc5</auto-service.version>


### PR DESCRIPTION
Relates to issue #1126.

This is a similar change to the other PR, however the logic has been moved out of the standard `JsonReader`, and moved into a more specific implementation.

To facilitate this, the `JsonReader` abstract class has now had to become an interface, and to maintain compatibility of the `JsonReader of(BufferedSource source)`  static method, the Java version has been increased to Java 8 (from Java 7).

Retrofit and several other square libraries have already increased their JVM version, so I thought this may be a possible approach.