### PR TITLE
Revert pull-request-target to pull-request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request_target]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This PR reverts #1255 and fixes #1294 by switching back to using `pull_request` instead of `pull_request_target`. This will correctly run tests against the updated code in PRs, instead of against the base branch.