### PR TITLE
Standardize (almost) all tests on Truth

### DIFF
--- a/adapters/build.gradle.kts
+++ b/adapters/build.gradle.kts
@@ -25,5 +25,5 @@ dependencies {
 
   testCompileOnly(Dependencies.jsr305)
   testImplementation(Dependencies.Testing.junit)
-  testImplementation(Dependencies.Testing.assertj)
+  testImplementation(Dependencies.Testing.truth)
 }

--- a/adapters/src/test/java/com/squareup/moshi/adapters/EnumJsonAdapterTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/EnumJsonAdapterTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.moshi.adapters;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import com.squareup.moshi.Json;
@@ -48,7 +48,7 @@ public final class EnumJsonAdapterTest {
       adapter.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected one of [ROCK, PAPER, scr] but was SPOCK at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected one of [ROCK, PAPER, scr] but was SPOCK at path $");
     }
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
   }

--- a/adapters/src/test/java/com/squareup/moshi/adapters/EnumJsonAdapterTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/EnumJsonAdapterTest.java
@@ -48,7 +48,9 @@ public final class EnumJsonAdapterTest {
       adapter.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected one of [ROCK, PAPER, scr] but was SPOCK at path $");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Expected one of [ROCK, PAPER, scr] but was SPOCK at path $");
     }
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
   }

--- a/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.moshi.adapters;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import com.squareup.moshi.JsonAdapter;
@@ -84,7 +84,7 @@ public final class PolymorphicJsonAdapterFactoryTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Expected one of [success, error] for key 'type' but found"
                   + " 'data'. Register a subtype for this label.");
     }
@@ -105,7 +105,7 @@ public final class PolymorphicJsonAdapterFactoryTest {
     JsonAdapter<Message> adapter = moshi.adapter(Message.class);
 
     Message message = adapter.fromJson("{\"type\":\"data\",\"value\":\"Okay!\"}");
-    assertThat(message).isSameAs(fallbackError);
+    assertThat(message).isSameInstanceAs(fallbackError);
   }
 
   @Test
@@ -176,7 +176,7 @@ public final class PolymorphicJsonAdapterFactoryTest {
       adapter.toJson(new EmptyMessage());
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Expected one of [class"
                   + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$Success, class"
                   + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$Error] but found"
@@ -203,7 +203,7 @@ public final class PolymorphicJsonAdapterFactoryTest {
       adapter.toJson(new EmptyMessage());
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Expected one of [class"
                   + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$Success, class"
                   + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$Error] but found"
@@ -256,7 +256,7 @@ public final class PolymorphicJsonAdapterFactoryTest {
       adapter.fromJson("{\"type\":{},\"value\":\"Okay!\"}");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected a string but was BEGIN_OBJECT at path $.type");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected a string but was BEGIN_OBJECT at path $.type");
     }
   }
 
@@ -276,7 +276,7 @@ public final class PolymorphicJsonAdapterFactoryTest {
       adapter.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected BEGIN_OBJECT but was STRING at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected BEGIN_OBJECT but was STRING at path $");
     }
     assertThat(reader.nextString()).isEqualTo("Failure");
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
@@ -313,7 +313,7 @@ public final class PolymorphicJsonAdapterFactoryTest {
       factory.withSubtype(Error.class, "data");
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("Labels must be unique.");
+      assertThat(expected).hasMessageThat().isEqualTo("Labels must be unique.");
     }
   }
 

--- a/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
@@ -84,7 +84,8 @@ public final class PolymorphicJsonAdapterFactoryTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Expected one of [success, error] for key 'type' but found"
                   + " 'data'. Register a subtype for this label.");
     }
@@ -176,7 +177,8 @@ public final class PolymorphicJsonAdapterFactoryTest {
       adapter.toJson(new EmptyMessage());
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Expected one of [class"
                   + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$Success, class"
                   + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$Error] but found"
@@ -203,7 +205,8 @@ public final class PolymorphicJsonAdapterFactoryTest {
       adapter.toJson(new EmptyMessage());
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Expected one of [class"
                   + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$Success, class"
                   + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$Error] but found"
@@ -256,7 +259,9 @@ public final class PolymorphicJsonAdapterFactoryTest {
       adapter.fromJson("{\"type\":{},\"value\":\"Okay!\"}");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a string but was BEGIN_OBJECT at path $.type");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Expected a string but was BEGIN_OBJECT at path $.type");
     }
   }
 
@@ -276,7 +281,9 @@ public final class PolymorphicJsonAdapterFactoryTest {
       adapter.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected BEGIN_OBJECT but was STRING at path $");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Expected BEGIN_OBJECT but was STRING at path $");
     }
     assertThat(reader.nextString()).isEqualTo("Failure");
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);

--- a/adapters/src/test/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapterTest.java
+++ b/adapters/src/test/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapterTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.moshi.adapters;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import com.squareup.moshi.JsonAdapter;
 import java.util.Calendar;

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -49,8 +49,8 @@ object Dependencies {
 
   object Testing {
     const val assertj = "org.assertj:assertj-core:3.11.1"
-    const val compileTesting = "com.github.tschuchortdev:kotlin-compile-testing:1.2.10"
-    const val junit = "junit:junit:4.12"
-    const val truth = "com.google.truth:truth:1.0"
+    const val compileTesting = "com.github.tschuchortdev:kotlin-compile-testing:1.2.11"
+    const val junit = "junit:junit:4.13"
+    const val truth = "com.google.truth:truth:1.0.1"
   }
 }

