### PR TITLE
Update README to include enum section in ProGuard/R8 rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,7 +708,7 @@ Moshi contains minimally required rules for its own internals to work without ne
 
 #### Enums
 
-Remember to annotate enums with `@JsonClass(generateAdapter = false)` to prevent them from being removed from your code by R8/ProGuard.
+Annotate enums with `@JsonClass(generateAdapter = false)` to prevent them from being removed/obfuscated from your code by R8/ProGuard.
 
 License
 --------

--- a/README.md
+++ b/README.md
@@ -706,6 +706,10 @@ R8 / ProGuard
 
 Moshi contains minimally required rules for its own internals to work without need for consumers to embed their own. However if you are using reflective serialization and R8 or ProGuard, you must add keep rules in your proguard configuration file for your reflectively serialized classes.
 
+#### Enums
+
+Remember to annotate enums with `@JsonClass(generateAdapter = false)` to prevent them from being removed from your code by R8/ProGuard.
+
 License
 --------
 


### PR DESCRIPTION
I've updated the README to include a section to describe how to work with enums in builds using Proguard/R8.
Cheers!