### PR TITLE
Use exclusiveContent API for jcenter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,11 +104,19 @@ spotless {
 subprojects {
   repositories {
     mavenCentral()
-    jcenter().mavenContent {
-      // Required for Dokka
-      includeModule("org.jetbrains.kotlinx", "kotlinx-html-jvm")
-      includeGroup("org.jetbrains.dokka")
-      includeModule("org.jetbrains", "markdown")
+    // Required for Dokka
+    exclusiveContent {
+      forRepository {
+        maven {
+          name = "JCenter"
+          setUrl("https://jcenter.bintray.com/")
+        }
+      }
+      filter {
+        includeModule("org.jetbrains.kotlinx", "kotlinx-html-jvm")
+        includeGroup("org.jetbrains.dokka")
+        includeModule("org.jetbrains", "markdown")
+      }
     }
   }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,18 +18,6 @@ pluginManagement {
   repositories {
     mavenCentral()
     gradlePluginPortal()
-    @Suppress("UnstableApiUsage")
-    exclusiveContent {
-      forRepository {
-        maven {
-          name = "JCenter"
-          setUrl("https://jcenter.bintray.com/")
-        }
-      }
-      filter {
-        includeModule("org.jetbrains.dokka", "dokka-fatjar")
-      }
-    }
   }
 }
 


### PR DESCRIPTION
The previous setup said to only look for those packages in jcenter. This is a more powerful alternative, which says only use jcenter for those packages