### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Ignored revisions for git blame. Configure with
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Migrate to Spotless and format code
+538890e8c0a8178913030d80af306707ce67cb67


### PR DESCRIPTION
Annoyingly this requires users to locally configure this once via `git config blame.ignoreRevsFile .git-blame-ignore-revs`

![image](https://user-images.githubusercontent.com/1361086/91645558-060d4580-ea14-11ea-9518-c58af19382a6.png)
