### PR TITLE
Reserve simple type names referenced by properties to avoid collisions

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -158,7 +158,15 @@ internal class AdapterGenerator(
     .build()
 
   fun prepare(typeHook: (TypeSpec) -> TypeSpec = { it }): PreparedAdapter {
+    val reservedSimpleNames = mutableSetOf<String>()
     for (property in nonTransientProperties) {
+      // Allocate names for simple property types first to avoid collisions
+      // See https://github.com/square/moshi/issues/1277
+      property.target.type.findRawType()?.simpleName?.let { simpleNameToReserve ->
+        if (reservedSimpleNames.add(simpleNameToReserve)) {
+          nameAllocator.newName(simpleNameToReserve)
+        }
+      }
       property.allocateNames(nameAllocator)
     }
 

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/kotlintypes.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/kotlintypes.kt
@@ -39,10 +39,14 @@ import com.squareup.kotlinpoet.WildcardTypeName
 import com.squareup.kotlinpoet.asTypeName
 
 internal fun TypeName.rawType(): ClassName {
+  return findRawType() ?: throw IllegalArgumentException("Cannot get raw type from $this")
+}
+
+internal fun TypeName.findRawType(): ClassName? {
   return when (this) {
     is ClassName -> this
     is ParameterizedTypeName -> rawType
-    else -> throw IllegalArgumentException("Cannot get raw type from $this")
+    else -> null
   }
 }
 

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -1366,11 +1366,11 @@ class GeneratedAdaptersTest {
 // Regression test for https://github.com/square/moshi/issues/1277
 // Compile-only test
 @JsonClass(generateAdapter = true)
-data class OtherTestModel(val TestModel : TestModel? = null)
+data class OtherTestModel(val TestModel: TestModel? = null)
 @JsonClass(generateAdapter = true)
 data class TestModel(
-  val someVariable : Int,
-  val anotherVariable : String
+  val someVariable: Int,
+  val anotherVariable: String
 )
 
 // Regression test for https://github.com/square/moshi/issues/1022

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -1363,6 +1363,16 @@ class GeneratedAdaptersTest {
   data class MultipleGenerics<A, B, C, D>(val prop: String)
 }
 
+// Regression test for https://github.com/square/moshi/issues/1277
+// Compile-only test
+@JsonClass(generateAdapter = true)
+data class OtherTestModel(val TestModel : TestModel? = null)
+@JsonClass(generateAdapter = true)
+data class TestModel(
+  val someVariable : Int,
+  val anotherVariable : String
+)
+
 // Regression test for https://github.com/square/moshi/issues/1022
 // Compile-only test
 @JsonClass(generateAdapter = true)


### PR DESCRIPTION
Resolves #1277