### PR TITLE
DO NOT MERGE: Add example failing test

### DIFF
--- a/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessorTest.kt
+++ b/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/JsonClassCodegenProcessorTest.kt
@@ -40,6 +40,8 @@ class JsonClassCodegenProcessorTest {
 
   @Test
   fun privateConstructor() {
+    throw RuntimeException("Failing test!")
+
     val result = compile(
       kotlin(
         "source.kt",


### PR DESCRIPTION
This PR adds a failing test, which should cause CI to fail. However, it currently isn't due to #1294 