### PR TITLE
Introduced tags to reader/writers

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -573,16 +573,26 @@ public abstract class JsonReader implements Closeable {
   }
 
   /** Returns the tag value for the given class key. */
+  @SuppressWarnings("unchecked")
   @CheckReturnValue
-  public final @Nullable Object getTag(Class<?> clazz) {
+  public final @Nullable <T> T tag(Class<? extends T> clazz) {
     if (tags == null) {
       return null;
     }
-    return tags.get(clazz);
+    return (T) tags.get(clazz);
   }
 
   /** Assigns the tag value using the given class key and value. */
-  public final void setTag(Class<?> clazz, Object value) {
+  public final <T> void setTag(Class<? extends T> clazz, T value) {
+    if (!clazz.isInstance(value)) {
+      throw new IllegalArgumentException(
+          "Tag value '"
+              + value
+              + "' ("
+              + value.getClass().getName()
+              + ") is not of type "
+              + clazz.getName());
+    }
     if (tags == null) {
       tags = new HashMap<>();
     }

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -584,14 +584,8 @@ public abstract class JsonReader implements Closeable {
 
   /** Assigns the tag value using the given class key and value. */
   public final <T> void setTag(Class<? extends T> clazz, T value) {
-    if (!clazz.isInstance(value)) {
-      throw new IllegalArgumentException(
-          "Tag value '"
-              + value
-              + "' ("
-              + value.getClass().getName()
-              + ") is not of type "
-              + clazz.getName());
+    if (clazz != value.getClass()) {
+      throw new IllegalArgumentException("Tag value must be of type " + clazz.getName());
     }
     if (tags == null) {
       tags = new HashMap<>();

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -584,7 +584,7 @@ public abstract class JsonReader implements Closeable {
 
   /** Assigns the tag value using the given class key and value. */
   public final <T> void setTag(Class<T> clazz, T value) {
-    if (clazz != value.getClass()) {
+    if (!clazz.isAssignableFrom(value.getClass())) {
       throw new IllegalArgumentException("Tag value must be of type " + clazz.getName());
     }
     if (tags == null) {

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -21,6 +21,8 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.CheckReturnValue;
@@ -196,6 +198,8 @@ public abstract class JsonReader implements Closeable {
 
   /** True to throw a {@link JsonDataException} on any attempt to call {@link #skipValue()}. */
   boolean failOnUnknown;
+
+  private Map<Class<?>, Object> tags;
 
   /** Returns a new instance that reads UTF-8 encoded JSON from {@code source}. */
   @CheckReturnValue
@@ -567,6 +571,32 @@ public abstract class JsonReader implements Closeable {
   @CheckReturnValue
   public final String getPath() {
     return JsonScope.getPath(stackSize, scopes, pathNames, pathIndices);
+  }
+
+  /** Returns the tag value for the given class key. */
+  @CheckReturnValue
+  public final @Nullable Object getTag(Class<?> clazz) {
+    if (tags == null) {
+      return null;
+    }
+    return tags.get(clazz);
+  }
+
+  /** Returns all tag values as an unmodifiable list. */
+  @CheckReturnValue
+  public final Map<Class<?>, Object> getTags() {
+    if (tags == null) {
+      return Collections.emptyMap();
+    }
+    return Collections.unmodifiableMap(tags);
+  }
+
+  /** Assigns the tag value using the given class key and value. */
+  public final void setTag(Class<?> clazz, Object value) {
+    if (tags == null) {
+      tags = new HashMap<>();
+    }
+    tags.put(clazz, value);
   }
 
   /**

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -21,7 +21,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.CheckReturnValue;
@@ -588,7 +588,7 @@ public abstract class JsonReader implements Closeable {
       throw new IllegalArgumentException("Tag value must be of type " + clazz.getName());
     }
     if (tags == null) {
-      tags = new HashMap<>();
+      tags = new LinkedHashMap<>();
     }
     tags.put(clazz, value);
   }

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -21,7 +21,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -580,15 +579,6 @@ public abstract class JsonReader implements Closeable {
       return null;
     }
     return tags.get(clazz);
-  }
-
-  /** Returns all tag values as an unmodifiable list. */
-  @CheckReturnValue
-  public final Map<Class<?>, Object> getTags() {
-    if (tags == null) {
-      return Collections.emptyMap();
-    }
-    return Collections.unmodifiableMap(tags);
   }
 
   /** Assigns the tag value using the given class key and value. */

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -575,7 +575,7 @@ public abstract class JsonReader implements Closeable {
   /** Returns the tag value for the given class key. */
   @SuppressWarnings("unchecked")
   @CheckReturnValue
-  public final @Nullable <T> T tag(Class<? extends T> clazz) {
+  public final @Nullable <T> T tag(Class<T> clazz) {
     if (tags == null) {
       return null;
     }
@@ -583,7 +583,7 @@ public abstract class JsonReader implements Closeable {
   }
 
   /** Assigns the tag value using the given class key and value. */
-  public final <T> void setTag(Class<? extends T> clazz, T value) {
+  public final <T> void setTag(Class<T> clazz, T value) {
     if (clazz != value.getClass()) {
       throw new IllegalArgumentException("Tag value must be of type " + clazz.getName());
     }

--- a/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
@@ -577,7 +577,7 @@ public abstract class JsonWriter implements Closeable, Flushable {
 
   /** Assigns the tag value using the given class key and value. */
   public final <T> void setTag(Class<T> clazz, T value) {
-    if (clazz != value.getClass()) {
+    if (!clazz.isAssignableFrom(value.getClass())) {
       throw new IllegalArgumentException("Tag value must be of type " + clazz.getName());
     }
     if (tags == null) {

--- a/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
@@ -577,14 +577,8 @@ public abstract class JsonWriter implements Closeable, Flushable {
 
   /** Assigns the tag value using the given class key and value. */
   public final <T> void setTag(Class<? extends T> clazz, T value) {
-    if (!clazz.isInstance(value)) {
-      throw new IllegalArgumentException(
-          "Tag value '"
-              + value
-              + "' ("
-              + value.getClass().getName()
-              + ") is not of type "
-              + clazz.getName());
+    if (clazz != value.getClass()) {
+      throw new IllegalArgumentException("Tag value must be of type " + clazz.getName());
     }
     if (tags == null) {
       tags = new HashMap<>();

--- a/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
@@ -568,7 +568,7 @@ public abstract class JsonWriter implements Closeable, Flushable {
   /** Returns the tag value for the given class key. */
   @SuppressWarnings("unchecked")
   @CheckReturnValue
-  public final @Nullable <T> T tag(Class<? extends T> clazz) {
+  public final @Nullable <T> T tag(Class<T> clazz) {
     if (tags == null) {
       return null;
     }
@@ -576,7 +576,7 @@ public abstract class JsonWriter implements Closeable, Flushable {
   }
 
   /** Assigns the tag value using the given class key and value. */
-  public final <T> void setTag(Class<? extends T> clazz, T value) {
+  public final <T> void setTag(Class<T> clazz, T value) {
     if (clazz != value.getClass()) {
       throw new IllegalArgumentException("Tag value must be of type " + clazz.getName());
     }

--- a/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
@@ -24,7 +24,6 @@ import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -573,15 +572,6 @@ public abstract class JsonWriter implements Closeable, Flushable {
       return null;
     }
     return tags.get(clazz);
-  }
-
-  /** Returns all tag values as an unmodifiable list. */
-  @CheckReturnValue
-  public final Map<Class<?>, Object> getTags() {
-    if (tags == null) {
-      return Collections.emptyMap();
-    }
-    return Collections.unmodifiableMap(tags);
   }
 
   /** Assigns the tag value using the given class key and value. */

--- a/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
@@ -24,7 +24,7 @@ import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.CheckReturnValue;
@@ -581,7 +581,7 @@ public abstract class JsonWriter implements Closeable, Flushable {
       throw new IllegalArgumentException("Tag value must be of type " + clazz.getName());
     }
     if (tags == null) {
-      tags = new HashMap<>();
+      tags = new LinkedHashMap<>();
     }
     tags.put(clazz, value);
   }

--- a/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
@@ -24,6 +24,8 @@ import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.CheckReturnValue;
@@ -170,6 +172,8 @@ public abstract class JsonWriter implements Closeable, Flushable {
    * with {@link #endFlatten}.
    */
   int flattenStackSize = -1;
+
+  private Map<Class<?>, Object> tags;
 
   /** Returns a new instance that writes UTF-8 encoded JSON to {@code sink}. */
   @CheckReturnValue
@@ -560,5 +564,31 @@ public abstract class JsonWriter implements Closeable, Flushable {
   @CheckReturnValue
   public final String getPath() {
     return JsonScope.getPath(stackSize, scopes, pathNames, pathIndices);
+  }
+
+  /** Returns the tag value for the given class key. */
+  @CheckReturnValue
+  public final @Nullable Object getTag(Class<?> clazz) {
+    if (tags == null) {
+      return null;
+    }
+    return tags.get(clazz);
+  }
+
+  /** Returns all tag values as an unmodifiable list. */
+  @CheckReturnValue
+  public final Map<Class<?>, Object> getTags() {
+    if (tags == null) {
+      return Collections.emptyMap();
+    }
+    return Collections.unmodifiableMap(tags);
+  }
+
+  /** Assigns the tag value using the given class key and value. */
+  public final void setTag(Class<?> clazz, Object value) {
+    if (tags == null) {
+      tags = new HashMap<>();
+    }
+    tags.put(clazz, value);
   }
 }

--- a/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
@@ -566,16 +566,26 @@ public abstract class JsonWriter implements Closeable, Flushable {
   }
 
   /** Returns the tag value for the given class key. */
+  @SuppressWarnings("unchecked")
   @CheckReturnValue
-  public final @Nullable Object getTag(Class<?> clazz) {
+  public final @Nullable <T> T tag(Class<? extends T> clazz) {
     if (tags == null) {
       return null;
     }
-    return tags.get(clazz);
+    return (T) tags.get(clazz);
   }
 
   /** Assigns the tag value using the given class key and value. */
-  public final void setTag(Class<?> clazz, Object value) {
+  public final <T> void setTag(Class<? extends T> clazz, T value) {
+    if (!clazz.isInstance(value)) {
+      throw new IllegalArgumentException(
+          "Tag value '"
+              + value
+              + "' ("
+              + value.getClass().getName()
+              + ") is not of type "
+              + clazz.getName());
+    }
     if (tags == null) {
       tags = new HashMap<>();
     }

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assume.assumeTrue;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -1431,6 +1432,24 @@ public final class JsonReaderTest {
     reader.nextSource(); // Not closed.
     assertThat(reader.nextName()).isEqualTo("c");
     assertThat(reader.nextString()).isEqualTo("d");
+  }
+
+  @Test
+  public void tags() throws IOException {
+    JsonReader reader = newReader("{}");
+    assertThat(reader.getTag(String.class)).isNull();
+    assertThat(reader.getTag(Integer.class)).isNull();
+    assertThat(reader.getTags()).isEmpty();
+
+    reader.setTag(String.class, "Foo");
+    reader.setTag(Integer.class, "Bar");
+
+    assertThat(reader.getTag(String.class)).isEqualTo("Foo");
+    assertThat(reader.getTag(Integer.class)).isEqualTo("Bar");
+    assertThat(reader.getTags())
+        .containsOnly(
+            new SimpleEntry<Class<?>, Object>(String.class, "Foo"),
+            new SimpleEntry<Class<?>, Object>(Integer.class, "Bar"));
   }
 
   /** Peek a value, then read it, recursively. */

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assume.assumeTrue;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -1439,17 +1438,12 @@ public final class JsonReaderTest {
     JsonReader reader = newReader("{}");
     assertThat(reader.getTag(String.class)).isNull();
     assertThat(reader.getTag(Integer.class)).isNull();
-    assertThat(reader.getTags()).isEmpty();
 
     reader.setTag(String.class, "Foo");
     reader.setTag(Integer.class, "Bar");
 
     assertThat(reader.getTag(String.class)).isEqualTo("Foo");
     assertThat(reader.getTag(Integer.class)).isEqualTo("Bar");
-    assertThat(reader.getTags())
-        .containsOnly(
-            new SimpleEntry<Class<?>, Object>(String.class, "Foo"),
-            new SimpleEntry<Class<?>, Object>(Integer.class, "Bar"));
   }
 
   /** Peek a value, then read it, recursively. */

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
@@ -1436,14 +1436,22 @@ public final class JsonReaderTest {
   @Test
   public void tags() throws IOException {
     JsonReader reader = newReader("{}");
-    assertThat(reader.getTag(String.class)).isNull();
-    assertThat(reader.getTag(Integer.class)).isNull();
+    assertThat(reader.tag(String.class)).isNull();
+    assertThat(reader.tag(Integer.class)).isNull();
 
     reader.setTag(String.class, "Foo");
-    reader.setTag(Integer.class, "Bar");
+    reader.setTag(Integer.class, 1);
+    try {
+      reader.setTag(Integer.class, "Invalid");
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected)
+          .hasMessage("Tag value 'Invalid' (java.lang.String) is not of type java.lang.Integer");
+    }
 
-    assertThat(reader.getTag(String.class)).isEqualTo("Foo");
-    assertThat(reader.getTag(Integer.class)).isEqualTo("Bar");
+    assertThat(reader.tag(String.class)).isEqualTo("Foo").isInstanceOf(String.class);
+    assertThat(reader.tag(Integer.class)).isEqualTo(1).isInstanceOf(Integer.class);
+    assertThat(reader.tag(Long.class)).isNull();
   }
 
   /** Peek a value, then read it, recursively. */

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
@@ -1433,76 +1433,25 @@ public final class JsonReaderTest {
     assertThat(reader.nextString()).isEqualTo("d");
   }
 
-  private static final class TagA {
-    private final int data;
-
-    private TagA(int data) {
-      this.data = data;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-
-      TagA tagA = (TagA) o;
-
-      return data == tagA.data;
-    }
-
-    @Override
-    public int hashCode() {
-      return data;
-    }
-  }
-
-  private interface TagB {}
-
-  private static final class TagBSubType implements TagB {
-    private final int data;
-
-    private TagBSubType(int data) {
-      this.data = data;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-
-      TagBSubType tagA = (TagBSubType) o;
-
-      return data == tagA.data;
-    }
-
-    @Override
-    public int hashCode() {
-      return data;
-    }
-  }
-
   @SuppressWarnings("rawtypes")
   @Test
   public void tags() throws IOException {
     JsonReader reader = newReader("{}");
-    assertThat(reader.tag(TagA.class)).isNull();
-    assertThat(reader.tag(TagB.class)).isNull();
+    assertThat(reader.tag(Integer.class)).isNull();
+    assertThat(reader.tag(CharSequence.class)).isNull();
 
-    reader.setTag(TagA.class, new TagA(1));
-    reader.setTag(TagB.class, new TagBSubType(2));
+    reader.setTag(Integer.class, 1);
+    reader.setTag(CharSequence.class, "Foo");
     try {
-      reader.setTag((Class) TagA.class, "Invalid");
+      reader.setTag((Class) CharSequence.class, 1);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessage("Tag value must be of type com.squareup.moshi.JsonReaderTest$TagA");
+      assertThat(expected).hasMessage("Tag value must be of type java.lang.CharSequence");
     }
 
-    assertThat(reader.tag(TagA.class)).isEqualTo(new TagA(1)).isInstanceOf(TagA.class);
-    assertThat(reader.tag(TagB.class))
-        .isEqualTo(new TagBSubType(2))
-        .isInstanceOf(TagBSubType.class);
-    assertThat(reader.tag(TagBSubType.class)).isNull();
+    assertThat(reader.tag(Integer.class)).isEqualTo(1).isInstanceOf(Integer.class);
+    assertThat(reader.tag(CharSequence.class)).isEqualTo("Foo").isInstanceOf(String.class);
+    assertThat(reader.tag(String.class)).isNull();
   }
 
   /** Peek a value, then read it, recursively. */

--- a/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
@@ -954,75 +954,24 @@ public final class JsonWriterTest {
     assertThat(factory.json()).isEqualTo("{}");
   }
 
-  private static final class TagA {
-    private final int data;
-
-    private TagA(int data) {
-      this.data = data;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-
-      TagA tagA = (TagA) o;
-
-      return data == tagA.data;
-    }
-
-    @Override
-    public int hashCode() {
-      return data;
-    }
-  }
-
-  private interface TagB {}
-
-  private static final class TagBSubType implements TagB {
-    private final int data;
-
-    private TagBSubType(int data) {
-      this.data = data;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-
-      TagBSubType tagA = (TagBSubType) o;
-
-      return data == tagA.data;
-    }
-
-    @Override
-    public int hashCode() {
-      return data;
-    }
-  }
-
   @SuppressWarnings("rawtypes")
   @Test
   public void tags() throws IOException {
     JsonWriter writer = factory.newWriter();
-    assertThat(writer.tag(TagA.class)).isNull();
-    assertThat(writer.tag(TagB.class)).isNull();
+    assertThat(writer.tag(Integer.class)).isNull();
+    assertThat(writer.tag(CharSequence.class)).isNull();
 
-    writer.setTag(TagA.class, new TagA(1));
-    writer.setTag(TagB.class, new TagBSubType(2));
+    writer.setTag(Integer.class, 1);
+    writer.setTag(CharSequence.class, "Foo");
     try {
-      writer.setTag((Class) TagA.class, "Invalid");
+      writer.setTag((Class) CharSequence.class, 1);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessage("Tag value must be of type com.squareup.moshi.JsonWriterTest$TagA");
+      assertThat(expected).hasMessage("Tag value must be of type java.lang.CharSequence");
     }
 
-    assertThat(writer.tag(TagA.class)).isEqualTo(new TagA(1)).isInstanceOf(TagA.class);
-    assertThat(writer.tag(TagB.class))
-        .isEqualTo(new TagBSubType(2))
-        .isInstanceOf(TagBSubType.class);
-    assertThat(writer.tag(TagBSubType.class)).isNull();
+    assertThat(writer.tag(Integer.class)).isEqualTo(1).isInstanceOf(Integer.class);
+    assertThat(writer.tag(CharSequence.class)).isEqualTo("Foo").isInstanceOf(String.class);
+    assertThat(writer.tag(String.class)).isNull();
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assume.assumeTrue;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -952,5 +953,23 @@ public final class JsonWriterTest {
     writer.promoteValueToName();
     writer.endObject();
     assertThat(factory.json()).isEqualTo("{}");
+  }
+
+  @Test
+  public void tags() throws IOException {
+    JsonWriter writer = factory.newWriter();
+    assertThat(writer.getTag(String.class)).isNull();
+    assertThat(writer.getTag(Integer.class)).isNull();
+    assertThat(writer.getTags()).isEmpty();
+
+    writer.setTag(String.class, "Foo");
+    writer.setTag(Integer.class, "Bar");
+
+    assertThat(writer.getTag(String.class)).isEqualTo("Foo");
+    assertThat(writer.getTag(Integer.class)).isEqualTo("Bar");
+    assertThat(writer.getTags())
+        .containsOnly(
+            new SimpleEntry<Class<?>, Object>(String.class, "Foo"),
+            new SimpleEntry<Class<?>, Object>(Integer.class, "Bar"));
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assume.assumeTrue;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -960,16 +959,11 @@ public final class JsonWriterTest {
     JsonWriter writer = factory.newWriter();
     assertThat(writer.getTag(String.class)).isNull();
     assertThat(writer.getTag(Integer.class)).isNull();
-    assertThat(writer.getTags()).isEmpty();
 
     writer.setTag(String.class, "Foo");
     writer.setTag(Integer.class, "Bar");
 
     assertThat(writer.getTag(String.class)).isEqualTo("Foo");
     assertThat(writer.getTag(Integer.class)).isEqualTo("Bar");
-    assertThat(writer.getTags())
-        .containsOnly(
-            new SimpleEntry<Class<?>, Object>(String.class, "Foo"),
-            new SimpleEntry<Class<?>, Object>(Integer.class, "Bar"));
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
@@ -954,24 +954,76 @@ public final class JsonWriterTest {
     assertThat(factory.json()).isEqualTo("{}");
   }
 
+  private static final class TagA {
+    private final int data;
+
+    private TagA(int data) {
+      this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      TagA tagA = (TagA) o;
+
+      return data == tagA.data;
+    }
+
+    @Override
+    public int hashCode() {
+      return data;
+    }
+  }
+
+  private static class TagB {
+    private final int data;
+
+    private TagB(int data) {
+      this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      TagB tagA = (TagB) o;
+
+      return data == tagA.data;
+    }
+
+    @Override
+    public int hashCode() {
+      return data;
+    }
+  }
+
+  private static final class TagBSubType extends TagB {
+    private TagBSubType(int data) {
+      super(data);
+    }
+  }
+
   @Test
   public void tags() throws IOException {
     JsonWriter writer = factory.newWriter();
-    assertThat(writer.tag(String.class)).isNull();
-    assertThat(writer.tag(Integer.class)).isNull();
+    assertThat(writer.tag(TagA.class)).isNull();
+    assertThat(writer.tag(TagB.class)).isNull();
 
-    writer.setTag(String.class, "Foo");
-    writer.setTag(Integer.class, 1);
+    writer.setTag(TagA.class, new TagA(1));
+    writer.setTag(TagB.class, new TagB(2));
     try {
-      writer.setTag(Integer.class, "Invalid");
+      writer.setTag(TagB.class, new TagBSubType(3));
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessage("Tag value 'Invalid' (java.lang.String) is not of type java.lang.Integer");
+          .hasMessage("Tag value must be of type com.squareup.moshi.JsonWriterTest$TagB");
     }
 
-    assertThat(writer.tag(String.class)).isEqualTo("Foo").isInstanceOf(String.class);
-    assertThat(writer.tag(Integer.class)).isEqualTo(1).isInstanceOf(Integer.class);
-    assertThat(writer.tag(Long.class)).isNull();
+    assertThat(writer.tag(TagA.class)).isEqualTo(new TagA(1)).isInstanceOf(TagA.class);
+    assertThat(writer.tag(TagB.class)).isEqualTo(new TagB(2)).isInstanceOf(TagB.class);
+    assertThat(writer.tag(TagBSubType.class)).isNull();
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
@@ -957,13 +957,21 @@ public final class JsonWriterTest {
   @Test
   public void tags() throws IOException {
     JsonWriter writer = factory.newWriter();
-    assertThat(writer.getTag(String.class)).isNull();
-    assertThat(writer.getTag(Integer.class)).isNull();
+    assertThat(writer.tag(String.class)).isNull();
+    assertThat(writer.tag(Integer.class)).isNull();
 
     writer.setTag(String.class, "Foo");
-    writer.setTag(Integer.class, "Bar");
+    writer.setTag(Integer.class, 1);
+    try {
+      writer.setTag(Integer.class, "Invalid");
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected)
+          .hasMessage("Tag value 'Invalid' (java.lang.String) is not of type java.lang.Integer");
+    }
 
-    assertThat(writer.getTag(String.class)).isEqualTo("Foo");
-    assertThat(writer.getTag(Integer.class)).isEqualTo("Bar");
+    assertThat(writer.tag(String.class)).isEqualTo("Foo").isInstanceOf(String.class);
+    assertThat(writer.tag(Integer.class)).isEqualTo(1).isInstanceOf(Integer.class);
+    assertThat(writer.tag(Long.class)).isNull();
   }
 }


### PR DESCRIPTION
Relates to issue #1126.

This is an implementation of a suggestion from @swankjesse (https://github.com/square/moshi/pull/1209#issuecomment-683903925)

This will give developers the ability to append custom data to JsonReader/JsonWriter classes. This will be very useful for custom adapters that wish to track supplemental data.