### PR TITLE
Codegen: Ignore properties without backing fields

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
@@ -385,9 +385,10 @@ private val AnnotationSpec.isTransient: Boolean
       val mirror = requireNotNull(tag<AnnotationMirror>()) {
         "Could not get the annotation mirror from the annotation spec"
       }
-      return mirror.elementValues.entries.single {
+      val isTransient = mirror.elementValues.entries.singleOrNull {
         it.key.simpleName.contentEquals("isTransient")
-      }.value.value as Boolean
+      } ?: return false
+      return isTransient.value.value as Boolean
     }
 
     return false

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
@@ -25,6 +25,7 @@ import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.metadata.ImmutableKmConstructor
+import com.squareup.kotlinpoet.metadata.ImmutableKmProperty
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 import com.squareup.kotlinpoet.metadata.isAbstract
 import com.squareup.kotlinpoet.metadata.isClass
@@ -401,6 +402,11 @@ internal fun TargetProperty.generator(
 
   if (!isSettable) {
     return null // This property is not settable. Ignore it.
+  }
+
+  val propertyInfo = propertySpec.tag<ImmutableKmProperty>()
+  if (propertyInfo != null && propertyInfo.fieldSignature == null) {
+    return null // This property does not have a backing field. Ignore it.
   }
 
   // Merge parameter and property annotations

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/metadata.kt
@@ -404,11 +404,6 @@ internal fun TargetProperty.generator(
     return null // This property is not settable. Ignore it.
   }
 
-  val propertyInfo = propertySpec.tag<ImmutableKmProperty>()
-  if (propertyInfo != null && propertyInfo.fieldSignature == null) {
-    return null // This property does not have a backing field. Ignore it.
-  }
-
   // Merge parameter and property annotations
   val qualifiers = parameter?.qualifiers.orEmpty() + propertySpec.annotations.qualifiers(elements)
   for (jsonQualifier in qualifiers) {

--- a/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessorTest.kt
+++ b/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessorTest.kt
@@ -399,15 +399,17 @@ class JsonClassCodegenProcessorTest {
   }
 
   @Test
-  fun `Properties without a backing field should be ignored`() {
+  fun `Properties with @Json(isTransient = true) should be ignored`() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
+          import com.squareup.moshi.Json
           
           class FullName(val first: String, val last: String)
           
           @JsonClass(generateAdapter = true)
           data class Person(var firstName: String, var lastName: String) {
+            @Json(isTransient = true)
             var fullName: FullName
               get() = FullName(firstName, lastName)
               set(value) {

--- a/moshi/src/main/java/com/squareup/moshi/Json.java
+++ b/moshi/src/main/java/com/squareup/moshi/Json.java
@@ -39,5 +39,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Documented
 public @interface Json {
-  String name();
+  String name() default "";
+  boolean isTransient() default false;
 }


### PR DESCRIPTION
Fixes #1151 

Currently, if a type has a property that is acting as a getter-setter pair (and, thus, does not have a backing field) Moshi still tries to create a JsonAdapter for it, read it from inputs, and write it to outputs. Since Moshi normally operates on fields rather than getters/setters (I think?) this behavior is counter to intuition, and can lead to extra work that is at best unnecessary and at worst crashing, when the property type is not serializable.