### PR TITLE
Update to Kotlin 1.4.0

### DIFF
--- a/kotlin/codegen/pom.xml
+++ b/kotlin/codegen/pom.xml
@@ -155,8 +155,8 @@
         <configuration>
           <args>
             <!-- So we can declare ourselves as users of KotlinPoetMetadataPreview -->
-            <arg>-Xuse-experimental=com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview</arg>
-            <arg>-Xuse-experimental=kotlin.Experimental</arg>
+            <arg>-Xopt-in=com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview</arg>
+            <arg>-Xopt-in=kotlin.OptIn</arg>
           </args>
         </configuration>
       </plugin>

--- a/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessorTest.kt
+++ b/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessorTest.kt
@@ -36,7 +36,7 @@ import kotlin.reflect.full.createType
 import kotlin.reflect.full.declaredMemberProperties
 
 /** Execute kotlinc to confirm that either files are generated or errors are printed. */
-@UseExperimental(KotlinPoetMetadataPreview::class)
+@OptIn(KotlinPoetMetadataPreview::class)
 class JsonClassCodegenProcessorTest {
   @Rule @JvmField var temporaryFolder: TemporaryFolder = TemporaryFolder()
 

--- a/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessorTest.kt
+++ b/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessorTest.kt
@@ -40,7 +40,9 @@ import kotlin.reflect.full.declaredMemberProperties
 class JsonClassCodegenProcessorTest {
   @Rule @JvmField var temporaryFolder: TemporaryFolder = TemporaryFolder()
 
-  @Test fun privateConstructor() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun privateConstructor() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -59,7 +61,9 @@ class JsonClassCodegenProcessorTest {
     assertThat(result.messages).contains("constructor is not internal or public")
   }
 
-  @Test fun privateConstructorParameter() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun privateConstructorParameter() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -72,7 +76,9 @@ class JsonClassCodegenProcessorTest {
     assertThat(result.messages).contains("property a is not visible")
   }
 
-  @Test fun privateProperties() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun privateProperties() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -88,7 +94,9 @@ class JsonClassCodegenProcessorTest {
     assertThat(result.messages).contains("property a is not visible")
   }
 
-  @Test fun interfacesNotSupported() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun interfacesNotSupported() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -102,7 +110,9 @@ class JsonClassCodegenProcessorTest {
         "error: @JsonClass can't be applied to Interface: must be a Kotlin class")
   }
 
-  @Test fun interfacesDoNotErrorWhenGeneratorNotSet() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun interfacesDoNotErrorWhenGeneratorNotSet() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -114,7 +124,9 @@ class JsonClassCodegenProcessorTest {
     assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
   }
 
-  @Test fun abstractClassesNotSupported() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun abstractClassesNotSupported() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -128,7 +140,9 @@ class JsonClassCodegenProcessorTest {
         "error: @JsonClass can't be applied to AbstractClass: must not be abstract")
   }
 
-  @Test fun sealedClassesNotSupported() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun sealedClassesNotSupported() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -142,7 +156,9 @@ class JsonClassCodegenProcessorTest {
         "error: @JsonClass can't be applied to SealedClass: must not be sealed")
   }
 
-  @Test fun innerClassesNotSupported() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun innerClassesNotSupported() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -158,7 +174,9 @@ class JsonClassCodegenProcessorTest {
         "error: @JsonClass can't be applied to Outer.InnerClass: must not be an inner class")
   }
 
-  @Test fun enumClassesNotSupported() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun enumClassesNotSupported() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -175,8 +193,9 @@ class JsonClassCodegenProcessorTest {
   }
 
   // Annotation processors don't get called for local classes, so we don't have the opportunity to
-  // print an error message. Instead local classes will fail at runtime.
-  @Ignore @Test fun localClassesNotSupported() {
+  @Ignore
+  @Test
+  fun localClassesNotSupported() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -192,7 +211,9 @@ class JsonClassCodegenProcessorTest {
         "error: @JsonClass can't be applied to LocalClass: must not be local")
   }
 
-  @Test fun privateClassesNotSupported() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun privateClassesNotSupported() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -206,7 +227,9 @@ class JsonClassCodegenProcessorTest {
         "error: @JsonClass can't be applied to PrivateClass: must be internal or public")
   }
 
-  @Test fun objectDeclarationsNotSupported() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun objectDeclarationsNotSupported() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -222,7 +245,9 @@ class JsonClassCodegenProcessorTest {
         "error: @JsonClass can't be applied to ObjectDeclaration: must be a Kotlin class")
   }
 
-  @Test fun objectExpressionsNotSupported() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun objectExpressionsNotSupported() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -238,7 +263,9 @@ class JsonClassCodegenProcessorTest {
         "error: @JsonClass can't be applied to expression\$annotations(): must be a Kotlin class")
   }
 
