### PR TITLE
Update to Kotlin 1.5 (and associated deps)

### DIFF
--- a/adapters/build.gradle.kts
+++ b/adapters/build.gradle.kts
@@ -14,10 +14,18 @@
  * limitations under the License.
  */
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   kotlin("jvm")
   id("com.vanniktech.maven.publish")
   id("ru.vyarus.animalsniffer")
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+  kotlinOptions {
+    jvmTarget = "1.6"
+  }
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,8 +31,8 @@ buildscript {
 
 plugins {
   id("com.vanniktech.maven.publish") version "0.14.2" apply false
-  id("org.jetbrains.dokka") version "1.4.30" apply false
-  id("com.diffplug.spotless") version "5.11.0"
+  id("org.jetbrains.dokka") version "1.4.32" apply false
+  id("com.diffplug.spotless") version "5.12.4"
   id("ru.vyarus.animalsniffer") version "1.5.3" apply false
   id("me.champeau.gradle.japicmp") version "0.2.9" apply false
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -18,7 +18,7 @@ object Dependencies {
 
   const val asm = "org.ow2.asm:asm:7.1"
   const val jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
-  const val ktlintVersion = "0.39.0"
+  const val ktlintVersion = "0.41.0"
   const val okio = "com.squareup.okio:okio:2.10.0"
 
   object AnimalSniffer {
@@ -39,8 +39,8 @@ object Dependencies {
   }
 
   object Kotlin {
-    const val version = "1.4.32"
-    const val metadata = "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.2.0"
+    const val version = "1.5.0"
+    const val metadata = "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.3.0"
   }
 
   object KotlinPoet {
@@ -53,7 +53,7 @@ object Dependencies {
 
   object Testing {
     const val assertj = "org.assertj:assertj-core:3.11.1"
-    const val compileTesting = "com.github.tschuchortdev:kotlin-compile-testing:1.3.6"
+    const val compileTesting = "com.github.tschuchortdev:kotlin-compile-testing:1.4.0"
     const val junit = "junit:junit:4.13.2"
     const val truth = "com.google.truth:truth:1.0.1"
   }

--- a/kotlin/codegen/build.gradle.kts
+++ b/kotlin/codegen/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
   kotlin("jvm")
   kotlin("kapt")
   id("com.vanniktech.maven.publish")
-  id("com.github.johnrengelman.shadow") version "6.0.0"
+  id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 
 tasks.withType<KotlinCompile>().configureEach {
@@ -102,6 +102,6 @@ val shadowJar = tasks.shadowJar.apply {
 }
 
 artifacts {
-  runtime(shadowJar)
+  runtimeOnly(shadowJar)
   archives(shadowJar)
 }

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/DelegateKey.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/DelegateKey.kt
@@ -31,6 +31,7 @@ import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Types
+import java.util.Locale
 
 /** A JsonAdapter that can be used to encode and decode a particular field. */
 internal data class DelegateKey(
@@ -50,7 +51,7 @@ internal data class DelegateKey(
       "At${it.typeName.rawType().simpleName}"
     }
     val adapterName = nameAllocator.newName(
-      "${type.toVariableName().decapitalize()}${qualifierNames}Adapter",
+      "${type.toVariableName().replaceFirstChar { it.lowercase(Locale.US) }}${qualifierNames}Adapter",
       this
     )
 

--- a/kotlin/tests/build.gradle.kts
+++ b/kotlin/tests/build.gradle.kts
@@ -26,8 +26,7 @@ tasks.withType<KotlinCompile>().configureEach {
     @Suppress("SuspiciousCollectionReassignment")
     freeCompilerArgs += listOf(
       "-Werror",
-      "-Xopt-in=kotlin.ExperimentalStdlibApi",
-      "-Xinline-classes"
+      "-Xopt-in=kotlin.ExperimentalStdlibApi"
     )
   }
 }

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -285,9 +285,9 @@ class DualKotlinTest(useReflection: Boolean) {
   }
 
   @Test fun inlineClass() {
-    val adapter = moshi.adapter<InlineClass>()
+    val adapter = moshi.adapter<ValueClass>()
 
-    val inline = InlineClass(5)
+    val inline = ValueClass(5)
 
     val expectedJson =
       """{"i":5}"""
@@ -300,12 +300,12 @@ class DualKotlinTest(useReflection: Boolean) {
   }
 
   @JsonClass(generateAdapter = true)
-  data class InlineConsumer(val inline: InlineClass)
+  data class InlineConsumer(val inline: ValueClass)
 
   @Test fun inlineClassConsumer() {
     val adapter = moshi.adapter<InlineConsumer>()
 
-    val consumer = InlineConsumer(InlineClass(23))
+    val consumer = InlineConsumer(ValueClass(23))
 
     @Language("JSON")
     val expectedJson =
@@ -622,9 +622,10 @@ typealias GenericTypeAlias = List<out GenericClass<in TypeAlias>?>?
 @JsonClass(generateAdapter = true)
 data class GenericClass<T>(val value: T)
 
-// Has to be outside since inline classes are only allowed on top level
+// Has to be outside since value classes are only allowed on top level
+@JvmInline
 @JsonClass(generateAdapter = true)
-inline class InlineClass(val i: Int)
+value class ValueClass(val i: Int)
 
 typealias A = Int
 typealias NullableA = A?

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -1191,11 +1191,14 @@ class GeneratedAdaptersTest {
   annotation class Uppercase(val inFrench: Boolean, val onSundays: Boolean = false)
 
   class UppercaseJsonAdapter {
-    @ToJson fun toJson(@Uppercase(inFrench = true) s: String): String {
-      return s.toUpperCase(Locale.US)
+    @ToJson
+    fun toJson(@Uppercase(inFrench = true) s: String): String {
+      return s.uppercase(Locale.US)
     }
-    @FromJson @Uppercase(inFrench = true) fun fromJson(s: String): String {
-      return s.toLowerCase(Locale.US)
+    @FromJson
+    @Uppercase(inFrench = true)
+    fun fromJson(s: String): String {
+      return s.lowercase(Locale.US)
     }
   }
 

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/annotation/UppercaseInAnnotationPackage.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/annotation/UppercaseInAnnotationPackage.kt
@@ -24,10 +24,13 @@ import java.util.Locale
 annotation class UppercaseInAnnotationPackage
 
 class UppercaseInAnnotationPackageJsonAdapter {
-  @ToJson fun toJson(@UppercaseInAnnotationPackage s: String): String {
-    return s.toUpperCase(Locale.US)
+  @ToJson
+  fun toJson(@UppercaseInAnnotationPackage s: String): String {
+    return s.uppercase(Locale.US)
   }
-  @FromJson @UppercaseInAnnotationPackage fun fromJson(s: String): String {
-    return s.toLowerCase(Locale.US)
+  @FromJson
+  @UppercaseInAnnotationPackage
+  fun fromJson(s: String): String {
+    return s.lowercase(Locale.US)
   }
 }

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -916,11 +916,14 @@ class KotlinJsonAdapterTest {
   annotation class Uppercase
 
   class UppercaseJsonAdapter {
-    @ToJson fun toJson(@Uppercase s: String): String {
-      return s.toUpperCase(Locale.US)
+    @ToJson
+    fun toJson(@Uppercase s: String): String {
+      return s.uppercase(Locale.US)
     }
-    @FromJson @Uppercase fun fromJson(s: String): String {
-      return s.toLowerCase(Locale.US)
+    @FromJson
+    @Uppercase
+    fun fromJson(s: String): String {
+      return s.lowercase(Locale.US)
     }
   }
 

--- a/moshi/build.gradle.kts
+++ b/moshi/build.gradle.kts
@@ -23,11 +23,14 @@ plugins {
 }
 
 tasks.withType<KotlinCompile>()
-  .matching { it.name.contains("test", true) }
   .configureEach {
     kotlinOptions {
-      @Suppress("SuspiciousCollectionReassignment") // It's not suspicious
-      freeCompilerArgs += listOf("-Xopt-in=kotlin.ExperimentalStdlibApi")
+      jvmTarget = "1.6"
+
+      if (name.contains("test", true)) {
+        @Suppress("SuspiciousCollectionReassignment") // It's not suspicious
+        freeCompilerArgs += listOf("-Xopt-in=kotlin.ExperimentalStdlibApi")
+      }
     }
   }
 


### PR DESCRIPTION
This updates to Kotlin 1.5. Note that there's a larger KotlinPoet update in the works too, as there's a few changes in the kotlinx-metadata infrastructure.

This starts some preliminary support of value classes, but only just bumping our test example up.

Other bits:
* Auto-migrated some deprecated APIs
* Kept jvmTarget at "1.6" for backward compatibility, but we could revisit this
* ktlint update has to go with this too as newer version supports the `value class` keyword combo