### PR TITLE
Moshi event listener proposal

### DIFF
--- a/adapters/src/main/java/com/squareup/moshi/adapters/EnumJsonAdapter.java
+++ b/adapters/src/main/java/com/squareup/moshi/adapters/EnumJsonAdapter.java
@@ -15,7 +15,12 @@
  */
 package com.squareup.moshi.adapters;
 
-import com.squareup.moshi.*;
+import com.squareup.moshi.Json;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonDataException;
+import com.squareup.moshi.JsonEventListener;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;

--- a/adapters/src/test/java/com/squareup/moshi/adapters/EnumJsonAdapterTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/EnumJsonAdapterTest.java
@@ -20,7 +20,13 @@ import static org.junit.Assert.fail;
 
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonDataException;
+import com.squareup.moshi.JsonEventListener;
 import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.adapters.EnumJsonAdapter.UnknownEnumValueEvent;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
 import okio.Buffer;
 import org.junit.Test;
 
@@ -63,6 +69,24 @@ public final class EnumJsonAdapterTest {
   }
 
   @Test
+  public void withFallbackValueAndEventListenerRegistered() throws Exception {
+    EnumJsonAdapter<Roshambo> adapter =
+        EnumJsonAdapter.create(Roshambo.class).withUnknownFallback(Roshambo.ROCK);
+    DataMappingFailureEventListener eventListener = new DataMappingFailureEventListener();
+    JsonReader reader =
+        JsonReader.of(
+            new Buffer().writeUtf8("\"SPOCK\""),
+            Collections.<JsonEventListener>singletonList(eventListener));
+    assertThat(adapter.fromJson(reader)).isEqualTo(Roshambo.ROCK);
+    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+
+    assertThat(eventListener.unknownEnumValueEventList.size()).isEqualTo(1);
+    UnknownEnumValueEvent unknownEnumValueEvent = eventListener.unknownEnumValueEventList.get(0);
+    assertThat(unknownEnumValueEvent.getUnknownValue()).isEqualTo("SPOCK");
+    assertThat(unknownEnumValueEvent.getPath()).isEqualTo("$");
+  }
+
+  @Test
   public void withNullFallbackValue() throws Exception {
     EnumJsonAdapter<Roshambo> adapter =
         EnumJsonAdapter.create(Roshambo.class).withUnknownFallback(null);
@@ -76,5 +100,28 @@ public final class EnumJsonAdapterTest {
     PAPER,
     @Json(name = "scr")
     SCISSORS
+  }
+
+  private static final class DataMappingFailureEventListener implements JsonEventListener {
+    final List<UnknownEnumValueEvent> unknownEnumValueEventList;
+
+    private DataMappingFailureEventListener() {
+      unknownEnumValueEventList = new ArrayList<>();
+    }
+
+    @Override
+    public void onReadEvent(@Nonnull JsonReadEvent event) {
+      if (event instanceof UnknownEnumValueEvent) {
+        unknownEnumValueEventList.add((UnknownEnumValueEvent) event);
+      }
+    }
+
+    @Override
+    public void onWriteEvent(@Nonnull JsonWriteEvent event) {}
+
+    @Override
+    public JsonEventListener copy() {
+      return null;
+    }
   }
 }