-  @Test fun requiredTransientConstructorParameterFails() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun requiredTransientConstructorParameterFails() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -252,7 +279,9 @@ class JsonClassCodegenProcessorTest {
         "error: No default value for transient property a")
   }
 
-  @Test fun nonPropertyConstructorParameter() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun nonPropertyConstructorParameter() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -267,7 +296,9 @@ class JsonClassCodegenProcessorTest {
         "error: No property for required constructor parameter a")
   }
 
-  @Test fun badGeneratedAnnotation() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun badGeneratedAnnotation() {
     val result = prepareCompilation(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -282,7 +313,9 @@ class JsonClassCodegenProcessorTest {
         "Invalid option value for ${JsonClassCodegenProcessor.OPTION_GENERATED}")
   }
 
-  @Test fun multipleErrors() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun multipleErrors() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -299,7 +332,9 @@ class JsonClassCodegenProcessorTest {
     assertThat(result.messages).contains("property c is not visible")
   }
 
-  @Test fun extendPlatformType() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun extendPlatformType() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -312,7 +347,9 @@ class JsonClassCodegenProcessorTest {
     assertThat(result.messages).contains("supertype java.util.Date is not a Kotlin type")
   }
 
-  @Test fun extendJavaType() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun extendJavaType() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -327,7 +364,9 @@ class JsonClassCodegenProcessorTest {
         .contains("supertype com.squareup.moshi.kotlin.codegen.JavaSuperclass is not a Kotlin type")
   }
 
-  @Test fun nonFieldApplicableQualifier() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun nonFieldApplicableQualifier() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -350,7 +389,9 @@ class JsonClassCodegenProcessorTest {
     assertThat(result.messages).contains("JsonQualifier @UpperCase must support FIELD target")
   }
 
-  @Test fun nonRuntimeQualifier() {
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
+  @Test
+  fun nonRuntimeQualifier() {
     val result = compile(kotlin("source.kt",
         """
           import com.squareup.moshi.JsonClass
@@ -374,6 +415,7 @@ class JsonClassCodegenProcessorTest {
     assertThat(result.messages).contains("JsonQualifier @UpperCase must have RUNTIME retention")
   }
 
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
   @Test
   fun `TypeAliases with the same backing type should share the same adapter`() {
     val result = compile(kotlin("source.kt",
@@ -398,6 +440,7 @@ class JsonClassCodegenProcessorTest {
     )
   }
 
+  @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")
   @Test
   fun `Processor should generate comprehensive proguard rules`() {
     val result = compile(kotlin("source.kt",

--- a/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessorTest.kt
+++ b/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessorTest.kt
@@ -260,7 +260,7 @@ class JsonClassCodegenProcessorTest {
     ))
     assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
     assertThat(result.messages).contains(
-        "error: @JsonClass can't be applied to expression\$annotations(): must be a Kotlin class")
+        "error: @JsonClass can't be applied to getExpression\$annotations(): must be a Kotlin class")
   }
 
   @Ignore("Temporarily ignored pending a new KCT release https://github.com/tschuchortdev/kotlin-compile-testing/issues/51")

--- a/kotlin/reflect/src/main/resources/META-INF/proguard/moshi-kotlin.pro
+++ b/kotlin/reflect/src/main/resources/META-INF/proguard/moshi-kotlin.pro
@@ -1,5 +1,0 @@
--keep class kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoaderImpl
-
--keepclassmembers class kotlin.Metadata {
-    public <methods>;
-}

--- a/kotlin/tests/pom.xml
+++ b/kotlin/tests/pom.xml
@@ -116,7 +116,7 @@
         <configuration>
           <args>
             <arg>-Werror</arg>
-            <arg>-Xuse-experimental=kotlin.ExperimentalStdlibApi</arg>
+            <arg>-Xopt-in=kotlin.ExperimentalStdlibApi</arg>
               <arg>-XXLanguage:+InlineClasses</arg>
           </args>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <incap.version>0.2</incap.version>
     <okio.version>1.16.0</okio.version>
     <okio2.version>2.1.0</okio2.version>
-    <kotlin.version>1.3.60</kotlin.version>
+    <kotlin.version>1.4.0</kotlin.version>
     <kotlinpoet.version>1.5.0</kotlinpoet.version>
     <asm.version>7.1</asm.version>
     <kotlinx-metadata.version>0.1.0</kotlinx-metadata.version>


### PR DESCRIPTION
This eliminates the need for the moshi-kotlin proguard rules since kotlin-reflect packages its own now

Resolves #1095
Resolves #345