### PR TITLE
Fix version on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ add the following to your build to enable the annotation processor:
 ```
 
 ```kotlin
-kapt("com.squareup.moshi:moshi-kotlin-codegen:1.11.0")
+kapt("com.squareup.moshi:moshi-kotlin-codegen:1.12.0")
 ```
 
 You must also have the `kotlin-stdlib` dependency on the classpath during compilation in order for
@@ -695,7 +695,7 @@ Download [the latest JAR][dl] or depend via Maven:
 ```
 or Gradle:
 ```kotlin
-implementation("com.squareup.moshi:moshi:1.11.0")
+implementation("com.squareup.moshi:moshi:1.12.0")
 ```
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].


### PR DESCRIPTION
Fixed from `1.11.0` to `1.12.0`.

## Question
Still have 1.11.0 in the following part, should fix it?
https://github.com/square/moshi/blob/1654313feed48ab09e6edfe7ebbef23a57869020/moshi/japicmp/build.gradle.kts#L28
https://github.com/square/moshi/blob/1654313feed48ab09e6edfe7ebbef23a57869020/adapters/japicmp/build.gradle.kts#L28

I'm not good at English, so I'm sorry if there is any rudeness.