### PR TITLE
Support generic arrays with defaults in code gen

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -53,7 +53,7 @@ object Dependencies {
 
   object Testing {
     const val assertj = "org.assertj:assertj-core:3.11.1"
-    const val compileTesting = "com.github.tschuchortdev:kotlin-compile-testing:1.3.4"
+    const val compileTesting = "com.github.tschuchortdev:kotlin-compile-testing:1.3.6"
     const val junit = "junit:junit:4.13.1"
     const val truth = "com.google.truth:truth:1.0.1"
   }

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/kotlintypes.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/kotlintypes.kt
@@ -78,7 +78,7 @@ internal fun TypeName.asTypeBlock(): CodeBlock {
           // "generic" array just uses the component's raw type
           // java.lang.reflect.Array.newInstance(<raw-type>, 0).javaClass
           CodeBlock.of(
-            "%T.newInstance(%T::class.java, 0).javaClass",
+            "%T.newInstance(%L, 0).javaClass",
             Array::class.java.asClassName(),
             componentType.rawType.asTypeBlock()
           )

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/kotlintypes.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/kotlintypes.kt
@@ -36,7 +36,9 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.WildcardTypeName
+import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
+import java.lang.reflect.Array
 
 internal fun TypeName.rawType(): ClassName {
   return findRawType() ?: throw IllegalArgumentException("Cannot get raw type from $this")
@@ -71,7 +73,18 @@ internal fun TypeName.asTypeBlock(): CodeBlock {
   when (this) {
     is ParameterizedTypeName -> {
       return if (rawType == ARRAY) {
-        CodeBlock.of("%T::class.java", copy(nullable = false))
+        val componentType = typeArguments[0]
+        if (componentType is ParameterizedTypeName) {
+          // "generic" array just uses the component's raw type
+          // java.lang.reflect.Array.newInstance(<raw-type>, 0).javaClass
+          CodeBlock.of(
+            "%T.newInstance(%T::class.java, 0).javaClass",
+            Array::class.java.asClassName(),
+            componentType.rawType.asTypeBlock()
+          )
+        } else {
+          CodeBlock.of("%T::class.java", copy(nullable = false))
+        }
       } else {
         rawType.asTypeBlock()
       }

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -1455,7 +1455,9 @@ data class SmokeTestType(
   val favoriteNullableArrayValues: Array<String?>,
   val nullableSetListMapArrayNullableIntWithDefault: Set<List<Map<String, Array<IntArray?>>>>? = null,
   val aliasedName: TypeAliasName = "Woah",
-  val genericAlias: GenericTypeAlias = listOf("Woah")
+  val genericAlias: GenericTypeAlias = listOf("Woah"),
+  // Regression test for https://github.com/square/moshi/issues/1272
+  val nestedArray: Array<Map<String, Any>>? = null
 )
 
 // Compile only, regression test for https://github.com/square/moshi/issues/848


### PR DESCRIPTION
This resolves #1272 by creating an array class with the raw type of the generic, which matches how kotlin treats cases like the one in the linked issue. See https://github.com/square/moshi/issues/1272#issuecomment-787703904