### PR TITLE
Improve readability of constructor invocation params

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -549,7 +549,12 @@ internal class AdapterGenerator(
           // We have to use the default primitive for the available type in order for
           // invokeDefaultConstructor to properly invoke it. Just using "null" isn't safe because
           // the transient type may be a primitive type.
-          result.addCode(input.type.rawType().defaultPrimitiveValue())
+          // Inline a little comment for readability indicating which parameter is it's referring to
+          result.addCode(
+            "/*·%L·*/·%L",
+            input.parameter.name,
+            input.type.rawType().defaultPrimitiveValue()
+          )
         } else {
           result.addCode("%N", (input as ParameterProperty).property.localName)
         }
@@ -576,7 +581,7 @@ internal class AdapterGenerator(
 
     if (useDefaultsConstructor) {
       // Add the masks and a null instance for the trailing default marker instance
-      result.addCode(",\n%L,\nnull", maskNames.map { CodeBlock.of("%L", it) }.joinToCode(", "))
+      result.addCode(",\n%L,\n/*·DefaultConstructorMarker·*/·null", maskNames.map { CodeBlock.of("%L", it) }.joinToCode(", "))
     }
 
     result.addCode("\n»)\n")


### PR DESCRIPTION
Since we don't get parameter hints or the ability to do named parameters on these, this makes them a tad more readable when just using default values for unfulfilled parameters

![image](https://user-images.githubusercontent.com/1361086/109471423-ba793a00-7a3e-11eb-836f-72563533d16a.png)
