### PR TITLE
Improve KotlinJsonAdapter performance by invoke KFunction by "call".

### DIFF
--- a/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
+++ b/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
@@ -94,21 +94,27 @@ internal class KotlinJsonAdapter<T>(
     reader.endObject()
 
     // Confirm all parameters are present, optional, or nullable.
+    var isFullInitialized = true
     for (i in 0 until constructorSize) {
-      if (values[i] === ABSENT_VALUE && !constructor.parameters[i].isOptional) {
-        if (!constructor.parameters[i].type.isMarkedNullable) {
-          throw Util.missingProperty(
+      if (values[i] === ABSENT_VALUE) {
+        when {
+          constructor.parameters[i].isOptional -> isFullInitialized = false
+          constructor.parameters[i].type.isMarkedNullable -> values[i] = null // Replace absent with null.
+          else -> throw Util.missingProperty(
             constructor.parameters[i].name,
             allBindings[i]?.jsonName,
             reader
           )
         }
-        values[i] = null // Replace absent with null.
       }
     }
 
     // Call the constructor using a Map so that absent optionals get defaults.
-    val result = constructor.callBy(IndexedParameterMap(constructor.parameters, values))
+    val result = if (isFullInitialized) {
+      constructor.call(*values)
+    } else {
+      constructor.callBy(IndexedParameterMap(constructor.parameters, values))
+    }
 
     // Set remaining properties.
     for (i in constructorSize until allBindings.size) {

--- a/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
+++ b/kotlin/reflect/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapter.kt
@@ -94,7 +94,7 @@ internal class KotlinJsonAdapter<T>(
     reader.endObject()
 
     // Confirm all parameters are present, optional, or nullable.
-    var isFullInitialized = true
+    var isFullInitialized = allBindings.size == constructorSize
     for (i in 0 until constructorSize) {
       if (values[i] === ABSENT_VALUE) {
         when {


### PR DESCRIPTION
This is my first time posting pull request and I am not good at English, so I'm sorry if there is something wrong with it.

## Overview
If the arguments are fully specified (= don't have to use `Default arguments`), can speed up by making a invoke with `KFunction.call`.

## Description
Currently `KotlinJsonAdapter` does mapping by calling` KFunction.callBy`.
On the other hand, [`KFunction.callBy` has about 1/5 the performance of` KFunction.call`](https://github.com/ProjectMapK/FastKFunction#how-fast), so you can expect speedup by doing `KFunction.call` as much as possible.

I tried to achieve this by making `IndexedParameterMap` manage the initialization state.

## Questions
### Base branch
Which `branch` is the appropriate destination for a `pull request`?
I'm expecting `moshi_1.11.x`, but I'm tentatively specifying `master`.

### Benchmarking
I'm thinking of making a benchmark to show the performance improvement with this method.
If you don't mind, could you point me to a suitable existing benchmark code?

I was thinking of using [this pull request](https://github.com/square/moshi/pull/773) or [this repository](https://github.com/ZacSweers/json-serialization-benchmarking) as a basis.