### PR TITLE
Suppress RedundantVisibilityModifier in generated adapters

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -80,7 +80,9 @@ internal class AdapterGenerator(
       "RedundantExplicitType",
       // NameAllocator will just add underscores to differentiate names, which Kotlin doesn't
       // like for stylistic reasons.
-      "LocalVariableName"
+      "LocalVariableName",
+      // KotlinPoet always generates explicit public modifiers for public members.
+      "RedundantVisibilityModifier"
     ).let { suppressions ->
       AnnotationSpec.builder(Suppress::class)
         .addMember(


### PR DESCRIPTION
KotlinPoet always generates explicit `PUBLIC` modifiers for public members now, so this avoid another point of compiler warnings in generated code