--- a/moshi/src/main/java/com/squareup/moshi/JsonEventListener.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonEventListener.java
@@ -1,0 +1,26 @@
+package com.squareup.moshi;
+
+/**
+ * Listens to any events triggered by {@link JsonAdapter#fromJson} or {@link JsonAdapter#toJson}.
+ */
+public interface JsonEventListener {
+  /** An event that was triggered by {@link JsonAdapter#fromJson}. */
+  void onReadEvent(JsonReadEvent event);
+
+  /** An event that was triggered by {@link JsonAdapter#toJson}. */
+  void onWriteEvent(JsonWriteEvent event);
+
+  /** @return a deep copy of the event listener. */
+  JsonEventListener copy();
+
+  interface JsonEvent {
+    /** @return the path where the event occurred within the JSON. */
+    String getPath();
+  }
+
+  /** An event that was triggered by {@link JsonAdapter#fromJson}. */
+  interface JsonReadEvent extends JsonEvent {}
+
+  /** An event that was triggered by {@link JsonAdapter#toJson}. */
+  interface JsonWriteEvent extends JsonEvent {}
+}

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -19,10 +19,7 @@ import static java.util.Collections.unmodifiableList;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import okio.Buffer;
@@ -200,7 +197,13 @@ public abstract class JsonReader implements Closeable {
   /** Returns a new instance that reads UTF-8 encoded JSON from {@code source}. */
   @CheckReturnValue
   public static JsonReader of(BufferedSource source) {
-    return new JsonUtf8Reader(source);
+    return of(source, Collections.<JsonEventListener>emptyList());
+  }
+
+  /** Returns a new instance that reads UTF-8 encoded JSON from {@code source}. */
+  @CheckReturnValue
+  public static JsonReader of(BufferedSource source, List<JsonEventListener> eventListeners) {
+    return new JsonUtf8Reader(source, eventListeners);
   }
 
   // Package-private to control subclasses.
@@ -525,6 +528,13 @@ public abstract class JsonReader implements Closeable {
   public final String getPath() {
     return JsonScope.getPath(stackSize, scopes, pathNames, pathIndices);
   }
+
+  /**
+   * Returns a read-only collection of event listeners that notify when something noteworthy occurs
+   * during read/write.
+   */
+  @CheckReturnValue
+  public abstract List<JsonEventListener> getEventListeners();
 
   /**
    * Changes the reader to treat the next name as a string value. This is useful for map adapters so

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -19,7 +19,11 @@ import static java.util.Collections.unmodifiableList;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import okio.Buffer;

--- a/moshi/src/main/java/com/squareup/moshi/JsonUtf8Writer.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonUtf8Writer.java
@@ -25,6 +25,8 @@ import static com.squareup.moshi.JsonScope.NONEMPTY_OBJECT;
 import static com.squareup.moshi.JsonScope.STREAMING_VALUE;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import javax.annotation.Nullable;
 import okio.Buffer;
 import okio.BufferedSink;
@@ -68,11 +70,18 @@ final class JsonUtf8Writer extends JsonWriter {
 
   private String deferredName;
 
+  private final List<JsonEventListener> eventListeners;
+
   JsonUtf8Writer(BufferedSink sink) {
+    this(sink, Collections.<JsonEventListener>emptyList());
+  }
+
+  JsonUtf8Writer(BufferedSink sink, List<JsonEventListener> eventListeners) {
     if (sink == null) {
       throw new NullPointerException("sink == null");
     }
     this.sink = sink;
+    this.eventListeners = Collections.unmodifiableList(eventListeners);
     pushScope(EMPTY_DOCUMENT);
   }
 
@@ -324,6 +333,11 @@ final class JsonUtf8Writer extends JsonWriter {
             return Timeout.NONE;
           }
         });
+  }
+
+  @Override
+  public List<JsonEventListener> getEventListeners() {
+    return eventListeners;
   }
 
   /**

--- a/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonValueReader.java
@@ -19,7 +19,12 @@ import static com.squareup.moshi.JsonScope.CLOSED;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**

--- a/moshi/src/main/java/com/squareup/moshi/JsonValueWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonValueWriter.java
@@ -26,6 +26,7 @@ import static java.lang.Double.POSITIVE_INFINITY;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -39,7 +40,14 @@ final class JsonValueWriter extends JsonWriter {
   Object[] stack = new Object[32];
   private @Nullable String deferredName;
 
+  private final List<JsonEventListener> eventListeners;
+
   JsonValueWriter() {
+    this(Collections.<JsonEventListener>emptyList());
+  }
+
+  JsonValueWriter(List<JsonEventListener> eventListeners) {
+    this.eventListeners = Collections.unmodifiableList(eventListeners);
     pushScope(EMPTY_DOCUMENT);
   }
 
@@ -265,7 +273,7 @@ final class JsonValueWriter extends JsonWriter {
             }
             stackSize--; // Remove STREAMING_VALUE from the stack.
 
-            Object value = JsonReader.of(buffer).readJsonValue();
+            Object value = JsonReader.of(buffer, eventListeners).readJsonValue();
             boolean serializeNulls = JsonValueWriter.this.serializeNulls;
             JsonValueWriter.this.serializeNulls = true;
             try {
@@ -276,6 +284,11 @@ final class JsonValueWriter extends JsonWriter {
             pathIndices[stackSize - 1]++;
           }
         });
+  }
+
+  @Override
+  public List<JsonEventListener> getEventListeners() {
+    return eventListeners;
   }
 
   @Override

--- a/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
@@ -24,6 +24,7 @@ import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.CheckReturnValue;
@@ -174,7 +175,13 @@ public abstract class JsonWriter implements Closeable, Flushable {
   /** Returns a new instance that writes UTF-8 encoded JSON to {@code sink}. */
   @CheckReturnValue
   public static JsonWriter of(BufferedSink sink) {
-    return new JsonUtf8Writer(sink);
+    return of(sink, Collections.<JsonEventListener>emptyList());
+  }
+
+  /** Returns a new instance that writes UTF-8 encoded JSON to {@code sink}. */
+  @CheckReturnValue
+  public static JsonWriter of(BufferedSink sink, List<JsonEventListener> eventListeners) {
+    return new JsonUtf8Writer(sink, eventListeners);
   }
 
   JsonWriter() {
@@ -561,4 +568,11 @@ public abstract class JsonWriter implements Closeable, Flushable {
   public final String getPath() {
     return JsonScope.getPath(stackSize, scopes, pathNames, pathIndices);
   }
+
+  /**
+   * Returns a read-only collection of event listeners that notify when something noteworthy occurs
+   * during read/write.
+   */
+  @CheckReturnValue
+  public abstract List<JsonEventListener> getEventListeners();
 }


### PR DESCRIPTION
Relates to issue #1126.

This is a potential counter proposal to https://github.com/square/moshi/pull/1131 in which events are listened to in a more generic way that does require extending/delegating to JsonReader.

This listener would allow the user to listen to events per serialization/deserialization call, which then grants them more context to the events (as they can potentially store state in the listener if they choose to).

I did attempt to also create 'global' listeners that could be added to the `Moshi` builder itself, however it seemed very difficult to pass the listeners to the adapters without creating a breaking change to the API, as the adapters would either need to be passed via the fromJson/toJson methods, or the constructor.

If the adapters had a reference to Moshi itself, it would be trivial to fetch the listeners, however this would also likely be a breaking change.

Any thoughts?

This change is actually quite useful when writing a custom Retrofit Moshi converter as the developer can have context of the API request that has potentially caused an error, and then log the event and any contextual data to their analytics tools.

(Note: there are likely more unit tests that should be added, but I thought I would hold off until the approach was agreed)