--- a/kotlin/codegen/build.gradle.kts
+++ b/kotlin/codegen/build.gradle.kts
@@ -76,7 +76,6 @@ dependencies {
   testImplementation(Dependencies.KotlinPoet.metadataSpecs)
   testImplementation(Dependencies.KotlinPoet.elementsClassInspector)
   testImplementation(Dependencies.Testing.junit)
-  testImplementation(Dependencies.Testing.assertj)
   testImplementation(Dependencies.Testing.truth)
   testImplementation(Dependencies.Testing.compileTesting)
   testImplementation(Dependencies.okio2)

--- a/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessorTest.kt
+++ b/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessorTest.kt
@@ -15,12 +15,12 @@
  */
 package com.squareup.moshi.kotlin.codegen
 
+import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import com.tschuchort.compiletesting.SourceFile.Companion.kotlin
-import com.google.common.truth.Truth.assertThat
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test

--- a/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessorTest.kt
+++ b/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessorTest.kt
@@ -20,7 +20,7 @@ import com.squareup.moshi.JsonReader
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import com.tschuchort.compiletesting.SourceFile.Companion.kotlin
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
@@ -616,7 +616,7 @@ class JsonClassCodegenProcessorTest {
 
     result.generatedFiles.filter { it.extension == "pro" }.forEach { generatedFile ->
       when (generatedFile.nameWithoutExtension) {
-        "moshi-testPackage.Aliases" -> assertThat(generatedFile).hasContent(
+        "moshi-testPackage.Aliases" -> assertThat(generatedFile.readText()).contains(
           """
           -if class testPackage.Aliases
           -keepnames class testPackage.Aliases
@@ -626,7 +626,7 @@ class JsonClassCodegenProcessorTest {
           }
           """.trimIndent()
         )
-        "moshi-testPackage.Simple" -> assertThat(generatedFile).hasContent(
+        "moshi-testPackage.Simple" -> assertThat(generatedFile.readText()).contains(
           """
           -if class testPackage.Simple
           -keepnames class testPackage.Simple
@@ -636,7 +636,7 @@ class JsonClassCodegenProcessorTest {
           }
           """.trimIndent()
         )
-        "moshi-testPackage.Generic" -> assertThat(generatedFile).hasContent(
+        "moshi-testPackage.Generic" -> assertThat(generatedFile.readText()).contains(
           """
           -if class testPackage.Generic
           -keepnames class testPackage.Generic
@@ -646,7 +646,7 @@ class JsonClassCodegenProcessorTest {
           }
           """.trimIndent()
         )
-        "moshi-testPackage.UsingQualifiers" -> assertThat(generatedFile).hasContent(
+        "moshi-testPackage.UsingQualifiers" -> assertThat(generatedFile.readText()).contains(
           """
           -if class testPackage.UsingQualifiers
           -keepnames class testPackage.UsingQualifiers
@@ -659,7 +659,7 @@ class JsonClassCodegenProcessorTest {
           -keep @interface testPackage.MyQualifier
           """.trimIndent()
         )
-        "moshi-testPackage.MixedTypes" -> assertThat(generatedFile).hasContent(
+        "moshi-testPackage.MixedTypes" -> assertThat(generatedFile.readText()).contains(
           """
           -if class testPackage.MixedTypes
           -keepnames class testPackage.MixedTypes
@@ -669,7 +669,7 @@ class JsonClassCodegenProcessorTest {
           }
           """.trimIndent()
         )
-        "moshi-testPackage.DefaultParams" -> assertThat(generatedFile).hasContent(
+        "moshi-testPackage.DefaultParams" -> assertThat(generatedFile.readText()).contains(
           """
           -if class testPackage.DefaultParams
           -keepnames class testPackage.DefaultParams
@@ -685,7 +685,7 @@ class JsonClassCodegenProcessorTest {
           }
           """.trimIndent()
         )
-        "moshi-testPackage.Complex" -> assertThat(generatedFile).hasContent(
+        "moshi-testPackage.Complex" -> assertThat(generatedFile.readText()).contains(
           """
           -if class testPackage.Complex
           -keepnames class testPackage.Complex
@@ -704,7 +704,7 @@ class JsonClassCodegenProcessorTest {
           }
           """.trimIndent()
         )
-        "moshi-testPackage.MultipleMasks" -> assertThat(generatedFile).hasContent(
+        "moshi-testPackage.MultipleMasks" -> assertThat(generatedFile.readText()).contains(
           """
           -if class testPackage.MultipleMasks
           -keepnames class testPackage.MultipleMasks
@@ -720,7 +720,7 @@ class JsonClassCodegenProcessorTest {
           }
           """.trimIndent()
         )
-        "moshi-testPackage.NestedType.NestedSimple" -> assertThat(generatedFile).hasContent(
+        "moshi-testPackage.NestedType.NestedSimple" -> assertThat(generatedFile.readText()).contains(
           """
           -if class testPackage.NestedType${'$'}NestedSimple
           -keepnames class testPackage.NestedType${'$'}NestedSimple

--- a/kotlin/reflect/build.gradle.kts
+++ b/kotlin/reflect/build.gradle.kts
@@ -25,5 +25,5 @@ dependencies {
 
   testImplementation(kotlin("test"))
   testImplementation(Dependencies.Testing.junit)
-  testImplementation(Dependencies.Testing.assertj)
+  testImplementation(Dependencies.Testing.truth)
 }

--- a/kotlin/reflect/src/test/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/kotlin/reflect/src/test/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -17,7 +17,7 @@ package com.squareup.moshi.kotlin.reflect
 
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class KotlinJsonAdapterTest {

--- a/kotlin/reflect/src/test/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/kotlin/reflect/src/test/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -15,9 +15,9 @@
  */
 package com.squareup.moshi.kotlin.reflect
 
+import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
-import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class KotlinJsonAdapterTest {

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.moshi.kotlin
 
+import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
@@ -26,7 +27,6 @@ import com.squareup.moshi.ToJson
 import com.squareup.moshi.Types
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.adapter
-import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.Assert.fail
 import org.junit.Test
@@ -87,7 +87,7 @@ class DualKotlinTest(useReflection: Boolean) {
       jsonAdapter.fromJson("""{"a":4}""")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessage("Required value 'b' missing at $")
+      assertThat(expected).hasMessageThat().isEqualTo("Required value 'b' missing at $")
     }
   }
 
@@ -102,7 +102,7 @@ class DualKotlinTest(useReflection: Boolean) {
       jsonAdapter.fromJson("""{"a":4}""")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessage("Required value 'b' (JSON name 'bPrime') missing at \$")
+      assertThat(expected).hasMessageThat().isEqualTo("Required value 'b' (JSON name 'bPrime') missing at \$")
     }
   }
 
@@ -117,7 +117,7 @@ class DualKotlinTest(useReflection: Boolean) {
       jsonAdapter.fromJson("{\"a\":null}")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessage("Non-null value 'a' was null at \$.a")
+      assertThat(expected).hasMessageThat().isEqualTo("Non-null value 'a' was null at \$.a")
     }
   }
 
@@ -138,7 +138,7 @@ class DualKotlinTest(useReflection: Boolean) {
       jsonAdapter.fromJson("{\"a\":\"hello\"}")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessage("Non-null value 'a' was null at \$.a")
+      assertThat(expected).hasMessageThat().isEqualTo("Non-null value 'a' was null at \$.a")
     }
   }
 
@@ -155,7 +155,7 @@ class DualKotlinTest(useReflection: Boolean) {
       jsonAdapter.fromJson("{\"aPrime\":null}")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessage("Non-null value 'a' (JSON name 'aPrime') was null at \$.aPrime")
+      assertThat(expected).hasMessageThat().isEqualTo("Non-null value 'a' (JSON name 'aPrime') was null at \$.aPrime")
     }
   }
 
@@ -176,7 +176,7 @@ class DualKotlinTest(useReflection: Boolean) {
       jsonAdapter.fromJson("{\"aPrime\":\"hello\"}")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessage("Non-null value 'a' (JSON name 'aPrime') was null at \$.aPrime")
+      assertThat(expected).hasMessageThat().isEqualTo("Non-null value 'a' (JSON name 'aPrime') was null at \$.aPrime")
     }
   }
 
@@ -193,7 +193,7 @@ class DualKotlinTest(useReflection: Boolean) {
       jsonAdapter.fromJson("{\"a\":null}")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessage("Non-null value 'a' was null at \$.a")
+      assertThat(expected).hasMessageThat().isEqualTo("Non-null value 'a' was null at \$.a")
     }
   }
 
@@ -214,7 +214,7 @@ class DualKotlinTest(useReflection: Boolean) {
       jsonAdapter.fromJson("{\"a\":\"hello\"}")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessage("Non-null value 'a' was null at \$.a")
+      assertThat(expected).hasMessageThat().isEqualTo("Non-null value 'a' was null at \$.a")
     }
   }
 

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/ComplexGenericsInheritanceTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/ComplexGenericsInheritanceTest.kt
@@ -17,10 +17,10 @@
 
 package com.squareup.moshi.kotlin.codegen
 
+import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.adapter
-import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -28,7 +28,7 @@ import com.squareup.moshi.ToJson
 import com.squareup.moshi.Types
 import com.squareup.moshi.internal.NullSafeJsonAdapter
 import com.squareup.moshi.kotlin.reflect.adapter
-import org.assertj.core.api.Assertions.assertThat
+import com.google.common.truth.Truth.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.Assert.assertNull
 import org.junit.Assert.fail
@@ -177,7 +177,7 @@ class GeneratedAdaptersTest {
       """{"data":[null,"why"]}"""
 
     val instance = adapter.fromJson(json)!!
-    assertThat(instance.data).containsExactly(null, "why")
+    assertThat(instance.data).asList().containsExactly(null, "why")
     assertThat(adapter.toJson(instance)).isEqualTo(json)
   }
 
@@ -193,7 +193,7 @@ class GeneratedAdaptersTest {
       """{"ints":[0,1]}"""
 
     val instance = adapter.fromJson(json)!!
-    assertThat(instance.ints).containsExactly(0, 1)
+    assertThat(instance.ints).asList().containsExactly(0, 1)
     assertThat(adapter.toJson(instance)).isEqualTo(json)
   }
 
@@ -219,7 +219,7 @@ class GeneratedAdaptersTest {
       adapter.fromJson(invalidJson)
       fail("The invalid json should have failed!")
     } catch (e: JsonDataException) {
-      assertThat(e).hasMessageContaining("foo")
+      assertThat(e).hasMessageThat().contains("foo")
     }
   }
 
@@ -933,7 +933,7 @@ class GeneratedAdaptersTest {
       jsonAdapter.fromJson("""{"a":4,"a":4}""")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessage("Multiple values for 'a' at $.a")
+      assertThat(expected).hasMessageThat().isEqualTo("Multiple values for 'a' at $.a")
     }
   }
 
@@ -948,7 +948,7 @@ class GeneratedAdaptersTest {
       jsonAdapter.fromJson("""{"a":4,"a":4}""")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessage("Multiple values for 'a' at $.a")
+      assertThat(expected).hasMessageThat().isEqualTo("Multiple values for 'a' at $.a")
     }
   }
 
@@ -1272,7 +1272,7 @@ class GeneratedAdaptersTest {
       moshi.adapter<CustomGeneratedClassMissing>()
       fail()
     } catch (e: RuntimeException) {
-      assertThat(e).hasMessageContaining("Failed to find the generated JsonAdapter class")
+      assertThat(e).hasMessageThat().contains("Failed to find the generated JsonAdapter class")
     }
   }
 
@@ -1349,7 +1349,7 @@ class GeneratedAdaptersTest {
       moshi.adapter(MultipleGenerics::class.java)
       fail("Should have failed to construct the adapter due to missing generics")
     } catch (e: RuntimeException) {
-      assertThat(e).hasMessage("Failed to find the generated JsonAdapter constructor for 'class com.squareup.moshi.kotlin.codegen.GeneratedAdaptersTest\$MultipleGenerics'. Suspiciously, the type was not parameterized but the target class 'com.squareup.moshi.kotlin.codegen.GeneratedAdaptersTest_MultipleGenericsJsonAdapter' is generic. Consider using Types#newParameterizedType() to define these missing type variables.")
+      assertThat(e).hasMessageThat().isEqualTo("Failed to find the generated JsonAdapter constructor for 'class com.squareup.moshi.kotlin.codegen.GeneratedAdaptersTest\$MultipleGenerics'. Suspiciously, the type was not parameterized but the target class 'com.squareup.moshi.kotlin.codegen.GeneratedAdaptersTest_MultipleGenericsJsonAdapter' is generic. Consider using Types#newParameterizedType() to define these missing type variables.")
     }
   }
 
@@ -1361,7 +1361,7 @@ class GeneratedAdaptersTest {
       )
       fail("Should have failed to construct the adapter due to wrong number of generics")
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessage("TypeVariable mismatch: Expecting 4 types for generic type variables [A, B, C, D], but received 1")
+      assertThat(e).hasMessageThat().isEqualTo("TypeVariable mismatch: Expecting 4 types for generic type variables [A, B, C, D], but received 1")
     }
   }
 

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.moshi.kotlin.codegen
 
+import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
@@ -28,7 +29,6 @@ import com.squareup.moshi.ToJson
 import com.squareup.moshi.Types
 import com.squareup.moshi.internal.NullSafeJsonAdapter
 import com.squareup.moshi.kotlin.reflect.adapter
-import com.google.common.truth.Truth.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.Assert.assertNull
 import org.junit.Assert.fail

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -177,7 +177,7 @@ class GeneratedAdaptersTest {
       """{"data":[null,"why"]}"""
 
     val instance = adapter.fromJson(json)!!
-    assertThat(instance.data).asList().containsExactly(null, "why")
+    assertThat(instance.data).asList().containsExactly(null, "why").inOrder()
     assertThat(adapter.toJson(instance)).isEqualTo(json)
   }
 
@@ -193,7 +193,7 @@ class GeneratedAdaptersTest {
       """{"ints":[0,1]}"""
 
     val instance = adapter.fromJson(json)!!
-    assertThat(instance.ints).asList().containsExactly(0, 1)
+    assertThat(instance.ints).asList().containsExactly(0, 1).inOrder()
     assertThat(adapter.toJson(instance)).isEqualTo(json)
   }
 

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.moshi.kotlin.reflect
 
+import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
@@ -26,7 +27,7 @@ import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.ToJson
 import com.squareup.moshi.Types
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions
 import org.junit.Assert.fail
 import org.junit.Test
 import java.io.ByteArrayOutputStream
@@ -141,7 +142,7 @@ class KotlinJsonAdapterTest {
       jsonAdapter.fromJson("""{"a":4,"a":4}""")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessage("Multiple values for 'a' at $.a")
+      assertThat(expected).hasMessageThat().isEqualTo("Multiple values for 'a' at $.a")
     }
   }
 
@@ -155,7 +156,7 @@ class KotlinJsonAdapterTest {
       jsonAdapter.fromJson("""{"a":4,"a":4}""")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessage("Multiple values for 'a' at $.a")
+      assertThat(expected).hasMessageThat().isEqualTo("Multiple values for 'a' at $.a")
     }
   }
 
@@ -202,7 +203,7 @@ class KotlinJsonAdapterTest {
       jsonAdapter.fromJson("""{"a":4,"b":null,"b":6}""")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessage("Multiple values for 'b' at $.b")
+      assertThat(expected).hasMessageThat().isEqualTo("Multiple values for 'b' at $.b")
     }
   }
 
@@ -315,7 +316,7 @@ class KotlinJsonAdapterTest {
       moshi.adapter<RequiredTransientConstructorParameter>()
       fail()
     } catch (expected: IllegalArgumentException) {
-      assertThat(expected).hasMessage(
+      assertThat(expected).hasMessageThat().isEqualTo(
         "No default value for transient constructor parameter #0 " +
           "a of fun <init>(kotlin.Int): " +
           "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest.RequiredTransientConstructorParameter"
@@ -359,7 +360,7 @@ class KotlinJsonAdapterTest {
       moshi.adapter<ConstructorParameterWithSameNameAsPropertyButDifferentType>()
       fail()
     } catch (expected: IllegalArgumentException) {
-      assertThat(expected).hasMessage(
+      assertThat(expected).hasMessageThat().isEqualTo(
         "'a' has a constructor parameter of type " +
           "kotlin.Int but a property of type kotlin.String."
       )
@@ -446,7 +447,7 @@ class KotlinJsonAdapterTest {
       moshi.adapter<Triple<*, *, *>>()
       fail()
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessage(
+      assertThat(e).hasMessageThat().isEqualTo(
         "Platform class kotlin.Triple in kotlin.Triple<java.lang.Object, java.lang.Object, java.lang.Object> requires explicit JsonAdapter to be registered"
       )
     }
@@ -590,7 +591,7 @@ class KotlinJsonAdapterTest {
       moshi.adapter<NonPropertyConstructorParameter>()
       fail()
     } catch (expected: IllegalArgumentException) {
-      assertThat(expected).hasMessage(
+      assertThat(expected).hasMessageThat().isEqualTo(
         "No property for required constructor parameter #0 a of fun <init>(" +
           "kotlin.Int, kotlin.Int): ${NonPropertyConstructorParameter::class.qualifiedName}"
       )
@@ -618,7 +619,7 @@ class KotlinJsonAdapterTest {
       moshi.adapter<Interface>()
       fail()
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessage(
+      assertThat(e).hasMessageThat().isEqualTo(
         "No JsonAdapter for interface " +
           "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$Interface (with no annotations)"
       )
@@ -633,7 +634,7 @@ class KotlinJsonAdapterTest {
       moshi.adapter<AbstractClass>()
       fail()
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessage(
+      assertThat(e).hasMessageThat().isEqualTo(
         "Cannot serialize abstract class " +
           "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$AbstractClass"
       )
@@ -648,7 +649,7 @@ class KotlinJsonAdapterTest {
       moshi.adapter<InnerClass>()
       fail()
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessage(
+      assertThat(e).hasMessageThat().isEqualTo(
         "Cannot serialize inner class " +
           "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$InnerClass"
       )
@@ -664,7 +665,7 @@ class KotlinJsonAdapterTest {
       moshi.adapter<LocalClass>()
       fail()
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessage(
+      assertThat(e).hasMessageThat().isEqualTo(
         "Cannot serialize local class or object expression " +
           "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$localClassesNotSupported\$LocalClass"
       )
@@ -677,7 +678,7 @@ class KotlinJsonAdapterTest {
       moshi.adapter<ObjectDeclaration>()
       fail()
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessage(
+      assertThat(e).hasMessageThat().isEqualTo(
         "Cannot serialize object declaration " +
           "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$ObjectDeclaration"
       )
@@ -704,7 +705,7 @@ class KotlinJsonAdapterTest {
       } else {
         "anonymous class"
       }
-      assertThat(e).hasMessage(
+      assertThat(e).hasMessageThat().isEqualTo(
         "Cannot serialize $type " +
           "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$anonymousClassesNotSupported" +
           "\$expression$1"
@@ -989,7 +990,7 @@ class KotlinJsonAdapterTest {
       moshi.adapter<PlainKotlinClass>()
       fail("Should not pass here")
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessageContaining("Reflective serialization of Kotlin classes")
+      assertThat(e).hasMessageThat().contains("Reflective serialization of Kotlin classes")
     }
   }
 
@@ -1142,7 +1143,7 @@ class KotlinJsonAdapterTest {
       moshi.adapter<SealedClass>()
       fail()
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessageContaining("Cannot reflectively serialize sealed class")
+      assertThat(e).hasMessageThat().contains("Cannot reflectively serialize sealed class")
     }
   }
 
@@ -1158,7 +1159,7 @@ class KotlinJsonAdapterTest {
     val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
     val adapter = moshi.adapter(type)
 
-    assertThat(adapter.fromJson(json)).isEqualToComparingFieldByFieldRecursively(value)
+    Assertions.assertThat(adapter.fromJson(json)).isEqualToComparingFieldByFieldRecursively(value)
     assertThat(adapter.toJson(value)).isEqualTo(json)
   }
 }

--- a/moshi/build.gradle.kts
+++ b/moshi/build.gradle.kts
@@ -25,5 +25,5 @@ dependencies {
 
   testCompileOnly(Dependencies.jsr305)
   testImplementation(Dependencies.Testing.junit)
-  testImplementation(Dependencies.Testing.assertj)
+  testImplementation(Dependencies.Testing.truth)
 }

--- a/moshi/src/test/java/com/squareup/moshi/AdapterMethodsTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/AdapterMethodsTest.java
@@ -15,8 +15,8 @@
  */
 package com.squareup.moshi;
 
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static com.google.common.truth.Truth.assertThat;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.junit.Assert.fail;
 
 import com.squareup.moshi.MoshiTest.Uppercase;
@@ -268,12 +268,9 @@ public final class AdapterMethodsTest {
       builder.add(new ConflictingsToJsonAdapter());
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected.getMessage())
-          .contains("Conflicting @ToJson methods:");
-      assertThat(expected.getMessage())
-          .contains("pointToJson1");
-      assertThat(expected.getMessage())
-          .contains("pointToJson2");
+      assertThat(expected.getMessage()).contains("Conflicting @ToJson methods:");
+      assertThat(expected.getMessage()).contains("pointToJson1");
+      assertThat(expected.getMessage()).contains("pointToJson2");
     }
   }
 
@@ -296,12 +293,9 @@ public final class AdapterMethodsTest {
       builder.add(new ConflictingsFromJsonAdapter());
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected.getMessage())
-          .contains("Conflicting @FromJson methods:");
-      assertThat(expected.getMessage())
-          .contains("pointFromJson1");
-      assertThat(expected.getMessage())
-          .contains("pointFromJson2");
+      assertThat(expected.getMessage()).contains("Conflicting @FromJson methods:");
+      assertThat(expected.getMessage()).contains("pointFromJson1");
+      assertThat(expected.getMessage()).contains("pointFromJson2");
     }
   }
 
@@ -325,7 +319,8 @@ public final class AdapterMethodsTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Expected at least one @ToJson or @FromJson method on "
                   + "com.squareup.moshi.AdapterMethodsTest$EmptyJsonAdapter");
     }
@@ -341,7 +336,8 @@ public final class AdapterMethodsTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Unexpected signature for void "
                   + "com.squareup.moshi.AdapterMethodsTest$UnexpectedSignatureToJsonAdapter.pointToJson"
                   + "(com.squareup.moshi.AdapterMethodsTest$Point).\n"
@@ -366,7 +362,8 @@ public final class AdapterMethodsTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Unexpected signature for void "
                   + "com.squareup.moshi.AdapterMethodsTest$UnexpectedSignatureFromJsonAdapter.pointFromJson"
                   + "(java.lang.String).\n"
@@ -510,12 +507,14 @@ public final class AdapterMethodsTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "No @FromJson adapter for interface "
                   + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)");
       assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause())
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "No next JsonAdapter for interface "
                   + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)");
     }
@@ -537,12 +536,14 @@ public final class AdapterMethodsTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "No @ToJson adapter for interface "
                   + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)");
       assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause())
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "No next JsonAdapter for interface "
                   + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)");
     }

--- a/moshi/src/test/java/com/squareup/moshi/AdapterMethodsTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/AdapterMethodsTest.java
@@ -16,7 +16,7 @@
 package com.squareup.moshi;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import com.squareup.moshi.MoshiTest.Uppercase;
@@ -269,7 +269,11 @@ public final class AdapterMethodsTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected.getMessage())
-          .contains("Conflicting @ToJson methods:", "pointToJson1", "pointToJson2");
+          .contains("Conflicting @ToJson methods:");
+      assertThat(expected.getMessage())
+          .contains("pointToJson1");
+      assertThat(expected.getMessage())
+          .contains("pointToJson2");
     }
   }
 
@@ -293,7 +297,11 @@ public final class AdapterMethodsTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected.getMessage())
-          .contains("Conflicting @FromJson methods:", "pointFromJson1", "pointFromJson2");
+          .contains("Conflicting @FromJson methods:");
+      assertThat(expected.getMessage())
+          .contains("pointFromJson1");
+      assertThat(expected.getMessage())
+          .contains("pointFromJson2");
     }
   }
 
@@ -317,7 +325,7 @@ public final class AdapterMethodsTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Expected at least one @ToJson or @FromJson method on "
                   + "com.squareup.moshi.AdapterMethodsTest$EmptyJsonAdapter");
     }
@@ -333,7 +341,7 @@ public final class AdapterMethodsTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Unexpected signature for void "
                   + "com.squareup.moshi.AdapterMethodsTest$UnexpectedSignatureToJsonAdapter.pointToJson"
                   + "(com.squareup.moshi.AdapterMethodsTest$Point).\n"
@@ -358,7 +366,7 @@ public final class AdapterMethodsTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Unexpected signature for void "
                   + "com.squareup.moshi.AdapterMethodsTest$UnexpectedSignatureFromJsonAdapter.pointFromJson"
                   + "(java.lang.String).\n"
@@ -502,12 +510,12 @@ public final class AdapterMethodsTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "No @FromJson adapter for interface "
                   + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)");
-      assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause())
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "No next JsonAdapter for interface "
                   + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)");
     }
@@ -529,12 +537,12 @@ public final class AdapterMethodsTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "No @ToJson adapter for interface "
                   + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)");
-      assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause())
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "No next JsonAdapter for interface "
                   + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)");
     }
@@ -585,8 +593,8 @@ public final class AdapterMethodsTest {
     Type b = brokenParameterizedType(1, List.class, String.class);
     Type c = brokenParameterizedType(2, List.class, String.class);
 
-    assertThat(moshi.adapter(b)).isSameAs(moshi.adapter(a));
-    assertThat(moshi.adapter(c)).isSameAs(moshi.adapter(a));
+    assertThat(moshi.adapter(b)).isSameInstanceAs(moshi.adapter(a));
+    assertThat(moshi.adapter(c)).isSameInstanceAs(moshi.adapter(a));
   }
 
   @Test
@@ -721,7 +729,7 @@ public final class AdapterMethodsTest {
       new Moshi.Builder().add(new ToJsonAdapterTakingJsonAdapterParameter());
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageStartingWith("Unexpected signature");
+      assertThat(expected).hasMessageThat().startsWith("Unexpected signature");
     }
   }
 
@@ -738,7 +746,7 @@ public final class AdapterMethodsTest {
       new Moshi.Builder().add(new FromJsonAdapterTakingJsonAdapterParameter());
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageStartingWith("Unexpected signature");
+      assertThat(expected).hasMessageThat().startsWith("Unexpected signature");
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/CircularAdaptersTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/CircularAdaptersTest.java
@@ -16,7 +16,7 @@
 package com.squareup.moshi;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import com.squareup.moshi.internal.Util;
 import java.io.IOException;

--- a/moshi/src/test/java/com/squareup/moshi/CircularAdaptersTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/CircularAdaptersTest.java
@@ -15,8 +15,8 @@
  */
 package com.squareup.moshi;
 
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static com.google.common.truth.Truth.assertThat;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import com.squareup.moshi.internal.Util;
 import java.io.IOException;

--- a/moshi/src/test/java/com/squareup/moshi/ClassJsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/ClassJsonAdapterTest.java
@@ -17,7 +17,7 @@ package com.squareup.moshi;
 
 import static com.squareup.moshi.TestUtil.newReader;
 import static com.squareup.moshi.internal.Util.NO_ANNOTATIONS;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
@@ -168,7 +168,7 @@ public final class ClassJsonAdapterTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Conflicting fields:\n"
                   + "    int com.squareup.moshi.ClassJsonAdapterTest$ExtendsBaseA.a\n"
                   + "    int com.squareup.moshi.ClassJsonAdapterTest$BaseA.a");
@@ -189,7 +189,7 @@ public final class ClassJsonAdapterTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Conflicting fields:\n"
                   + "    java.lang.String com.squareup.moshi.ClassJsonAdapterTest$NameCollision.foo\n"
                   + "    java.lang.String com.squareup.moshi.ClassJsonAdapterTest$NameCollision.bar");
@@ -245,7 +245,7 @@ public final class ClassJsonAdapterTest {
       fromJson(NoArgConstructorThrowsCheckedException.class, "{}");
       fail();
     } catch (RuntimeException expected) {
-      assertThat(expected.getCause()).hasMessage("foo");
+      assertThat(expected.getCause()).hasMessageThat().isEqualTo("foo");
     }
   }
 
@@ -261,7 +261,7 @@ public final class ClassJsonAdapterTest {
       fromJson(NoArgConstructorThrowsUncheckedException.class, "{}");
       fail();
     } catch (UnsupportedOperationException expected) {
-      assertThat(expected).hasMessage("foo");
+      assertThat(expected).hasMessageThat().isEqualTo("foo");
     }
   }
 
@@ -346,7 +346,7 @@ public final class ClassJsonAdapterTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Cannot serialize non-static nested class "
                   + "com.squareup.moshi.ClassJsonAdapterTest$NonStatic");
     }
@@ -365,7 +365,7 @@ public final class ClassJsonAdapterTest {
       ClassJsonAdapter.FACTORY.create(c.getClass(), NO_ANNOTATIONS, moshi);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("Cannot serialize anonymous class " + c.getClass().getName());
+      assertThat(expected).hasMessageThat().isEqualTo("Cannot serialize anonymous class " + c.getClass().getName());
     }
   }
 
@@ -377,7 +377,7 @@ public final class ClassJsonAdapterTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Cannot serialize local class " + "com.squareup.moshi.ClassJsonAdapterTest$1Local");
     }
   }
@@ -398,7 +398,7 @@ public final class ClassJsonAdapterTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Cannot serialize abstract class "
                   + "com.squareup.moshi.ClassJsonAdapterTest$Abstract");
     }
@@ -446,7 +446,7 @@ public final class ClassJsonAdapterTest {
         fromJson(
             ExtendsPlatformClassWithProtectedField.class, "{\"a\":4,\"buf\":[5,6],\"count\":2}");
     assertThat(fromJson.a).isEqualTo(4);
-    assertThat(fromJson.toByteArray()).contains((byte) 5, (byte) 6);
+    assertThat(fromJson.toByteArray()).asList().containsExactly((byte) 5, (byte) 6).inOrder();
   }
 
   static class NamedFields {

--- a/moshi/src/test/java/com/squareup/moshi/ClassJsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/ClassJsonAdapterTest.java
@@ -15,9 +15,9 @@
  */
 package com.squareup.moshi;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.moshi.TestUtil.newReader;
 import static com.squareup.moshi.internal.Util.NO_ANNOTATIONS;
-import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
@@ -168,7 +168,8 @@ public final class ClassJsonAdapterTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Conflicting fields:\n"
                   + "    int com.squareup.moshi.ClassJsonAdapterTest$ExtendsBaseA.a\n"
                   + "    int com.squareup.moshi.ClassJsonAdapterTest$BaseA.a");
@@ -189,7 +190,8 @@ public final class ClassJsonAdapterTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Conflicting fields:\n"
                   + "    java.lang.String com.squareup.moshi.ClassJsonAdapterTest$NameCollision.foo\n"
                   + "    java.lang.String com.squareup.moshi.ClassJsonAdapterTest$NameCollision.bar");
@@ -346,7 +348,8 @@ public final class ClassJsonAdapterTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Cannot serialize non-static nested class "
                   + "com.squareup.moshi.ClassJsonAdapterTest$NonStatic");
     }
@@ -365,7 +368,9 @@ public final class ClassJsonAdapterTest {
       ClassJsonAdapter.FACTORY.create(c.getClass(), NO_ANNOTATIONS, moshi);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Cannot serialize anonymous class " + c.getClass().getName());
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Cannot serialize anonymous class " + c.getClass().getName());
     }
   }
 
@@ -377,7 +382,8 @@ public final class ClassJsonAdapterTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Cannot serialize local class " + "com.squareup.moshi.ClassJsonAdapterTest$1Local");
     }
   }
@@ -398,7 +404,8 @@ public final class ClassJsonAdapterTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Cannot serialize abstract class "
                   + "com.squareup.moshi.ClassJsonAdapterTest$Abstract");
     }

--- a/moshi/src/test/java/com/squareup/moshi/DeferredAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/DeferredAdapterTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.moshi;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;

--- a/moshi/src/test/java/com/squareup/moshi/FlattenTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/FlattenTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.moshi;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -287,7 +287,7 @@ public final class FlattenTest {
       writer.beginFlatten();
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessage("Nesting problem.");
+      assertThat(e).hasMessageThat().isEqualTo("Nesting problem.");
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/JsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonAdapterTest.java
@@ -288,7 +288,8 @@ public final class JsonAdapterTest {
       fail();
     } catch (JsonEncodingException e) {
       assertThat(e)
-          .hasMessageThat().isEqualTo("Use JsonReader.setLenient(true) to accept malformed JSON at path $");
+          .hasMessageThat()
+          .isEqualTo("Use JsonReader.setLenient(true) to accept malformed JSON at path $");
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/JsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonAdapterTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.moshi;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
@@ -125,7 +125,7 @@ public final class JsonAdapterTest {
       toUpperCase.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Unexpected null at $[1]");
+      assertThat(expected).hasMessageThat().isEqualTo("Unexpected null at $[1]");
       assertThat(reader.nextNull()).isNull();
     }
     assertThat(toUpperCase.fromJson(reader)).isEqualTo("C");
@@ -138,7 +138,7 @@ public final class JsonAdapterTest {
       toUpperCase.toJson(writer, null);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Unexpected null at $[1]");
+      assertThat(expected).hasMessageThat().isEqualTo("Unexpected null at $[1]");
       writer.nullValue();
     }
     toUpperCase.toJson(writer, "c");
@@ -168,7 +168,7 @@ public final class JsonAdapterTest {
       alwaysSkip.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Cannot skip unexpected STRING at $[0]");
+      assertThat(expected).hasMessageThat().isEqualTo("Cannot skip unexpected STRING at $[0]");
     }
     assertThat(reader.nextString()).isEqualTo("a");
     reader.endArray();
@@ -219,7 +219,7 @@ public final class JsonAdapterTest {
       adapter.indent(null);
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessage("indent == null");
+      assertThat(expected).hasMessageThat().isEqualTo("indent == null");
     }
   }
 
@@ -265,7 +265,7 @@ public final class JsonAdapterTest {
       brokenAdapter.fromJson("\"value\"");
       fail();
     } catch (JsonDataException e) {
-      assertThat(e).hasMessage("JSON document was not fully consumed.");
+      assertThat(e).hasMessageThat().isEqualTo("JSON document was not fully consumed.");
     }
   }
 
@@ -288,7 +288,7 @@ public final class JsonAdapterTest {
       fail();
     } catch (JsonEncodingException e) {
       assertThat(e)
-          .hasMessage("Use JsonReader.setLenient(true) to accept malformed JSON at path $");
+          .hasMessageThat().isEqualTo("Use JsonReader.setLenient(true) to accept malformed JSON at path $");
     }
   }
 
@@ -329,12 +329,12 @@ public final class JsonAdapterTest {
   @Test
   public void nullSafeDoesntDuplicate() {
     JsonAdapter<Boolean> adapter = new Moshi.Builder().build().adapter(Boolean.class).nullSafe();
-    assertThat(adapter.nullSafe()).isSameAs(adapter);
+    assertThat(adapter.nullSafe()).isSameInstanceAs(adapter);
   }
 
   @Test
   public void nonNullDoesntDuplicate() {
     JsonAdapter<Boolean> adapter = new Moshi.Builder().build().adapter(Boolean.class).nonNull();
-    assertThat(adapter.nonNull()).isSameAs(adapter);
+    assertThat(adapter.nonNull()).isSameInstanceAs(adapter);
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonQualifiersTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonQualifiersTest.java
@@ -15,8 +15,8 @@
  */
 package com.squareup.moshi;
 
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static com.google.common.truth.Truth.assertThat;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -322,7 +322,8 @@ public final class JsonQualifiersTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "interface com.squareup.moshi.JsonQualifiersTest$Millis "
                   + "does not have @JsonQualifier");
     }
@@ -360,19 +361,22 @@ public final class JsonQualifiersTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "No @FromJson adapter for class java.lang.String annotated "
                   + "[@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]"
                   + "\nfor class java.lang.String b"
                   + "\nfor class com.squareup.moshi.JsonQualifiersTest$StringAndFooString");
       assertThat(expected).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(expected.getCause())
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "No @FromJson adapter for class java.lang.String "
                   + "annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
       assertThat(expected.getCause()).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(expected.getCause().getCause())
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "No next JsonAdapter for class "
                   + "java.lang.String annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
     }
@@ -395,19 +399,22 @@ public final class JsonQualifiersTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "No @ToJson adapter for class java.lang.String annotated "
                   + "[@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]"
                   + "\nfor class java.lang.String b"
                   + "\nfor class com.squareup.moshi.JsonQualifiersTest$StringAndFooString");
       assertThat(expected).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(expected.getCause())
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "No @ToJson adapter for class java.lang.String "
                   + "annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
       assertThat(expected.getCause()).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(expected.getCause().getCause())
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "No next JsonAdapter for class "
                   + "java.lang.String annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
     }

--- a/moshi/src/test/java/com/squareup/moshi/JsonQualifiersTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonQualifiersTest.java
@@ -16,7 +16,7 @@
 package com.squareup.moshi;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -322,7 +322,7 @@ public final class JsonQualifiersTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "interface com.squareup.moshi.JsonQualifiersTest$Millis "
                   + "does not have @JsonQualifier");
     }
@@ -334,7 +334,7 @@ public final class JsonQualifiersTest {
       new Moshi.Builder().add(new AnnotationsConflictJsonAdapter());
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageContaining("Conflicting @ToJson methods");
+      assertThat(expected).hasMessageThat().contains("Conflicting @ToJson methods");
     }
   }
 
@@ -360,19 +360,19 @@ public final class JsonQualifiersTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "No @FromJson adapter for class java.lang.String annotated "
                   + "[@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]"
                   + "\nfor class java.lang.String b"
                   + "\nfor class com.squareup.moshi.JsonQualifiersTest$StringAndFooString");
-      assertThat(expected).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(expected).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(expected.getCause())
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "No @FromJson adapter for class java.lang.String "
                   + "annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
-      assertThat(expected.getCause()).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(expected.getCause()).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(expected.getCause().getCause())
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "No next JsonAdapter for class "
                   + "java.lang.String annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
     }
@@ -395,19 +395,19 @@ public final class JsonQualifiersTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "No @ToJson adapter for class java.lang.String annotated "
                   + "[@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]"
                   + "\nfor class java.lang.String b"
                   + "\nfor class com.squareup.moshi.JsonQualifiersTest$StringAndFooString");
-      assertThat(expected).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(expected).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(expected.getCause())
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "No @ToJson adapter for class java.lang.String "
                   + "annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
-      assertThat(expected.getCause()).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(expected.getCause()).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(expected.getCause().getCause())
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "No next JsonAdapter for class "
                   + "java.lang.String annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
     }

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderPathTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderPathTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.moshi;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
@@ -20,7 +20,7 @@ import static com.squareup.moshi.JsonReader.Token.BEGIN_OBJECT;
 import static com.squareup.moshi.JsonReader.Token.NAME;
 import static com.squareup.moshi.JsonReader.Token.STRING;
 import static com.squareup.moshi.TestUtil.repeat;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -193,7 +193,7 @@ public final class JsonReaderTest {
       reader.skipValue();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Cannot skip unexpected NUMBER at $.a");
+      assertThat(expected).hasMessageThat().isEqualTo("Cannot skip unexpected NUMBER at $.a");
     }
     // Confirm that the reader is left in a consistent state after the exception.
     reader.setFailOnUnknown(false);
@@ -212,7 +212,7 @@ public final class JsonReaderTest {
       reader.skipValue();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Cannot skip unexpected NUMBER at $[1]");
+      assertThat(expected).hasMessageThat().isEqualTo("Cannot skip unexpected NUMBER at $[1]");
     }
     // Confirm that the reader is left in a consistent state after the exception.
     reader.setFailOnUnknown(false);
@@ -355,7 +355,7 @@ public final class JsonReaderTest {
       reader.nextDouble();
       fail();
     } catch (JsonEncodingException expected) {
-      assertThat(expected).hasMessageContaining("NaN");
+      assertThat(expected).hasMessageThat().contains("NaN");
     }
   }
 
@@ -1053,7 +1053,7 @@ public final class JsonReaderTest {
       reader.skipName();
       fail();
     } catch (JsonDataException e) {
-      assertThat(e).hasMessage("Cannot skip unexpected NAME at $.b");
+      assertThat(e).hasMessageThat().isEqualTo("Cannot skip unexpected NAME at $.b");
     }
   }
 
@@ -1083,7 +1083,7 @@ public final class JsonReaderTest {
       reader.skipValue();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected a value but was END_OBJECT at path $.");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected a value but was END_OBJECT at path $.");
     }
     reader.endObject();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
@@ -1097,7 +1097,7 @@ public final class JsonReaderTest {
       reader.skipValue();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected a value but was END_ARRAY at path $[0]");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected a value but was END_ARRAY at path $[0]");
     }
     reader.endArray();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
@@ -1111,7 +1111,7 @@ public final class JsonReaderTest {
       reader.skipValue();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected a value but was END_DOCUMENT at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected a value but was END_DOCUMENT at path $");
     }
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
   }
@@ -1329,7 +1329,7 @@ public final class JsonReaderTest {
     String[] options = new String[] {"a", "b", "c"};
     JsonReader.Options abc = JsonReader.Options.of("a", "b", "c");
     List<String> strings = abc.strings();
-    assertThat(options).containsExactlyElementsOf(strings);
+    assertThat(options).asList().containsExactlyElementsIn(strings).inOrder();
     try {
       // Confirm it's unmodifiable and we can't mutate the original underlying array
       strings.add("d");
@@ -1446,11 +1446,15 @@ public final class JsonReaderTest {
       reader.setTag((Class) CharSequence.class, 1);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("Tag value must be of type java.lang.CharSequence");
+      assertThat(expected).hasMessageThat().isEqualTo("Tag value must be of type java.lang.CharSequence");
     }
 
-    assertThat(reader.tag(Integer.class)).isEqualTo(1).isInstanceOf(Integer.class);
-    assertThat(reader.tag(CharSequence.class)).isEqualTo("Foo").isInstanceOf(String.class);
+    Object intTag = reader.tag(Integer.class);
+    assertThat(intTag).isEqualTo(1);
+    assertThat(intTag).isInstanceOf(Integer.class);
+    Object charSequenceTag = reader.tag(CharSequence.class);
+    assertThat(charSequenceTag).isEqualTo("Foo");
+    assertThat(charSequenceTag).isInstanceOf(String.class);
     assertThat(reader.tag(String.class)).isNull();
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
@@ -15,12 +15,12 @@
  */
 package com.squareup.moshi;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.moshi.JsonReader.Token.BEGIN_ARRAY;
 import static com.squareup.moshi.JsonReader.Token.BEGIN_OBJECT;
 import static com.squareup.moshi.JsonReader.Token.NAME;
 import static com.squareup.moshi.JsonReader.Token.STRING;
 import static com.squareup.moshi.TestUtil.repeat;
-import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -1083,7 +1083,9 @@ public final class JsonReaderTest {
       reader.skipValue();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a value but was END_OBJECT at path $.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Expected a value but was END_OBJECT at path $.");
     }
     reader.endObject();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
@@ -1097,7 +1099,9 @@ public final class JsonReaderTest {
       reader.skipValue();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a value but was END_ARRAY at path $[0]");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Expected a value but was END_ARRAY at path $[0]");
     }
     reader.endArray();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
@@ -1111,7 +1115,9 @@ public final class JsonReaderTest {
       reader.skipValue();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a value but was END_DOCUMENT at path $");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Expected a value but was END_DOCUMENT at path $");
     }
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
   }
@@ -1446,7 +1452,9 @@ public final class JsonReaderTest {
       reader.setTag((Class) CharSequence.class, 1);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Tag value must be of type java.lang.CharSequence");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Tag value must be of type java.lang.CharSequence");
     }
 
     Object intTag = reader.tag(Integer.class);

--- a/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.moshi;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.moshi.JsonReader.Token.BEGIN_ARRAY;
 import static com.squareup.moshi.JsonReader.Token.BEGIN_OBJECT;
 import static com.squareup.moshi.JsonReader.Token.BOOLEAN;
@@ -27,7 +28,6 @@ import static com.squareup.moshi.JsonReader.Token.STRING;
 import static com.squareup.moshi.TestUtil.MAX_DEPTH;
 import static com.squareup.moshi.TestUtil.newReader;
 import static com.squareup.moshi.TestUtil.repeat;
-import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -1127,7 +1127,9 @@ public final class JsonUtf8ReaderTest {
       reader.beginArray();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Nesting too deep at $" + repeat("[0]", MAX_DEPTH));
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Nesting too deep at $" + repeat("[0]", MAX_DEPTH));
     }
   }
 
@@ -1149,7 +1151,9 @@ public final class JsonUtf8ReaderTest {
       reader.beginObject();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Nesting too deep at $" + repeat(".a", MAX_DEPTH));
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Nesting too deep at $" + repeat(".a", MAX_DEPTH));
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
@@ -27,7 +27,7 @@ import static com.squareup.moshi.JsonReader.Token.STRING;
 import static com.squareup.moshi.TestUtil.MAX_DEPTH;
 import static com.squareup.moshi.TestUtil.newReader;
 import static com.squareup.moshi.TestUtil.repeat;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -1033,7 +1033,7 @@ public final class JsonUtf8ReaderTest {
       reader1.peek();
       fail();
     } catch (JsonEncodingException expected) {
-      assertThat(expected).hasMessage(message);
+      assertThat(expected).hasMessageThat().isEqualTo(message);
     }
 
     // Also validate that it works when skipping.
@@ -1045,7 +1045,7 @@ public final class JsonUtf8ReaderTest {
       reader2.peek();
       fail();
     } catch (JsonEncodingException expected) {
-      assertThat(expected).hasMessage(message);
+      assertThat(expected).hasMessageThat().isEqualTo(message);
     }
   }
 
@@ -1064,7 +1064,7 @@ public final class JsonUtf8ReaderTest {
       reader.peek();
       fail();
     } catch (JsonEncodingException expected) {
-      assertThat(expected).hasMessage("Expected value at path $[1].a[2]");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected value at path $[1].a[2]");
     }
   }
 
@@ -1079,7 +1079,7 @@ public final class JsonUtf8ReaderTest {
       reader.peek();
       fail();
     } catch (JsonEncodingException expected) {
-      assertThat(expected).hasMessage("Expected value at path $.null[1]");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected value at path $.null[1]");
     }
   }
 
@@ -1127,7 +1127,7 @@ public final class JsonUtf8ReaderTest {
       reader.beginArray();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Nesting too deep at $" + repeat("[0]", MAX_DEPTH));
+      assertThat(expected).hasMessageThat().isEqualTo("Nesting too deep at $" + repeat("[0]", MAX_DEPTH));
     }
   }
 
@@ -1149,7 +1149,7 @@ public final class JsonUtf8ReaderTest {
       reader.beginObject();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Nesting too deep at $" + repeat(".a", MAX_DEPTH));
+      assertThat(expected).hasMessageThat().isEqualTo("Nesting too deep at $" + repeat(".a", MAX_DEPTH));
     }
   }
 
@@ -1340,7 +1340,7 @@ public final class JsonUtf8ReaderTest {
       reader.nextString();
       fail();
     } catch (JsonEncodingException expected) {
-      assertThat(expected).hasMessage("Invalid escape sequence: \\i at path $[0]");
+      assertThat(expected).hasMessageThat().isEqualTo("Invalid escape sequence: \\i at path $[0]");
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/JsonUtf8WriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonUtf8WriterTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.moshi;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.io.IOException;
 import okio.Buffer;

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
@@ -15,11 +15,11 @@
  */
 package com.squareup.moshi;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.moshi.TestUtil.MAX_DEPTH;
 import static com.squareup.moshi.TestUtil.repeat;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -192,7 +192,8 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("Expected END_ARRAY but was s, a java.lang.String, at path $[0]");
+          .hasMessageThat()
+          .isEqualTo("Expected END_ARRAY but was s, a java.lang.String, at path $[0]");
     }
   }
 
@@ -219,7 +220,8 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("Expected a JSON value but was x, a java.lang.StringBuilder, at path $[0]");
+          .hasMessageThat()
+          .isEqualTo("Expected a JSON value but was x, a java.lang.StringBuilder, at path $[0]");
     }
   }
 
@@ -233,7 +235,8 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("Expected NAME but was x, a java.lang.StringBuilder, at path $.");
+          .hasMessageThat()
+          .isEqualTo("Expected NAME but was x, a java.lang.StringBuilder, at path $.");
     }
   }
 
@@ -259,7 +262,8 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]");
+          .hasMessageThat()
+          .isEqualTo("Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]");
     }
   }
 
@@ -272,7 +276,8 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]");
+          .hasMessageThat()
+          .isEqualTo("Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]");
     }
   }
 
@@ -285,7 +290,8 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]");
+          .hasMessageThat()
+          .isEqualTo("Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]");
     }
   }
 
@@ -298,7 +304,8 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("Expected STRING but was s, a java.lang.StringBuilder, at path $[0]");
+          .hasMessageThat()
+          .isEqualTo("Expected STRING but was s, a java.lang.StringBuilder, at path $[0]");
     }
   }
 
@@ -311,7 +318,8 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("Expected BOOLEAN but was true, a java.lang.StringBuilder, at path $[0]");
+          .hasMessageThat()
+          .isEqualTo("Expected BOOLEAN but was true, a java.lang.StringBuilder, at path $[0]");
     }
   }
 
@@ -324,7 +332,8 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("Expected NULL but was null, a java.lang.StringBuilder, at path $[0]");
+          .hasMessageThat()
+          .isEqualTo("Expected NULL but was null, a java.lang.StringBuilder, at path $[0]");
     }
   }
 
@@ -475,7 +484,9 @@ public final class JsonValueReaderTest {
       reader.beginArray();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Nesting too deep at $" + repeat("[0]", MAX_DEPTH + 1));
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Nesting too deep at $" + repeat("[0]", MAX_DEPTH + 1));
     }
   }
 
@@ -494,7 +505,9 @@ public final class JsonValueReaderTest {
       reader.beginObject();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Nesting too deep at $" + repeat(".a", MAX_DEPTH) + ".");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Nesting too deep at $" + repeat(".a", MAX_DEPTH) + ".");
     }
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
@@ -19,7 +19,7 @@ import static com.squareup.moshi.TestUtil.MAX_DEPTH;
 import static com.squareup.moshi.TestUtil.repeat;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -192,7 +192,7 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessage("Expected END_ARRAY but was s, a java.lang.String, at path $[0]");
+          .hasMessageThat().isEqualTo("Expected END_ARRAY but was s, a java.lang.String, at path $[0]");
     }
   }
 
@@ -205,7 +205,7 @@ public final class JsonValueReaderTest {
       reader.endObject();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageStartingWith("Expected END_OBJECT but was a=b");
+      assertThat(expected).hasMessageThat().startsWith("Expected END_OBJECT but was a=b");
     }
   }
 
@@ -219,7 +219,7 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessage("Expected a JSON value but was x, a java.lang.StringBuilder, at path $[0]");
+          .hasMessageThat().isEqualTo("Expected a JSON value but was x, a java.lang.StringBuilder, at path $[0]");
     }
   }
 
@@ -233,7 +233,7 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessage("Expected NAME but was x, a java.lang.StringBuilder, at path $.");
+          .hasMessageThat().isEqualTo("Expected NAME but was x, a java.lang.StringBuilder, at path $.");
     }
   }
 
@@ -246,7 +246,7 @@ public final class JsonValueReaderTest {
       reader.nextName();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected NAME but was null at path $.");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected NAME but was null at path $.");
     }
   }
 
@@ -259,7 +259,7 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessage("Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]");
+          .hasMessageThat().isEqualTo("Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]");
     }
   }
 
@@ -272,7 +272,7 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessage("Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]");
+          .hasMessageThat().isEqualTo("Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]");
     }
   }
 
@@ -285,7 +285,7 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessage("Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]");
+          .hasMessageThat().isEqualTo("Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]");
     }
   }
 
@@ -298,7 +298,7 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessage("Expected STRING but was s, a java.lang.StringBuilder, at path $[0]");
+          .hasMessageThat().isEqualTo("Expected STRING but was s, a java.lang.StringBuilder, at path $[0]");
     }
   }
 
@@ -311,7 +311,7 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessage("Expected BOOLEAN but was true, a java.lang.StringBuilder, at path $[0]");
+          .hasMessageThat().isEqualTo("Expected BOOLEAN but was true, a java.lang.StringBuilder, at path $[0]");
     }
   }
 
@@ -324,7 +324,7 @@ public final class JsonValueReaderTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessage("Expected NULL but was null, a java.lang.StringBuilder, at path $[0]");
+          .hasMessageThat().isEqualTo("Expected NULL but was null, a java.lang.StringBuilder, at path $[0]");
     }
   }
 
@@ -423,7 +423,7 @@ public final class JsonValueReaderTest {
       reader.skipValue();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Cannot skip unexpected STRING at $[0]");
+      assertThat(expected).hasMessageThat().isEqualTo("Cannot skip unexpected STRING at $[0]");
     }
   }
 
@@ -475,7 +475,7 @@ public final class JsonValueReaderTest {
       reader.beginArray();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Nesting too deep at $" + repeat("[0]", MAX_DEPTH + 1));
+      assertThat(expected).hasMessageThat().isEqualTo("Nesting too deep at $" + repeat("[0]", MAX_DEPTH + 1));
     }
   }
 
@@ -494,7 +494,7 @@ public final class JsonValueReaderTest {
       reader.beginObject();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Nesting too deep at $" + repeat(".a", MAX_DEPTH) + ".");
+      assertThat(expected).hasMessageThat().isEqualTo("Nesting too deep at $" + repeat(".a", MAX_DEPTH) + ".");
     }
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueSourceTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueSourceTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.moshi;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.EOFException;

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueWriterTest.java
@@ -15,14 +15,13 @@
  */
 package com.squareup.moshi;
 
-import static java.util.Collections.singletonList;
 import static com.google.common.truth.Truth.assertThat;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -60,11 +59,7 @@ public final class JsonValueWriterTest {
     writer.endObject();
 
     assertThat((Map<String, Object>) writer.root())
-        .containsExactly(
-            "a", "s",
-            "b", 1.5d,
-            "c", true,
-            "d", null);
+        .containsExactly("a", "s", "b", 1.5d, "c", true, "d", null);
   }
 
   @Test
@@ -76,7 +71,9 @@ public final class JsonValueWriterTest {
       writer.name("a").value(2L);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Map key 'a' has multiple values at path $.a: 1 and 2");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Map key 'a' has multiple values at path $.a: 1 and 2");
     }
   }
 
@@ -260,11 +257,7 @@ public final class JsonValueWriterTest {
     writer.value(new Buffer().writeUtf8("null"));
     writer.endObject();
     assertThat((Map<String, Object>) writer.root())
-        .containsExactly(
-            "a", singletonList("value"),
-            "b", 2.0d,
-            "c", 3L,
-            "d", null);
+        .containsExactly("a", singletonList("value"), "b", 2.0d, "c", 3L, "d", null);
   }
 
   /**

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueWriterTest.java
@@ -16,7 +16,7 @@
 package com.squareup.moshi;
 
 import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -61,10 +61,10 @@ public final class JsonValueWriterTest {
 
     assertThat((Map<String, Object>) writer.root())
         .containsExactly(
-            new SimpleEntry<String, Object>("a", "s"),
-            new SimpleEntry<String, Object>("b", 1.5d),
-            new SimpleEntry<String, Object>("c", true),
-            new SimpleEntry<String, Object>("d", null));
+            "a", "s",
+            "b", 1.5d,
+            "c", true,
+            "d", null);
   }
 
   @Test
@@ -76,7 +76,7 @@ public final class JsonValueWriterTest {
       writer.name("a").value(2L);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("Map key 'a' has multiple values at path $.a: 1 and 2");
+      assertThat(expected).hasMessageThat().isEqualTo("Map key 'a' has multiple values at path $.a: 1 and 2");
     }
   }
 
@@ -261,10 +261,10 @@ public final class JsonValueWriterTest {
     writer.endObject();
     assertThat((Map<String, Object>) writer.root())
         .containsExactly(
-            new SimpleEntry<String, Object>("a", singletonList("value")),
-            new SimpleEntry<String, Object>("b", 2.0d),
-            new SimpleEntry<String, Object>("c", 3L),
-            new SimpleEntry<String, Object>("d", null));
+            "a", singletonList("value"),
+            "b", 2.0d,
+            "c", 3L,
+            "d", null);
   }
 
   /**

--- a/moshi/src/test/java/com/squareup/moshi/JsonWriterPathTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonWriterPathTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.moshi;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;

--- a/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
@@ -17,7 +17,7 @@ package com.squareup.moshi;
 
 import static com.squareup.moshi.TestUtil.MAX_DEPTH;
 import static com.squareup.moshi.TestUtil.repeat;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
@@ -482,7 +482,7 @@ public final class JsonWriterTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessage("Nesting too deep at $" + repeat("[0]", MAX_DEPTH) + ": circular reference?");
+          .hasMessageThat().isEqualTo("Nesting too deep at $" + repeat("[0]", MAX_DEPTH) + ": circular reference?");
     }
   }
 
@@ -513,7 +513,7 @@ public final class JsonWriterTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessage("Nesting too deep at $" + repeat(".a", MAX_DEPTH) + ": circular reference?");
+          .hasMessageThat().isEqualTo("Nesting too deep at $" + repeat(".a", MAX_DEPTH) + ": circular reference?");
     }
   }
 
@@ -626,7 +626,7 @@ public final class JsonWriterTest {
       writer.name("a");
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessage("Nesting problem.");
+      assertThat(expected).hasMessageThat().isEqualTo("Nesting problem.");
     }
   }
 
@@ -639,7 +639,7 @@ public final class JsonWriterTest {
       writer.name("b");
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessage("Nesting problem.");
+      assertThat(expected).hasMessageThat().isEqualTo("Nesting problem.");
     }
   }
 
@@ -651,7 +651,7 @@ public final class JsonWriterTest {
       writer.name("a");
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessage("Nesting problem.");
+      assertThat(expected).hasMessageThat().isEqualTo("Nesting problem.");
     }
   }
 
@@ -664,7 +664,7 @@ public final class JsonWriterTest {
       writer.endObject();
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessage("Dangling name: a");
+      assertThat(expected).hasMessageThat().isEqualTo("Dangling name: a");
     }
   }
 
@@ -712,7 +712,7 @@ public final class JsonWriterTest {
       writer.valueSink();
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessage("Sink from valueSink() was not closed");
+      assertThat(e).hasMessageThat().isEqualTo("Sink from valueSink() was not closed");
     }
   }
 
@@ -727,7 +727,7 @@ public final class JsonWriterTest {
       writer.valueSink().writeByte('0').close();
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessage("Nesting problem.");
+      assertThat(e).hasMessageThat().isEqualTo("Nesting problem.");
     }
   }
 
@@ -741,7 +741,7 @@ public final class JsonWriterTest {
       writer.value("b");
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessage("Sink from valueSink() was not closed");
+      assertThat(e).hasMessageThat().isEqualTo("Sink from valueSink() was not closed");
     }
   }
 
@@ -755,7 +755,7 @@ public final class JsonWriterTest {
       writer.name("b");
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessage("Nesting problem.");
+      assertThat(e).hasMessageThat().isEqualTo("Nesting problem.");
     }
   }
 
@@ -771,7 +771,7 @@ public final class JsonWriterTest {
       sink.writeByte('1');
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessage("closed");
+      assertThat(e).hasMessageThat().isEqualTo("closed");
     }
   }
 
@@ -833,14 +833,14 @@ public final class JsonWriterTest {
       factory.newWriter().jsonValue(new Object());
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Unsupported type: java.lang.Object");
+      assertThat(e).hasMessageThat().isEqualTo("Unsupported type: java.lang.Object");
     }
 
     try {
       factory.newWriter().jsonValue('1');
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Unsupported type: java.lang.Character");
+      assertThat(e).hasMessageThat().isEqualTo("Unsupported type: java.lang.Character");
     }
 
     Map<Integer, String> mapWrongKey = new LinkedHashMap<>();
@@ -849,7 +849,7 @@ public final class JsonWriterTest {
       factory.newWriter().jsonValue(mapWrongKey);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Map keys must be of type String: java.lang.Integer");
+      assertThat(e).hasMessageThat().isEqualTo("Map keys must be of type String: java.lang.Integer");
     }
 
     Map<String, String> mapNullKey = new LinkedHashMap<>();
@@ -858,7 +858,7 @@ public final class JsonWriterTest {
       factory.newWriter().jsonValue(mapNullKey);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("Map keys must be non-null");
+      assertThat(e).hasMessageThat().isEqualTo("Map keys must be non-null");
     }
   }
 
@@ -915,7 +915,7 @@ public final class JsonWriterTest {
       writer.nullValue();
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessage("null cannot be used as a map key in JSON at path $.");
+      assertThat(expected).hasMessageThat().isEqualTo("null cannot be used as a map key in JSON at path $.");
     }
   }
 
@@ -928,7 +928,7 @@ public final class JsonWriterTest {
       writer.value(true);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessage("Boolean cannot be used as a map key in JSON at path $.");
+      assertThat(expected).hasMessageThat().isEqualTo("Boolean cannot be used as a map key in JSON at path $.");
     }
   }
 
@@ -941,7 +941,7 @@ public final class JsonWriterTest {
       writer.name("a");
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessage("Nesting problem.");
+      assertThat(expected).hasMessageThat().isEqualTo("Nesting problem.");
     }
   }
 
@@ -967,11 +967,15 @@ public final class JsonWriterTest {
       writer.setTag((Class) CharSequence.class, 1);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("Tag value must be of type java.lang.CharSequence");
+      assertThat(expected).hasMessageThat().isEqualTo("Tag value must be of type java.lang.CharSequence");
     }
 
-    assertThat(writer.tag(Integer.class)).isEqualTo(1).isInstanceOf(Integer.class);
-    assertThat(writer.tag(CharSequence.class)).isEqualTo("Foo").isInstanceOf(String.class);
+    Object intTag = writer.tag(Integer.class);
+    assertThat(intTag).isEqualTo(1);
+    assertThat(intTag).isInstanceOf(Integer.class);
+    Object charSequenceTag = writer.tag(CharSequence.class);
+    assertThat(charSequenceTag).isEqualTo("Foo");
+    assertThat(charSequenceTag).isInstanceOf(String.class);
     assertThat(writer.tag(String.class)).isNull();
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
@@ -15,9 +15,9 @@
  */
 package com.squareup.moshi;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.moshi.TestUtil.MAX_DEPTH;
 import static com.squareup.moshi.TestUtil.repeat;
-import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
@@ -482,7 +482,8 @@ public final class JsonWriterTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("Nesting too deep at $" + repeat("[0]", MAX_DEPTH) + ": circular reference?");
+          .hasMessageThat()
+          .isEqualTo("Nesting too deep at $" + repeat("[0]", MAX_DEPTH) + ": circular reference?");
     }
   }
 
@@ -513,7 +514,8 @@ public final class JsonWriterTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("Nesting too deep at $" + repeat(".a", MAX_DEPTH) + ": circular reference?");
+          .hasMessageThat()
+          .isEqualTo("Nesting too deep at $" + repeat(".a", MAX_DEPTH) + ": circular reference?");
     }
   }
 
@@ -849,7 +851,9 @@ public final class JsonWriterTest {
       factory.newWriter().jsonValue(mapWrongKey);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Map keys must be of type String: java.lang.Integer");
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo("Map keys must be of type String: java.lang.Integer");
     }
 
     Map<String, String> mapNullKey = new LinkedHashMap<>();
@@ -915,7 +919,9 @@ public final class JsonWriterTest {
       writer.nullValue();
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("null cannot be used as a map key in JSON at path $.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("null cannot be used as a map key in JSON at path $.");
     }
   }
 
@@ -928,7 +934,9 @@ public final class JsonWriterTest {
       writer.value(true);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Boolean cannot be used as a map key in JSON at path $.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Boolean cannot be used as a map key in JSON at path $.");
     }
   }
 
@@ -967,7 +975,9 @@ public final class JsonWriterTest {
       writer.setTag((Class) CharSequence.class, 1);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Tag value must be of type java.lang.CharSequence");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Tag value must be of type java.lang.CharSequence");
     }
 
     Object intTag = writer.tag(Integer.class);

--- a/moshi/src/test/java/com/squareup/moshi/LinkedHashTreeMapTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/LinkedHashTreeMapTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.moshi;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import com.squareup.moshi.LinkedHashTreeMap.AvlBuilder;
@@ -279,13 +279,13 @@ public final class LinkedHashTreeMapTest {
     int leftHeight = 0;
     if (node.left != null) {
       assertConsistent(node.left);
-      assertThat(node.left.parent).isSameAs(node);
+      assertThat(node.left.parent).isSameInstanceAs(node);
       leftHeight = node.left.height;
     }
     int rightHeight = 0;
     if (node.right != null) {
       assertConsistent(node.right);
-      assertThat(node.right.parent).isSameAs(node);
+      assertThat(node.right.parent).isSameInstanceAs(node);
       rightHeight = node.right.height;
     }
     if (node.parent != null) {

--- a/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
@@ -17,7 +17,7 @@ package com.squareup.moshi;
 
 import static com.squareup.moshi.TestUtil.newReader;
 import static com.squareup.moshi.internal.Util.NO_ANNOTATIONS;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -47,9 +47,9 @@ public final class MapJsonAdapterTest {
         fromJson(String.class, Boolean.class, "{\"a\":true,\"b\":false,\"c\":null}");
     assertThat(fromJson)
         .containsExactly(
-            new SimpleEntry<String, Boolean>("a", true),
-            new SimpleEntry<String, Boolean>("b", false),
-            new SimpleEntry<String, Boolean>("c", null));
+            "a", true,
+            "b", false,
+            "c", null);
   }
 
   @Test
@@ -61,7 +61,7 @@ public final class MapJsonAdapterTest {
       toJson(String.class, Boolean.class, map);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Map key is null at $.");
+      assertThat(expected).hasMessageThat().isEqualTo("Map key is null at $.");
     }
   }
 
@@ -136,7 +136,7 @@ public final class MapJsonAdapterTest {
       fromJson(String.class, Integer.class, "{\"c\":1,\"c\":2}");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Map key 'c' has multiple values at path $.c: 1 and 2");
+      assertThat(expected).hasMessageThat().isEqualTo("Map key 'c' has multiple values at path $.c: 1 and 2");
     }
   }
 
@@ -155,9 +155,9 @@ public final class MapJsonAdapterTest {
         fromJson(Integer.class, Boolean.class, "{\"5\":true,\"6\":false,\"7\":null}");
     assertThat(fromJson)
         .containsExactly(
-            new SimpleEntry<Integer, Boolean>(5, true),
-            new SimpleEntry<Integer, Boolean>(6, false),
-            new SimpleEntry<Integer, Boolean>(7, null));
+            5, true,
+            6, false,
+            7, null);
   }
 
   @Test
@@ -186,13 +186,13 @@ public final class MapJsonAdapterTest {
       adapter.toJson(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessage("Boolean cannot be used as a map key in JSON at path $.");
+      assertThat(expected).hasMessageThat().isEqualTo("Boolean cannot be used as a map key in JSON at path $.");
     }
     try {
       adapter.toJsonValue(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessage("Boolean cannot be used as a map key in JSON at path $.");
+      assertThat(expected).hasMessageThat().isEqualTo("Boolean cannot be used as a map key in JSON at path $.");
     }
   }
 
@@ -207,13 +207,13 @@ public final class MapJsonAdapterTest {
       adapter.toJson(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessage("Object cannot be used as a map key in JSON at path $.");
+      assertThat(expected).hasMessageThat().isEqualTo("Object cannot be used as a map key in JSON at path $.");
     }
     try {
       adapter.toJsonValue(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessage("Object cannot be " + "used as a map key in JSON at path $.");
+      assertThat(expected).hasMessageThat().isEqualTo("Object cannot be " + "used as a map key in JSON at path $.");
     }
   }
 
@@ -227,13 +227,13 @@ public final class MapJsonAdapterTest {
       adapter.toJson(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessage("Array cannot be used as a map key in JSON at path $.");
+      assertThat(expected).hasMessageThat().isEqualTo("Array cannot be used as a map key in JSON at path $.");
     }
     try {
       adapter.toJsonValue(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessage("Array cannot be used as a map key in JSON at path $.");
+      assertThat(expected).hasMessageThat().isEqualTo("Array cannot be used as a map key in JSON at path $.");
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
@@ -15,14 +15,13 @@
  */
 package com.squareup.moshi;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.moshi.TestUtil.newReader;
 import static com.squareup.moshi.internal.Util.NO_ANNOTATIONS;
-import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -136,7 +135,9 @@ public final class MapJsonAdapterTest {
       fromJson(String.class, Integer.class, "{\"c\":1,\"c\":2}");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Map key 'c' has multiple values at path $.c: 1 and 2");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Map key 'c' has multiple values at path $.c: 1 and 2");
     }
   }
 
@@ -186,13 +187,17 @@ public final class MapJsonAdapterTest {
       adapter.toJson(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Boolean cannot be used as a map key in JSON at path $.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Boolean cannot be used as a map key in JSON at path $.");
     }
     try {
       adapter.toJsonValue(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Boolean cannot be used as a map key in JSON at path $.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Boolean cannot be used as a map key in JSON at path $.");
     }
   }
 
@@ -207,13 +212,17 @@ public final class MapJsonAdapterTest {
       adapter.toJson(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Object cannot be used as a map key in JSON at path $.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Object cannot be used as a map key in JSON at path $.");
     }
     try {
       adapter.toJsonValue(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Object cannot be " + "used as a map key in JSON at path $.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Object cannot be " + "used as a map key in JSON at path $.");
     }
   }
 
@@ -227,13 +236,17 @@ public final class MapJsonAdapterTest {
       adapter.toJson(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Array cannot be used as a map key in JSON at path $.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Array cannot be used as a map key in JSON at path $.");
     }
     try {
       adapter.toJsonValue(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Array cannot be used as a map key in JSON at path $.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Array cannot be used as a map key in JSON at path $.");
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -18,7 +18,7 @@ package com.squareup.moshi;
 import static com.squareup.moshi.TestUtil.newReader;
 import static com.squareup.moshi.TestUtil.repeat;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import android.util.Pair;
@@ -65,7 +65,7 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected a boolean but was NULL at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected a boolean but was NULL at path $");
     }
 
     try {
@@ -110,14 +110,14 @@ public final class MoshiTest {
       adapter.fromJson("256");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected a byte but was 256 at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected a byte but was 256 at path $");
     }
 
     try {
       adapter.fromJson("-129");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected a byte but was -129 at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected a byte but was -129 at path $");
     }
 
     // Nulls not allowed for byte.class
@@ -125,7 +125,7 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected an int but was NULL at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected an int but was NULL at path $");
     }
 
     try {
@@ -208,7 +208,7 @@ public final class MoshiTest {
       adapter.fromJson("'ab'");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected a char but was \"ab\" at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected a char but was \"ab\" at path $");
     }
 
     // Nulls not allowed for char.class
@@ -216,7 +216,7 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected a string but was NULL at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected a string but was NULL at path $");
     }
 
     try {
@@ -239,7 +239,7 @@ public final class MoshiTest {
       adapter.fromJson("'ab'");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected a char but was \"ab\" at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected a char but was \"ab\" at path $");
     }
 
     // Allow nulls for Character.class
@@ -274,7 +274,7 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected a double but was NULL at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected a double but was NULL at path $");
     }
 
     try {
@@ -291,7 +291,7 @@ public final class MoshiTest {
       adapter.fromJson(reader);
       fail();
     } catch (IOException expected) {
-      assertThat(expected).hasMessage("JSON forbids NaN and infinities: Infinity at path $[0]");
+      assertThat(expected).hasMessageThat().isEqualTo("JSON forbids NaN and infinities: Infinity at path $[0]");
     }
 
     reader = newReader("[-1E309]");
@@ -300,7 +300,7 @@ public final class MoshiTest {
       adapter.fromJson(reader);
       fail();
     } catch (IOException expected) {
-      assertThat(expected).hasMessage("JSON forbids NaN and infinities: -Infinity at path $[0]");
+      assertThat(expected).hasMessageThat().isEqualTo("JSON forbids NaN and infinities: -Infinity at path $[0]");
     }
   }
 
@@ -344,7 +344,7 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected a double but was NULL at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected a double but was NULL at path $");
     }
 
     try {
@@ -361,7 +361,7 @@ public final class MoshiTest {
       adapter.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("JSON forbids NaN and infinities: Infinity at path $[1]");
+      assertThat(expected).hasMessageThat().isEqualTo("JSON forbids NaN and infinities: Infinity at path $[1]");
     }
 
     reader = newReader("[-1E39]");
@@ -370,7 +370,7 @@ public final class MoshiTest {
       adapter.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("JSON forbids NaN and infinities: -Infinity at path $[1]");
+      assertThat(expected).hasMessageThat().isEqualTo("JSON forbids NaN and infinities: -Infinity at path $[1]");
     }
   }
 
@@ -404,14 +404,14 @@ public final class MoshiTest {
       adapter.fromJson("2147483648");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected an int but was 2147483648 at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected an int but was 2147483648 at path $");
     }
 
     try {
       adapter.fromJson("-2147483649");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected an int but was -2147483649 at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected an int but was -2147483649 at path $");
     }
 
     // Nulls not allowed for int.class
@@ -419,7 +419,7 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected an int but was NULL at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected an int but was NULL at path $");
     }
 
     try {
@@ -457,14 +457,14 @@ public final class MoshiTest {
       adapter.fromJson("9223372036854775808");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected a long but was 9223372036854775808 at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected a long but was 9223372036854775808 at path $");
     }
 
     try {
       adapter.fromJson("-9223372036854775809");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected a long but was -9223372036854775809 at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected a long but was -9223372036854775809 at path $");
     }
 
     // Nulls not allowed for long.class
@@ -472,7 +472,7 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected a long but was NULL at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected a long but was NULL at path $");
     }
 
     try {
@@ -510,14 +510,14 @@ public final class MoshiTest {
       adapter.fromJson("32768");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected a short but was 32768 at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected a short but was 32768 at path $");
     }
 
     try {
       adapter.fromJson("-32769");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected a short but was -32769 at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected a short but was -32769 at path $");
     }
 
     // Nulls not allowed for short.class
@@ -525,7 +525,7 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected an int but was NULL at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected an int but was NULL at path $");
     }
 
     try {
@@ -573,7 +573,7 @@ public final class MoshiTest {
       moshi.adapter(Types.supertypeOf(String.class));
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("No JsonAdapter for ? super java.lang.String (with no annotations)");
+      assertThat(e).hasMessageThat().isEqualTo("No JsonAdapter for ? super java.lang.String (with no annotations)");
     }
   }
 
@@ -586,43 +586,43 @@ public final class MoshiTest {
       builder.add((null));
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("factory == null");
+      assertThat(expected).hasMessageThat().isEqualTo("factory == null");
     }
     try {
       builder.add((Object) null);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("adapter == null");
+      assertThat(expected).hasMessageThat().isEqualTo("adapter == null");
     }
     try {
       builder.add(null, null);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("type == null");
+      assertThat(expected).hasMessageThat().isEqualTo("type == null");
     }
     try {
       builder.add(type, null);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("jsonAdapter == null");
+      assertThat(expected).hasMessageThat().isEqualTo("jsonAdapter == null");
     }
     try {
       builder.add(null, null, null);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("type == null");
+      assertThat(expected).hasMessageThat().isEqualTo("type == null");
     }
     try {
       builder.add(type, null, null);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("annotation == null");
+      assertThat(expected).hasMessageThat().isEqualTo("annotation == null");
     }
     try {
       builder.add(type, annotation, null);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("jsonAdapter == null");
+      assertThat(expected).hasMessageThat().isEqualTo("jsonAdapter == null");
     }
   }
 
@@ -753,7 +753,7 @@ public final class MoshiTest {
       moshi.adapter(null, Collections.<Annotation>emptySet());
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessage("type == null");
+      assertThat(expected).hasMessageThat().isEqualTo("type == null");
     }
   }
 
@@ -764,13 +764,13 @@ public final class MoshiTest {
       moshi.adapter(String.class, (Class<? extends Annotation>) null);
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessage("annotationType == null");
+      assertThat(expected).hasMessageThat().isEqualTo("annotationType == null");
     }
     try {
       moshi.adapter(String.class, (Set<? extends Annotation>) null);
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessage("annotations == null");
+      assertThat(expected).hasMessageThat().isEqualTo("annotations == null");
     }
   }
 
@@ -790,7 +790,7 @@ public final class MoshiTest {
       moshi.adapter(Object.class);
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessage("annotations == null");
+      assertThat(expected).hasMessageThat().isEqualTo("annotations == null");
     }
   }
 
@@ -855,7 +855,7 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "No JsonAdapter for java.util.List<java.lang.String> "
                   + "annotated [@com.squareup.moshi.MoshiTest$Uppercase()]");
     }
@@ -871,7 +871,7 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "No JsonAdapter for class java.lang.String "
                   + "annotated [@com.squareup.moshi.MoshiTest$Uppercase()]");
     }
@@ -882,7 +882,7 @@ public final class MoshiTest {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<String[]> adapter = moshi.adapter(String[].class);
     assertThat(adapter.toJson(new String[] {"a", "b"})).isEqualTo("[\"a\",\"b\"]");
-    assertThat(adapter.fromJson("[\"a\",\"b\"]")).containsExactly("a", "b");
+    assertThat(adapter.fromJson("[\"a\",\"b\"]")).asList().containsExactly("a", "b").inOrder();
   }
 
   @Test
@@ -890,7 +890,7 @@ public final class MoshiTest {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<int[]> adapter = moshi.adapter(int[].class);
     assertThat(adapter.toJson(new int[] {1, 2})).isEqualTo("[1,2]");
-    assertThat(adapter.fromJson("[2,3]")).containsExactly(2, 3);
+    assertThat(adapter.fromJson("[2,3]")).asList().containsExactly(2, 3).inOrder();
   }
 
   @Test
@@ -917,7 +917,7 @@ public final class MoshiTest {
       adapter.fromJson("\"SPOCK\"");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Expected one of [ROCK, PAPER, scr] but was SPOCK at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Expected one of [ROCK, PAPER, scr] but was SPOCK at path $");
     }
   }
 
@@ -932,7 +932,7 @@ public final class MoshiTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessage("Expected one of [ROCK, PAPER, scr] but was SPOCK at path $[0]");
+          .hasMessageThat().isEqualTo("Expected one of [ROCK, PAPER, scr] but was SPOCK at path $[0]");
     }
     reader.endArray();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
@@ -963,7 +963,7 @@ public final class MoshiTest {
       adapter.fromJson("{\"diameter\":5,\"crust\":\"thick\",\"extraCheese\":true}");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessage("Cannot skip unexpected NAME at $.crust");
+      assertThat(expected).hasMessageThat().isEqualTo("Cannot skip unexpected NAME at $.crust");
     }
   }
 
@@ -975,14 +975,14 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessage("Platform class java.io.File requires explicit JsonAdapter to be registered");
+          .hasMessageThat().isEqualTo("Platform class java.io.File requires explicit JsonAdapter to be registered");
     }
     try {
       moshi.adapter(KeyGenerator.class);
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Platform class javax.crypto.KeyGenerator requires explicit "
                   + "JsonAdapter to be registered");
     }
@@ -991,7 +991,7 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Platform class android.util.Pair requires explicit JsonAdapter to be registered");
     }
   }
@@ -1004,7 +1004,7 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "No JsonAdapter for "
                   + "java.util.ArrayList<java.lang.String>, "
                   + "you should probably use List instead of ArrayList "
@@ -1017,7 +1017,7 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "No JsonAdapter for "
                   + "java.util.HashMap<java.lang.String, java.lang.String>, "
                   + "you should probably use Map instead of HashMap "
@@ -1065,16 +1065,16 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Platform class java.util.UUID requires explicit "
                   + "JsonAdapter to be registered"
                   + "\nfor class java.util.UUID uuid"
                   + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType"
                   + "\nfor java.util.Map<java.lang.String, "
                   + "com.squareup.moshi.MoshiTest$HasPlatformType>");
-      assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause())
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Platform class java.util.UUID " + "requires explicit JsonAdapter to be registered");
     }
   }
@@ -1087,15 +1087,15 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Platform class java.util.UUID requires explicit "
                   + "JsonAdapter to be registered"
                   + "\nfor class java.util.UUID uuid"
                   + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType hasPlatformType"
                   + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType$Wrapper");
-      assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause())
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Platform class java.util.UUID " + "requires explicit JsonAdapter to be registered");
     }
   }
@@ -1108,16 +1108,16 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Platform class java.util.UUID requires explicit "
                   + "JsonAdapter to be registered"
                   + "\nfor class java.util.UUID uuid"
                   + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType"
                   + "\nfor java.util.List<com.squareup.moshi.MoshiTest$HasPlatformType> platformTypes"
                   + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType$ListWrapper");
-      assertThat(e).hasCauseExactlyInstanceOf(IllegalArgumentException.class);
+      assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause())
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "Platform class java.util.UUID " + "requires explicit JsonAdapter to be registered");
     }
   }
@@ -1129,7 +1129,7 @@ public final class MoshiTest {
           .add(Boolean.class, Localized.class, StandardJsonAdapters.BOOLEAN_JSON_ADAPTER);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("Use JsonAdapter.Factory for annotations with elements");
+      assertThat(expected).hasMessageThat().isEqualTo("Use JsonAdapter.Factory for annotations with elements");
     }
   }
 
@@ -1191,7 +1191,7 @@ public final class MoshiTest {
 
     JsonAdapter<MealDeal> adapter1 = moshi.adapter(MealDeal.class);
     JsonAdapter<MealDeal> adapter2 = moshi.adapter(MealDeal.class);
-    assertThat(adapter1).isSameAs(adapter2);
+    assertThat(adapter1).isSameInstanceAs(adapter2);
   }
 
   @Test
@@ -1213,7 +1213,7 @@ public final class MoshiTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessage("Nesting too deep at $" + repeat(".a", 255) + ": circular reference?");
+          .hasMessageThat().isEqualTo("Nesting too deep at $" + repeat(".a", 255) + ": circular reference?");
     }
   }
 
@@ -1227,7 +1227,7 @@ public final class MoshiTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessage("Nesting too deep at $" + repeat("[0]", 255) + ": circular reference?");
+          .hasMessageThat().isEqualTo("Nesting too deep at $" + repeat("[0]", 255) + ": circular reference?");
     }
   }
 
@@ -1243,7 +1243,7 @@ public final class MoshiTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessage("Nesting too deep at $[0]" + repeat(".a[0]", 127) + ": circular reference?");
+          .hasMessageThat().isEqualTo("Nesting too deep at $[0]" + repeat(".a[0]", 127) + ": circular reference?");
     }
   }
 
@@ -1257,7 +1257,7 @@ public final class MoshiTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessage("Map key 'diameter' has multiple values at path $.diameter: 5.0 and 5.0");
+          .hasMessageThat().isEqualTo("Map key 'diameter' has multiple values at path $.diameter: 5.0 and 5.0");
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -15,10 +15,10 @@
  */
 package com.squareup.moshi;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.moshi.TestUtil.newReader;
 import static com.squareup.moshi.TestUtil.repeat;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import android.util.Pair;
@@ -291,7 +291,9 @@ public final class MoshiTest {
       adapter.fromJson(reader);
       fail();
     } catch (IOException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("JSON forbids NaN and infinities: Infinity at path $[0]");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("JSON forbids NaN and infinities: Infinity at path $[0]");
     }
 
     reader = newReader("[-1E309]");
@@ -300,7 +302,9 @@ public final class MoshiTest {
       adapter.fromJson(reader);
       fail();
     } catch (IOException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("JSON forbids NaN and infinities: -Infinity at path $[0]");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("JSON forbids NaN and infinities: -Infinity at path $[0]");
     }
   }
 
@@ -361,7 +365,9 @@ public final class MoshiTest {
       adapter.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("JSON forbids NaN and infinities: Infinity at path $[1]");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("JSON forbids NaN and infinities: Infinity at path $[1]");
     }
 
     reader = newReader("[-1E39]");
@@ -370,7 +376,9 @@ public final class MoshiTest {
       adapter.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("JSON forbids NaN and infinities: -Infinity at path $[1]");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("JSON forbids NaN and infinities: -Infinity at path $[1]");
     }
   }
 
@@ -404,14 +412,18 @@ public final class MoshiTest {
       adapter.fromJson("2147483648");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected an int but was 2147483648 at path $");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Expected an int but was 2147483648 at path $");
     }
 
     try {
       adapter.fromJson("-2147483649");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected an int but was -2147483649 at path $");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Expected an int but was -2147483649 at path $");
     }
 
     // Nulls not allowed for int.class
@@ -457,14 +469,18 @@ public final class MoshiTest {
       adapter.fromJson("9223372036854775808");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a long but was 9223372036854775808 at path $");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Expected a long but was 9223372036854775808 at path $");
     }
 
     try {
       adapter.fromJson("-9223372036854775809");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a long but was -9223372036854775809 at path $");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Expected a long but was -9223372036854775809 at path $");
     }
 
     // Nulls not allowed for long.class
@@ -573,7 +589,9 @@ public final class MoshiTest {
       moshi.adapter(Types.supertypeOf(String.class));
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().isEqualTo("No JsonAdapter for ? super java.lang.String (with no annotations)");
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo("No JsonAdapter for ? super java.lang.String (with no annotations)");
     }
   }
 
@@ -855,7 +873,8 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "No JsonAdapter for java.util.List<java.lang.String> "
                   + "annotated [@com.squareup.moshi.MoshiTest$Uppercase()]");
     }
@@ -871,7 +890,8 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "No JsonAdapter for class java.lang.String "
                   + "annotated [@com.squareup.moshi.MoshiTest$Uppercase()]");
     }
@@ -917,7 +937,9 @@ public final class MoshiTest {
       adapter.fromJson("\"SPOCK\"");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected one of [ROCK, PAPER, scr] but was SPOCK at path $");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Expected one of [ROCK, PAPER, scr] but was SPOCK at path $");
     }
   }
 
@@ -932,7 +954,8 @@ public final class MoshiTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("Expected one of [ROCK, PAPER, scr] but was SPOCK at path $[0]");
+          .hasMessageThat()
+          .isEqualTo("Expected one of [ROCK, PAPER, scr] but was SPOCK at path $[0]");
     }
     reader.endArray();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
@@ -975,14 +998,16 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessageThat().isEqualTo("Platform class java.io.File requires explicit JsonAdapter to be registered");
+          .hasMessageThat()
+          .isEqualTo("Platform class java.io.File requires explicit JsonAdapter to be registered");
     }
     try {
       moshi.adapter(KeyGenerator.class);
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Platform class javax.crypto.KeyGenerator requires explicit "
                   + "JsonAdapter to be registered");
     }
@@ -991,7 +1016,8 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Platform class android.util.Pair requires explicit JsonAdapter to be registered");
     }
   }
@@ -1004,7 +1030,8 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "No JsonAdapter for "
                   + "java.util.ArrayList<java.lang.String>, "
                   + "you should probably use List instead of ArrayList "
@@ -1017,7 +1044,8 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "No JsonAdapter for "
                   + "java.util.HashMap<java.lang.String, java.lang.String>, "
                   + "you should probably use Map instead of HashMap "
@@ -1065,7 +1093,8 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Platform class java.util.UUID requires explicit "
                   + "JsonAdapter to be registered"
                   + "\nfor class java.util.UUID uuid"
@@ -1074,7 +1103,8 @@ public final class MoshiTest {
                   + "com.squareup.moshi.MoshiTest$HasPlatformType>");
       assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause())
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Platform class java.util.UUID " + "requires explicit JsonAdapter to be registered");
     }
   }
@@ -1087,7 +1117,8 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Platform class java.util.UUID requires explicit "
                   + "JsonAdapter to be registered"
                   + "\nfor class java.util.UUID uuid"
@@ -1095,7 +1126,8 @@ public final class MoshiTest {
                   + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType$Wrapper");
       assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause())
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Platform class java.util.UUID " + "requires explicit JsonAdapter to be registered");
     }
   }
@@ -1108,7 +1140,8 @@ public final class MoshiTest {
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Platform class java.util.UUID requires explicit "
                   + "JsonAdapter to be registered"
                   + "\nfor class java.util.UUID uuid"
@@ -1117,7 +1150,8 @@ public final class MoshiTest {
                   + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType$ListWrapper");
       assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause())
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "Platform class java.util.UUID " + "requires explicit JsonAdapter to be registered");
     }
   }
@@ -1129,7 +1163,9 @@ public final class MoshiTest {
           .add(Boolean.class, Localized.class, StandardJsonAdapters.BOOLEAN_JSON_ADAPTER);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Use JsonAdapter.Factory for annotations with elements");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Use JsonAdapter.Factory for annotations with elements");
     }
   }
 
@@ -1213,7 +1249,8 @@ public final class MoshiTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("Nesting too deep at $" + repeat(".a", 255) + ": circular reference?");
+          .hasMessageThat()
+          .isEqualTo("Nesting too deep at $" + repeat(".a", 255) + ": circular reference?");
     }
   }
 
@@ -1227,7 +1264,8 @@ public final class MoshiTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("Nesting too deep at $" + repeat("[0]", 255) + ": circular reference?");
+          .hasMessageThat()
+          .isEqualTo("Nesting too deep at $" + repeat("[0]", 255) + ": circular reference?");
     }
   }
 
@@ -1243,7 +1281,8 @@ public final class MoshiTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("Nesting too deep at $[0]" + repeat(".a[0]", 127) + ": circular reference?");
+          .hasMessageThat()
+          .isEqualTo("Nesting too deep at $[0]" + repeat(".a[0]", 127) + ": circular reference?");
     }
   }
 
@@ -1257,7 +1296,8 @@ public final class MoshiTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("Map key 'diameter' has multiple values at path $.diameter: 5.0 and 5.0");
+          .hasMessageThat()
+          .isEqualTo("Map key 'diameter' has multiple values at path $.diameter: 5.0 and 5.0");
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/ObjectAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/ObjectAdapterTest.java
@@ -17,7 +17,7 @@ package com.squareup.moshi;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -229,7 +229,7 @@ public final class ObjectAdapterTest {
     JsonAdapter<Object> objectAdapter = moshi.adapter(Object.class);
     Map<String, String> value =
         (Map<String, String>) objectAdapter.fromJson("{\"a\":\"b\", \"c\":\"d\"}");
-    assertThat(value).containsExactly(new SimpleEntry<>("A", "B"), new SimpleEntry<>("C", "D"));
+    assertThat(value).containsExactly("A","B", "C", "D");
   }
 
   /**

--- a/moshi/src/test/java/com/squareup/moshi/ObjectAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/ObjectAdapterTest.java
@@ -15,9 +15,9 @@
  */
 package com.squareup.moshi;
 
+import static com.google.common.truth.Truth.assertThat;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static com.google.common.truth.Truth.assertThat;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -26,7 +26,6 @@ import java.math.BigDecimal;
 import java.util.AbstractCollection;
 import java.util.AbstractList;
 import java.util.AbstractMap;
-import java.util.AbstractMap.SimpleEntry;
 import java.util.AbstractSet;
 import java.util.Arrays;
 import java.util.Collection;
@@ -229,7 +228,7 @@ public final class ObjectAdapterTest {
     JsonAdapter<Object> objectAdapter = moshi.adapter(Object.class);
     Map<String, String> value =
         (Map<String, String>) objectAdapter.fromJson("{\"a\":\"b\", \"c\":\"d\"}");
-    assertThat(value).containsExactly("A","B", "C", "D");
+    assertThat(value).containsExactly("A", "B", "C", "D");
   }
 
   /**

--- a/moshi/src/test/java/com/squareup/moshi/PromoteNameToValueTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/PromoteNameToValueTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.moshi;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.List;
@@ -91,8 +91,8 @@ public final class PromoteNameToValueTest {
       reader.nextBoolean();
       fail();
     } catch (JsonDataException e) {
-      assertThat(e.getMessage())
-          .isIn(
+      assertThat(e).hasMessageThat()
+          .isAnyOf(
               "Expected BOOLEAN but was true, a java.lang.String, at path $.true",
               "Expected a boolean but was STRING at path $.true");
     }
@@ -130,8 +130,8 @@ public final class PromoteNameToValueTest {
       reader.nextNull();
       fail();
     } catch (JsonDataException e) {
-      assertThat(e.getMessage())
-          .isIn(
+      assertThat(e).hasMessageThat()
+          .isAnyOf(
               "Expected NULL but was null, a java.lang.String, at path $.null",
               "Expected null but was STRING at path $.null");
     }
@@ -271,7 +271,7 @@ public final class PromoteNameToValueTest {
       writer.value(true);
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessage("Boolean cannot be used as a map key in JSON at path $.");
+      assertThat(e).hasMessageThat().isEqualTo("Boolean cannot be used as a map key in JSON at path $.");
     }
     writer.value("true");
     assertThat(writer.getPath()).isEqualTo("$.true");
@@ -304,7 +304,7 @@ public final class PromoteNameToValueTest {
       writer.nullValue();
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessage("null cannot be used as a map key in JSON at path $.");
+      assertThat(e).hasMessageThat().isEqualTo("null cannot be used as a map key in JSON at path $.");
     }
     writer.value("null");
     assertThat(writer.getPath()).isEqualTo("$.null");
@@ -368,7 +368,7 @@ public final class PromoteNameToValueTest {
       fail();
     } catch (IllegalStateException expected) {
       assertThat(expected)
-          .hasMessage("BufferedSource cannot be used as a map key in JSON at path $.");
+          .hasMessageThat().isEqualTo("BufferedSource cannot be used as a map key in JSON at path $.");
     }
     writer.value("a");
     writer.value("a value");
@@ -386,7 +386,7 @@ public final class PromoteNameToValueTest {
       fail();
     } catch (IllegalStateException expected) {
       assertThat(expected)
-          .hasMessage("BufferedSink cannot be used as a map key in JSON at path $.");
+          .hasMessageThat().isEqualTo("BufferedSink cannot be used as a map key in JSON at path $.");
     }
     writer.value("a");
     writer.value("a value");

--- a/moshi/src/test/java/com/squareup/moshi/PromoteNameToValueTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/PromoteNameToValueTest.java
@@ -91,7 +91,8 @@ public final class PromoteNameToValueTest {
       reader.nextBoolean();
       fail();
     } catch (JsonDataException e) {
-      assertThat(e).hasMessageThat()
+      assertThat(e)
+          .hasMessageThat()
           .isAnyOf(
               "Expected BOOLEAN but was true, a java.lang.String, at path $.true",
               "Expected a boolean but was STRING at path $.true");
@@ -130,7 +131,8 @@ public final class PromoteNameToValueTest {
       reader.nextNull();
       fail();
     } catch (JsonDataException e) {
-      assertThat(e).hasMessageThat()
+      assertThat(e)
+          .hasMessageThat()
           .isAnyOf(
               "Expected NULL but was null, a java.lang.String, at path $.null",
               "Expected null but was STRING at path $.null");
@@ -271,7 +273,9 @@ public final class PromoteNameToValueTest {
       writer.value(true);
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Boolean cannot be used as a map key in JSON at path $.");
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo("Boolean cannot be used as a map key in JSON at path $.");
     }
     writer.value("true");
     assertThat(writer.getPath()).isEqualTo("$.true");
@@ -304,7 +308,9 @@ public final class PromoteNameToValueTest {
       writer.nullValue();
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessageThat().isEqualTo("null cannot be used as a map key in JSON at path $.");
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo("null cannot be used as a map key in JSON at path $.");
     }
     writer.value("null");
     assertThat(writer.getPath()).isEqualTo("$.null");
@@ -368,7 +374,8 @@ public final class PromoteNameToValueTest {
       fail();
     } catch (IllegalStateException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("BufferedSource cannot be used as a map key in JSON at path $.");
+          .hasMessageThat()
+          .isEqualTo("BufferedSource cannot be used as a map key in JSON at path $.");
     }
     writer.value("a");
     writer.value("a value");
@@ -386,7 +393,8 @@ public final class PromoteNameToValueTest {
       fail();
     } catch (IllegalStateException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo("BufferedSink cannot be used as a map key in JSON at path $.");
+          .hasMessageThat()
+          .isEqualTo("BufferedSink cannot be used as a map key in JSON at path $.");
     }
     writer.value("a");
     writer.value("a value");

--- a/moshi/src/test/java/com/squareup/moshi/TypesTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/TypesTest.java
@@ -15,10 +15,10 @@
  */
 package com.squareup.moshi;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.moshi.internal.Util.canonicalize;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import java.lang.annotation.Annotation;
@@ -56,7 +56,8 @@ public final class TypesTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessageThat().isEqualTo(
+          .hasMessageThat()
+          .isEqualTo(
               "interface com.squareup.moshi.TypesTest$TestAnnotation is not a JsonQualifier.");
     }
   }
@@ -115,7 +116,9 @@ public final class TypesTest {
       Types.newParameterizedType(A.class, B.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("unexpected owner type for " + A.class + ": null");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("unexpected owner type for " + A.class + ": null");
     }
   }
 
@@ -125,7 +128,9 @@ public final class TypesTest {
       Types.newParameterizedTypeWithOwner(A.class, List.class, B.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("unexpected owner type for " + List.class + ": " + A.class);
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("unexpected owner type for " + List.class + ": " + A.class);
     }
   }
 
@@ -135,7 +140,9 @@ public final class TypesTest {
       Types.newParameterizedTypeWithOwner(A.class, D.class, B.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("unexpected owner type for " + D.class + ": " + A.class);
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("unexpected owner type for " + D.class + ": " + A.class);
     }
   }
 
@@ -243,19 +250,25 @@ public final class TypesTest {
     Type mapOfStringIntegerType =
         TypesTest.class.getDeclaredField("mapOfStringInteger").getGenericType();
     assertThat(Types.mapKeyAndValueTypes(mapOfStringIntegerType, Map.class))
-        .asList().containsExactly(String.class, Integer.class).inOrder();
+        .asList()
+        .containsExactly(String.class, Integer.class)
+        .inOrder();
   }
 
   @Test
   public void propertiesTypes() throws Exception {
     assertThat(Types.mapKeyAndValueTypes(Properties.class, Properties.class))
-        .asList().containsExactly(String.class, String.class).inOrder();
+        .asList()
+        .containsExactly(String.class, String.class)
+        .inOrder();
   }
 
   @Test
   public void fixedVariablesTypes() throws Exception {
     assertThat(Types.mapKeyAndValueTypes(StringIntegerMap.class, StringIntegerMap.class))
-        .asList().containsExactly(String.class, Integer.class).inOrder();
+        .asList()
+        .containsExactly(String.class, Integer.class)
+        .inOrder();
   }
 
   @SuppressWarnings("GetClassOnAnnotation") // Explicitly checking for proxy implementation.
@@ -285,19 +298,25 @@ public final class TypesTest {
       Types.newParameterizedType(List.class, int.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Unexpected primitive int. Use the boxed type.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Unexpected primitive int. Use the boxed type.");
     }
     try {
       Types.subtypeOf(byte.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Unexpected primitive byte. Use the boxed type.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Unexpected primitive byte. Use the boxed type.");
     }
     try {
       Types.subtypeOf(boolean.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Unexpected primitive boolean. Use the boxed type.");
+      assertThat(expected)
+          .hasMessageThat()
+          .isEqualTo("Unexpected primitive boolean. Use the boxed type.");
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/TypesTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/TypesTest.java
@@ -18,7 +18,7 @@ package com.squareup.moshi;
 import static com.squareup.moshi.internal.Util.canonicalize;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import java.lang.annotation.Annotation;
@@ -56,7 +56,7 @@ public final class TypesTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected)
-          .hasMessage(
+          .hasMessageThat().isEqualTo(
               "interface com.squareup.moshi.TypesTest$TestAnnotation is not a JsonQualifier.");
     }
   }
@@ -98,14 +98,14 @@ public final class TypesTest {
       Types.newParameterizedType(List.class);
       fail("Should have errored due to missing type variable");
     } catch (Exception e) {
-      assertThat(e).hasMessageContaining("Missing type arguments");
+      assertThat(e).hasMessageThat().contains("Missing type arguments");
     }
 
     try {
       Types.newParameterizedTypeWithOwner(TypesTest.class, A.class);
       fail("Should have errored due to missing type variable");
     } catch (Exception e) {
-      assertThat(e).hasMessageContaining("Missing type arguments");
+      assertThat(e).hasMessageThat().contains("Missing type arguments");
     }
   }
 
@@ -115,7 +115,7 @@ public final class TypesTest {
       Types.newParameterizedType(A.class, B.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("unexpected owner type for " + A.class + ": null");
+      assertThat(expected).hasMessageThat().isEqualTo("unexpected owner type for " + A.class + ": null");
     }
   }
 
@@ -125,7 +125,7 @@ public final class TypesTest {
       Types.newParameterizedTypeWithOwner(A.class, List.class, B.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("unexpected owner type for " + List.class + ": " + A.class);
+      assertThat(expected).hasMessageThat().isEqualTo("unexpected owner type for " + List.class + ": " + A.class);
     }
   }
 
@@ -135,7 +135,7 @@ public final class TypesTest {
       Types.newParameterizedTypeWithOwner(A.class, D.class, B.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("unexpected owner type for " + D.class + ": " + A.class);
+      assertThat(expected).hasMessageThat().isEqualTo("unexpected owner type for " + D.class + ": " + A.class);
     }
   }
 
@@ -243,19 +243,19 @@ public final class TypesTest {
     Type mapOfStringIntegerType =
         TypesTest.class.getDeclaredField("mapOfStringInteger").getGenericType();
     assertThat(Types.mapKeyAndValueTypes(mapOfStringIntegerType, Map.class))
-        .containsExactly(String.class, Integer.class);
+        .asList().containsExactly(String.class, Integer.class).inOrder();
   }
 
   @Test
   public void propertiesTypes() throws Exception {
     assertThat(Types.mapKeyAndValueTypes(Properties.class, Properties.class))
-        .containsExactly(String.class, String.class);
+        .asList().containsExactly(String.class, String.class).inOrder();
   }
 
   @Test
   public void fixedVariablesTypes() throws Exception {
     assertThat(Types.mapKeyAndValueTypes(StringIntegerMap.class, StringIntegerMap.class))
-        .containsExactly(String.class, Integer.class);
+        .asList().containsExactly(String.class, Integer.class).inOrder();
   }
 
   @SuppressWarnings("GetClassOnAnnotation") // Explicitly checking for proxy implementation.
@@ -285,19 +285,19 @@ public final class TypesTest {
       Types.newParameterizedType(List.class, int.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("Unexpected primitive int. Use the boxed type.");
+      assertThat(expected).hasMessageThat().isEqualTo("Unexpected primitive int. Use the boxed type.");
     }
     try {
       Types.subtypeOf(byte.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("Unexpected primitive byte. Use the boxed type.");
+      assertThat(expected).hasMessageThat().isEqualTo("Unexpected primitive byte. Use the boxed type.");
     }
     try {
       Types.subtypeOf(boolean.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("Unexpected primitive boolean. Use the boxed type.");
+      assertThat(expected).hasMessageThat().isEqualTo("Unexpected primitive boolean. Use the boxed type.");
     }
   }
 
@@ -346,7 +346,7 @@ public final class TypesTest {
       Types.generatedJsonAdapterName(TestNonJsonClass.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageContaining("Class does not have a JsonClass annotation");
+      assertThat(e).hasMessageThat().contains("Class does not have a JsonClass annotation");
     }
   }
 


### PR DESCRIPTION
Been meaning to do this for awhile. This moves almost all the remaining tests to Truth, with the exception of one KotlinJsonAdapter test that relies on a special field comparison utility in assertj