### PR TITLE
Reorder annotations in shrinker rule to minimize R8 bug

### DIFF
--- a/moshi/src/main/resources/META-INF/proguard/moshi.pro
+++ b/moshi/src/main/resources/META-INF/proguard/moshi.pro
@@ -24,7 +24,7 @@
 # We can't _just_ keep the defaults constructor because Proguard/R8's spec doesn't allow wildcard
 # matching preceding parameters.
 -keepnames class kotlin.jvm.internal.DefaultConstructorMarker
--keepclassmembers @com.squareup.moshi.JsonClass @kotlin.Metadata class * {
+-keepclassmembers @kotlin.Metadata @com.squareup.moshi.JsonClass class * {
     synthetic <init>(...);
 }
 


### PR DESCRIPTION
R8 has [a bug](https://issuetracker.google.com/issues/158454684) where it only honors the _last_ annotation defined in a shrinker rule class specification. This has been fixed in the latest R8, but it will be a while before that reaches stable.

Inverting the order means that the effective rule on affected R8 versions becomes

```
-keepclassmembers @com.squareup.moshi.JsonClass class * {
  synthetic <init>(...);
}
```

instead of

```
-keepclassmembers @kotlin.Metadata class * {
  synthetic <init>(...);
}
```

Since most (all?) Kotlin classes are annotated with `@Metadata`, the old form would match every synthetic constructor of any Kotlin class. These occur when you use default arguments or on companion objects. In practice we found this rule causes companion object classes to be retained solely because of this kept method, even when all its members were made static on the enclosing class.

This rule is completely removed on `master` in favor of generating targeted rules, but such a change is too risky for a 1.9.x patch release.

Anecdotally, on Cash this reduced our APK size by 100KB and removed ~2800 methods.