### PR TITLE
Fix R8 keeping all Kotlin metadata when using Moshi.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/internal/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/Util.java
@@ -54,7 +54,7 @@ public final class Util {
     Class<? extends Annotation> metadata = null;
     try {
       //noinspection unchecked
-      metadata = (Class<? extends Annotation>) Class.forName("kotlin.Metadata");
+      metadata = (Class<? extends Annotation>) Class.forName(getKotlinMetadataClassName());
     } catch (ClassNotFoundException ignored) {
     }
     METADATA = metadata;
@@ -67,6 +67,11 @@ public final class Util {
     } catch (ClassNotFoundException ignored) {
     }
     DEFAULT_CONSTRUCTOR_MARKER = defaultConstructorMarker;
+  }
+
+  // Extracted as a method with a keep rule to prevent R8 from keeping Kotlin Metada
+  private static String getKotlinMetadataClassName() {
+    return "kotlin.Metadata";
   }
 
   private Util() {

--- a/moshi/src/main/resources/META-INF/proguard/moshi.pro
+++ b/moshi/src/main/resources/META-INF/proguard/moshi.pro
@@ -14,3 +14,8 @@
     <fields>;
     **[] values();
 }
+
+# Keep helper method to avoid R8 optimisation that would keep all Kotlin Metadata when unwanted
+-keepclassmembers class com.squareup.moshi.internal.Util {
+    private static java.lang.String getKotlinMetadataClassName();
+}


### PR DESCRIPTION
R8 now have automatic detection of Class.forName and auto generate keep rules.

This makes application built with Moshi to keep unwanted Kotlin Metadata that have a huge impact on APK size.

After discussion with R8 team, there's currently no solution to avoid this other than using the trick in this PR.

Fixes https://github.com/square/moshi/issues/1115