### PR TITLE
Prepare project for Kotlin migration

### DIFF
--- a/adapters/build.gradle.kts
+++ b/adapters/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  `java-library`
+  kotlin("jvm")
   id("com.vanniktech.maven.publish")
   id("ru.vyarus.animalsniffer")
 }

--- a/adapters/build.gradle.kts
+++ b/adapters/build.gradle.kts
@@ -17,6 +17,7 @@
 plugins {
   `java-library`
   id("com.vanniktech.maven.publish")
+  id("ru.vyarus.animalsniffer")
 }
 
 dependencies {

--- a/adapters/japicmp/build.gradle.kts
+++ b/adapters/japicmp/build.gradle.kts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import me.champeau.gradle.japicmp.JapicmpTask
 
 plugins {

--- a/adapters/japicmp/build.gradle.kts
+++ b/adapters/japicmp/build.gradle.kts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import me.champeau.gradle.japicmp.JapicmpTask
+
+plugins {
+  `java-library`
+  id("me.champeau.gradle.japicmp")
+}
+
+val baseline = configurations.create("baseline")
+val latest = configurations.create("latest")
+
+dependencies {
+  baseline("com.squareup.moshi:moshi-adapters:1.11.0") {
+    isTransitive = false
+    isForce = true
+  }
+  latest(project(":adapters"))
+}
+
+val japicmp = tasks.register<JapicmpTask>("japicmp") {
+  dependsOn("jar")
+  oldClasspath = baseline
+  newClasspath = latest
+  onlyBinaryIncompatibleModified = true
+  failOnModification = true
+  txtOutputFile = file("$buildDir/reports/japi.txt")
+  ignoreMissingClasses = true
+  includeSynthetic = true
+}
+
+tasks.named("check").configure {
+  dependsOn(japicmp)
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@
 import com.diffplug.gradle.spotless.JavaExtension
 import org.gradle.jvm.tasks.Jar
 import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URL
 
 buildscript {
@@ -136,6 +137,15 @@ subprojects {
     dependencies {
       "compileOnly"(Dependencies.AnimalSniffer.annotations)
       "signature"(Dependencies.AnimalSniffer.java7Signature)
+    }
+  }
+
+  pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+    tasks.withType<KotlinCompile>().configureEach {
+      kotlinOptions {
+        @Suppress("SuspiciousCollectionReassignment")
+        freeCompilerArgs += listOf("-progressive")
+      }
     }
   }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,8 @@ import java.net.URL
 buildscript {
   dependencies {
     classpath(kotlin("gradle-plugin", version = Dependencies.Kotlin.version))
+    // https://github.com/melix/japicmp-gradle-plugin/issues/36
+    classpath("com.google.guava:guava:28.2-jre")
   }
 }
 
@@ -29,6 +31,8 @@ plugins {
   id("com.vanniktech.maven.publish") version "0.13.0" apply false
   id("org.jetbrains.dokka") version "1.4.10" apply false
   id("com.diffplug.spotless") version "5.6.0"
+  id("ru.vyarus.animalsniffer") version "1.5.1" apply false
+  id("me.champeau.gradle.japicmp") version "0.2.8" apply false
 }
 
 spotless {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@
 import com.diffplug.gradle.spotless.JavaExtension
 import org.gradle.jvm.tasks.Jar
 import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URL
 
@@ -145,6 +146,12 @@ subprojects {
       kotlinOptions {
         @Suppress("SuspiciousCollectionReassignment")
         freeCompilerArgs += listOf("-progressive")
+      }
+    }
+
+    configure<KotlinProjectExtension> {
+      if (project.name != "examples") {
+        explicitApi()
       }
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -132,6 +132,13 @@ subprojects {
     }
   }
 
+  pluginManager.withPlugin("ru.vyarus.animalsniffer") {
+    dependencies {
+      "compileOnly"(Dependencies.AnimalSniffer.annotations)
+      "signature"(Dependencies.AnimalSniffer.java7Signature)
+    }
+  }
+
   // Configure publishing
   pluginManager.withPlugin("com.vanniktech.maven.publish") {
     // Configure automatic-module-name, but only for published modules

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -41,7 +41,6 @@ object Dependencies {
 
   object Kotlin {
     const val version = "1.4.10"
-    const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib:$version"
     const val metadata = "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0"
   }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -22,6 +22,11 @@ object Dependencies {
   const val okio = "com.squareup.okio:okio:1.17.5"
   const val okio2 = "com.squareup.okio:okio:2.8.0"
 
+  object AnimalSniffer {
+    private const val version = "1.16"
+    const val annotations = "org.codehaus.mojo:animal-sniffer-annotations:$version"
+  }
+
   object AutoService {
     private const val version = "1.0-rc7"
     const val annotations = "com.google.auto.service:auto-service-annotations:$version"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -23,8 +23,8 @@ object Dependencies {
   const val okio2 = "com.squareup.okio:okio:2.8.0"
 
   object AnimalSniffer {
-    private const val version = "1.16"
-    const val annotations = "org.codehaus.mojo:animal-sniffer-annotations:$version"
+    const val annotations = "org.codehaus.mojo:animal-sniffer-annotations:1.16"
+    const val java7Signature = "org.codehaus.mojo.signature:java17:1.0@signature"
   }
 
   object AutoService {

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -14,17 +14,9 @@
  * limitations under the License.
  */
 
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
   kotlin("jvm")
   kotlin("kapt")
-}
-
-tasks.withType<KotlinCompile>().configureEach {
-  kotlinOptions {
-    freeCompilerArgs = listOf("-progressive")
-  }
 }
 
 dependencies {

--- a/kotlin/codegen/build.gradle.kts
+++ b/kotlin/codegen/build.gradle.kts
@@ -25,16 +25,11 @@ plugins {
   id("com.github.johnrengelman.shadow") version "6.0.0"
 }
 
-configure<JavaPluginExtension> {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 tasks.withType<KotlinCompile>().configureEach {
   kotlinOptions {
     jvmTarget = "1.8"
-    freeCompilerArgs = listOf(
-      "-progressive",
+    @Suppress("SuspiciousCollectionReassignment")
+    freeCompilerArgs += listOf(
       "-Xopt-in=com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview"
     )
   }

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessor.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessor.kt
@@ -46,9 +46,9 @@ import javax.tools.Diagnostic
  */
 @AutoService(Processor::class)
 @IncrementalAnnotationProcessor(ISOLATING)
-class JsonClassCodegenProcessor : AbstractProcessor() {
+public class JsonClassCodegenProcessor : AbstractProcessor() {
 
-  companion object {
+  public companion object {
     /**
      * This annotation processing argument can be specified to have a `@Generated` annotation
      * included in the generated code. It is not encouraged unless you need it for static analysis
@@ -58,7 +58,7 @@ class JsonClassCodegenProcessor : AbstractProcessor() {
      *   * `"javax.annotation.processing.Generated"` (JRE 9+)
      *   * `"javax.annotation.Generated"` (JRE <9)
      */
-    const val OPTION_GENERATED = "moshi.generated"
+    public const val OPTION_GENERATED: String = "moshi.generated"
     private val POSSIBLE_GENERATED_NAMES = arrayOf(
       ClassName("javax.annotation.processing", "Generated"),
       ClassName("javax.annotation", "Generated")
@@ -73,11 +73,11 @@ class JsonClassCodegenProcessor : AbstractProcessor() {
   private val annotation = JsonClass::class.java
   private var generatedType: ClassName? = null
 
-  override fun getSupportedAnnotationTypes() = setOf(annotation.canonicalName)
+  override fun getSupportedAnnotationTypes(): Set<String> = setOf(annotation.canonicalName)
 
   override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latest()
 
-  override fun getSupportedOptions() = setOf(OPTION_GENERATED)
+  override fun getSupportedOptions(): Set<String> = setOf(OPTION_GENERATED)
 
   override fun init(processingEnv: ProcessingEnvironment) {
     super.init(processingEnv)

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/TypeRenderer.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/TypeRenderer.kt
@@ -37,7 +37,7 @@ import com.squareup.moshi.Types
  * Rendering is pluggable so that type variables can either be resolved or emitted as other code
  * blocks.
  */
-abstract class TypeRenderer {
+internal abstract class TypeRenderer {
   abstract fun renderTypeVariable(typeVariable: TypeVariableName): CodeBlock
 
   fun render(typeName: TypeName, forceBox: Boolean = false): CodeBlock {

--- a/kotlin/reflect/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
+++ b/kotlin/reflect/src/main/java/com/squareup/moshi/KotlinJsonAdapter.kt
@@ -21,5 +21,5 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
   message = "this moved to avoid a package name conflict in the Java Platform Module System.",
   replaceWith = ReplaceWith("com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory")
 )
-class KotlinJsonAdapterFactory :
+public class KotlinJsonAdapterFactory :
   JsonAdapter.Factory by KotlinJsonAdapterFactory()

--- a/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
+++ b/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
@@ -179,7 +179,7 @@ internal class KotlinJsonAdapter<T>(
   }
 }
 
-class KotlinJsonAdapterFactory : JsonAdapter.Factory {
+public class KotlinJsonAdapterFactory : JsonAdapter.Factory {
   override fun create(type: Type, annotations: MutableSet<out Annotation>, moshi: Moshi):
     JsonAdapter<*>? {
       if (annotations.isNotEmpty()) return null

--- a/kotlin/tests/build.gradle.kts
+++ b/kotlin/tests/build.gradle.kts
@@ -23,7 +23,8 @@ plugins {
 
 tasks.withType<KotlinCompile>().configureEach {
   kotlinOptions {
-    freeCompilerArgs = listOf(
+    @Suppress("SuspiciousCollectionReassignment")
+    freeCompilerArgs += listOf(
       "-Werror",
       "-Xopt-in=kotlin.ExperimentalStdlibApi",
       "-Xinline-classes"

--- a/moshi/build.gradle.kts
+++ b/moshi/build.gradle.kts
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   kotlin("jvm")
   id("com.vanniktech.maven.publish")
+  id("ru.vyarus.animalsniffer")
 }
 
 tasks.withType<KotlinCompile>()

--- a/moshi/build.gradle.kts
+++ b/moshi/build.gradle.kts
@@ -27,18 +27,14 @@ tasks.withType<KotlinCompile>()
   .configureEach {
     kotlinOptions {
       @Suppress("SuspiciousCollectionReassignment") // It's not suspicious
-      freeCompilerArgs += listOf(
-        "-Xopt-in=kotlin.ExperimentalStdlibApi"
-      )
+      freeCompilerArgs += listOf("-Xopt-in=kotlin.ExperimentalStdlibApi")
     }
   }
 
 dependencies {
   compileOnly(Dependencies.jsr305)
-  compileOnly(Dependencies.Kotlin.stdlib)
   api(Dependencies.okio)
 
-  testImplementation(Dependencies.Kotlin.stdlib)
   testCompileOnly(Dependencies.jsr305)
   testImplementation(Dependencies.Testing.junit)
   testImplementation(Dependencies.Testing.truth)

--- a/moshi/gradle.properties
+++ b/moshi/gradle.properties
@@ -18,7 +18,3 @@ POM_NAME=Moshi
 POM_ARTIFACT_ID=moshi
 POM_PACKAGING=jar
 AUTOMATIC_MODULE_NAME=com.squareup.moshi
-
-# Kotlin adds the stdlib dep by default in 1.4.0+, but we want to effectively make it compileOnly
-# for our case to avoid imposing it on consumers.
-kotlin.stdlib.default.dependency=false

--- a/moshi/japicmp/build.gradle.kts
+++ b/moshi/japicmp/build.gradle.kts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import me.champeau.gradle.japicmp.JapicmpTask
 
 plugins {

--- a/moshi/japicmp/build.gradle.kts
+++ b/moshi/japicmp/build.gradle.kts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import me.champeau.gradle.japicmp.JapicmpTask
+
+plugins {
+  `java-library`
+  id("me.champeau.gradle.japicmp")
+}
+
+val baseline = configurations.create("baseline")
+val latest = configurations.create("latest")
+
+dependencies {
+  baseline("com.squareup.moshi:moshi:1.11.0") {
+    isTransitive = false
+    isForce = true
+  }
+  latest(project(":moshi"))
+}
+
+val japicmp = tasks.register<JapicmpTask>("japicmp") {
+  dependsOn("jar")
+  oldClasspath = baseline
+  newClasspath = latest
+  onlyBinaryIncompatibleModified = true
+  failOnModification = true
+  txtOutputFile = file("$buildDir/reports/japi.txt")
+  ignoreMissingClasses = true
+  includeSynthetic = true
+  classExcludes = listOf(
+    "com.squareup.moshi.internal.NonNullJsonAdapter", // Internal.
+    "com.squareup.moshi.internal.NullSafeJsonAdapter", // Internal.
+    "com.squareup.moshi.internal.Util" // Internal.
+  )
+}
+
+tasks.named("check").configure {
+  dependsOn(japicmp)
+}

--- a/moshi/src/main/java/com/squareup/moshi/-MoshiKotlinExtensions.kt
+++ b/moshi/src/main/java/com/squareup/moshi/-MoshiKotlinExtensions.kt
@@ -26,17 +26,17 @@ import kotlin.reflect.typeOf
  *         itself is handled, nested types (such as in generics) are not resolved.
  */
 @ExperimentalStdlibApi
-inline fun <reified T> Moshi.adapter(): JsonAdapter<T> = adapter(typeOf<T>())
+public inline fun <reified T> Moshi.adapter(): JsonAdapter<T> = adapter(typeOf<T>())
 
 @ExperimentalStdlibApi
-inline fun <reified T> Moshi.Builder.addAdapter(adapter: JsonAdapter<T>): Moshi.Builder = add(typeOf<T>().javaType, adapter)
+public inline fun <reified T> Moshi.Builder.addAdapter(adapter: JsonAdapter<T>): Moshi.Builder = add(typeOf<T>().javaType, adapter)
 
 /**
  * @return a [JsonAdapter] for [ktype], creating it if necessary. Note that while nullability of
  *         [ktype] itself is handled, nested types (such as in generics) are not resolved.
  */
 @ExperimentalStdlibApi
-fun <T> Moshi.adapter(ktype: KType): JsonAdapter<T> {
+public fun <T> Moshi.adapter(ktype: KType): JsonAdapter<T> {
   val adapter = adapter<T>(ktype.javaType)
   return if (adapter is NullSafeJsonAdapter || adapter is NonNullJsonAdapter) {
     // TODO CR - Assume that these know what they're doing? Or should we defensively avoid wrapping for matching nullability?

--- a/moshi/src/main/java/com/squareup/moshi/-MoshiKotlinTypesExtensions.kt
+++ b/moshi/src/main/java/com/squareup/moshi/-MoshiKotlinTypesExtensions.kt
@@ -25,13 +25,13 @@ import kotlin.reflect.javaType
 import kotlin.reflect.typeOf
 
 /** Returns the raw [Class] type of this type. */
-val Type.rawType: Class<*> get() = Types.getRawType(this)
+public val Type.rawType: Class<*> get() = Types.getRawType(this)
 
 /**
  * Checks if [this] contains [T]. Returns the subset of [this] without [T], or null if
  * [this] does not contain [T].
  */
-inline fun <reified T : Annotation> Set<Annotation>.nextAnnotations(): Set<Annotation>? = Types.nextAnnotations(this, T::class.java)
+public inline fun <reified T : Annotation> Set<Annotation>.nextAnnotations(): Set<Annotation>? = Types.nextAnnotations(this, T::class.java)
 
 /**
  * Returns a type that represents an unknown type that extends [T]. For example, if
@@ -39,7 +39,7 @@ inline fun <reified T : Annotation> Set<Annotation>.nextAnnotations(): Set<Annot
  * [T] is [Any], this returns `*`, which is shorthand for `out Any?`.
  */
 @ExperimentalStdlibApi
-inline fun <reified T> subtypeOf(): WildcardType {
+public inline fun <reified T> subtypeOf(): WildcardType {
   var type = typeOf<T>().javaType
   if (type is Class<*>) {
     type = Util.boxIfPrimitive(type)
@@ -52,7 +52,7 @@ inline fun <reified T> subtypeOf(): WildcardType {
  * [String], this returns `in String`.
  */
 @ExperimentalStdlibApi
-inline fun <reified T> supertypeOf(): WildcardType {
+public inline fun <reified T> supertypeOf(): WildcardType {
   var type = typeOf<T>().javaType
   if (type is Class<*>) {
     type = Util.boxIfPrimitive(type)
@@ -62,10 +62,10 @@ inline fun <reified T> supertypeOf(): WildcardType {
 
 /** Returns a [GenericArrayType] with [this] as its [GenericArrayType.getGenericComponentType]. */
 @ExperimentalStdlibApi
-fun KType.asArrayType(): GenericArrayType = javaType.asArrayType()
+public fun KType.asArrayType(): GenericArrayType = javaType.asArrayType()
 
 /** Returns a [GenericArrayType] with [this] as its [GenericArrayType.getGenericComponentType]. */
-fun KClass<*>.asArrayType(): GenericArrayType = java.asArrayType()
+public fun KClass<*>.asArrayType(): GenericArrayType = java.asArrayType()
 
 /** Returns a [GenericArrayType] with [this] as its [GenericArrayType.getGenericComponentType]. */
-fun Type.asArrayType(): GenericArrayType = Types.arrayOf(this)
+public fun Type.asArrayType(): GenericArrayType = Types.arrayOf(this)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,7 +23,9 @@ pluginManagement {
 
 rootProject.name = "moshi-root"
 include(":moshi")
+include(":moshi:japicmp")
 include(":adapters")
+include(":adapters:japicmp")
 include(":examples")
 include(":kotlin:reflect")
 include(":kotlin:codegen")


### PR DESCRIPTION
Completes part 1 of #1252 

* Adds japicmp for `moshi` and `adapters` projects
* Adds animalsniffer. We don't target Java 8 yet though like okio/okhttp, but keeping this as a toe-hold
* Prepares `moshi` and `adapters` as full kotlin projects
* Configure all kotlin projects with common `KotlinCompile` task configuration and explicit API mode