### PR TITLE
Implement reflective support for Java Records

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         java-version:
-          - 8
-          - 9
-          - 10
-          - 11
-          - 12
-          - 13
-          - 14
-          - 15
+          - 16
+          - 17-ea
 
     steps:
       - name: Checkout
@@ -46,7 +40,7 @@ jobs:
         run: ./gradlew build check --stacktrace
 
       - name: Publish (default branch only)
-        if: github.repository == 'square/moshi' && github.ref == 'refs/heads/master' && matrix.java-version == '8'
+        if: github.repository == 'square/moshi' && github.ref == 'refs/heads/master' && matrix.java-version == '16'
         run: ./gradlew uploadArchives
         env:
           ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         java-version:
           - 16
-          - 17-ea
 
     steps:
       - name: Checkout

--- a/adapters/build.gradle.kts
+++ b/adapters/build.gradle.kts
@@ -17,7 +17,6 @@
 plugins {
   kotlin("jvm")
   id("com.vanniktech.maven.publish")
-  id("ru.vyarus.animalsniffer")
 }
 
 dependencies {

--- a/adapters/build.gradle.kts
+++ b/adapters/build.gradle.kts
@@ -14,18 +14,10 @@
  * limitations under the License.
  */
 
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
   kotlin("jvm")
   id("com.vanniktech.maven.publish")
   id("ru.vyarus.animalsniffer")
-}
-
-tasks.withType<KotlinCompile>().configureEach {
-  kotlinOptions {
-    jvmTarget = "1.6"
-  }
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ spotless {
       "**/TypesTest.java"
     )
     val configureCommonJavaFormat: JavaExtension.() -> Unit = {
-      googleJavaFormat("1.10")
+      googleJavaFormat("1.11")
     }
     java {
       configureCommonJavaFormat()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,7 @@ spotless {
       "**/TypesTest.java"
     )
     val configureCommonJavaFormat: JavaExtension.() -> Unit = {
-      googleJavaFormat("1.7")
+      googleJavaFormat("1.10")
     }
     java {
       configureCommonJavaFormat()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,50 +43,47 @@ spotless {
     indentWithSpaces(2)
     endWithNewline()
   }
-  // GJF not compatible with JDK 15 yet
-  if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
-    val externalJavaFiles = arrayOf(
-      "**/ClassFactory.java",
-      "**/Iso8601Utils.java",
-      "**/JsonReader.java",
-      "**/JsonReaderPathTest.java",
-      "**/JsonReaderTest.java",
-      "**/JsonScope.java",
-      "**/JsonUtf8Reader.java",
-      "**/JsonUtf8ReaderPathTest.java",
-      "**/JsonUtf8ReaderTest.java",
-      "**/JsonUtf8ReaderTest.java",
-      "**/JsonUtf8Writer.java",
-      "**/JsonUtf8WriterTest.java",
-      "**/JsonWriter.java",
-      "**/JsonWriterPathTest.java",
-      "**/JsonWriterTest.java",
-      "**/LinkedHashTreeMap.java",
-      "**/LinkedHashTreeMapTest.java",
-      "**/PolymorphicJsonAdapterFactory.java",
-      "**/RecursiveTypesResolveTest.java",
-      "**/Types.java",
-      "**/TypesTest.java"
+  val externalJavaFiles = arrayOf(
+    "**/ClassFactory.java",
+    "**/Iso8601Utils.java",
+    "**/JsonReader.java",
+    "**/JsonReaderPathTest.java",
+    "**/JsonReaderTest.java",
+    "**/JsonScope.java",
+    "**/JsonUtf8Reader.java",
+    "**/JsonUtf8ReaderPathTest.java",
+    "**/JsonUtf8ReaderTest.java",
+    "**/JsonUtf8ReaderTest.java",
+    "**/JsonUtf8Writer.java",
+    "**/JsonUtf8WriterTest.java",
+    "**/JsonWriter.java",
+    "**/JsonWriterPathTest.java",
+    "**/JsonWriterTest.java",
+    "**/LinkedHashTreeMap.java",
+    "**/LinkedHashTreeMapTest.java",
+    "**/PolymorphicJsonAdapterFactory.java",
+    "**/RecursiveTypesResolveTest.java",
+    "**/Types.java",
+    "**/TypesTest.java"
+  )
+  val configureCommonJavaFormat: JavaExtension.() -> Unit = {
+    googleJavaFormat("1.11.0")
+  }
+  java {
+    configureCommonJavaFormat()
+    target("**/*.java")
+    targetExclude(
+      "**/spotless.java",
+      "**/build/**",
+      *externalJavaFiles
     )
-    val configureCommonJavaFormat: JavaExtension.() -> Unit = {
-      googleJavaFormat("1.11")
-    }
-    java {
-      configureCommonJavaFormat()
-      target("**/*.java")
-      targetExclude(
-        "**/spotless.java",
-        "**/build/**",
-        *externalJavaFiles
-      )
-      licenseHeaderFile("spotless/spotless.java")
-    }
-    format("externalJava", JavaExtension::class.java) {
-      // These don't use our spotless config for header files since we don't want to overwrite the
-      // existing copyright headers.
-      configureCommonJavaFormat()
-      target(*externalJavaFiles)
-    }
+    licenseHeaderFile("spotless/spotless.java")
+  }
+  format("externalJava", JavaExtension::class.java) {
+    // These don't use our spotless config for header files since we don't want to overwrite the
+    // existing copyright headers.
+    configureCommonJavaFormat()
+    target(*externalJavaFiles)
   }
   kotlin {
     ktlint(Dependencies.ktlintVersion).userData(mapOf("indent_size" to "2"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,10 +127,13 @@ subprojects {
   }
 
   // Apply with "java" instead of just "java-library" so kotlin projects get it too
-  pluginManager.withPlugin("java") {
-    configure<JavaPluginExtension> {
-      sourceCompatibility = JavaVersion.VERSION_1_7
-      targetCompatibility = JavaVersion.VERSION_1_7
+  if (project.name != "records-tests") {
+    pluginManager.withPlugin("java") {
+      configure<JavaPluginExtension> {
+        toolchain {
+          languageVersion.set(JavaLanguageVersion.of(8))
+        }
+      }
     }
   }
 
@@ -146,6 +149,7 @@ subprojects {
       kotlinOptions {
         @Suppress("SuspiciousCollectionReassignment")
         freeCompilerArgs += listOf("-progressive")
+        jvmTarget = "1.8"
       }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,6 @@ plugins {
   id("com.vanniktech.maven.publish") version "0.14.2" apply false
   id("org.jetbrains.dokka") version "1.4.32" apply false
   id("com.diffplug.spotless") version "5.12.4"
-  id("ru.vyarus.animalsniffer") version "1.5.3" apply false
   id("me.champeau.gradle.japicmp") version "0.2.9" apply false
 }
 
@@ -134,13 +133,6 @@ subprojects {
           languageVersion.set(JavaLanguageVersion.of(8))
         }
       }
-    }
-  }
-
-  pluginManager.withPlugin("ru.vyarus.animalsniffer") {
-    dependencies {
-      "compileOnly"(Dependencies.AnimalSniffer.annotations)
-      "signature"(Dependencies.AnimalSniffer.java7Signature)
     }
   }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,12 +126,15 @@ subprojects {
   }
 
   // Apply with "java" instead of just "java-library" so kotlin projects get it too
-  if (project.name != "records-tests") {
-    pluginManager.withPlugin("java") {
-      configure<JavaPluginExtension> {
-        toolchain {
-          languageVersion.set(JavaLanguageVersion.of(8))
-        }
+  pluginManager.withPlugin("java") {
+    configure<JavaPluginExtension> {
+      toolchain {
+        languageVersion.set(JavaLanguageVersion.of(16))
+      }
+    }
+    if (project.name != "records-tests") {
+      tasks.withType<JavaCompile>().configureEach {
+        options.release.set(8)
       }
     }
   }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -48,7 +48,7 @@ object Dependencies {
 
   object Testing {
     const val assertj = "org.assertj:assertj-core:3.11.1"
-    const val compileTesting = "com.github.tschuchortdev:kotlin-compile-testing:1.4.0"
+    const val compileTesting = "com.github.tschuchortdev:kotlin-compile-testing:1.4.3"
     const val junit = "junit:junit:4.13.2"
     const val truth = "com.google.truth:truth:1.0.1"
   }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -21,11 +21,6 @@ object Dependencies {
   const val ktlintVersion = "0.41.0"
   const val okio = "com.squareup.okio:okio:2.10.0"
 
-  object AnimalSniffer {
-    const val annotations = "org.codehaus.mojo:animal-sniffer-annotations:1.16"
-    const val java7Signature = "org.codehaus.mojo.signature:java17:1.0@signature"
-  }
-
   object AutoService {
     private const val version = "1.0"
     const val annotations = "com.google.auto.service:auto-service-annotations:$version"

--- a/examples/src/main/java/com/squareup/moshi/recipes/FallbackEnum.java
+++ b/examples/src/main/java/com/squareup/moshi/recipes/FallbackEnum.java
@@ -58,9 +58,8 @@ final class FallbackEnum {
             if (!(annotation instanceof Fallback)) {
               return null;
             }
-            Class<Enum> enumType = (Class<Enum>) rawType;
-            Enum<?> fallback = Enum.valueOf(enumType, ((Fallback) annotation).value());
-            return new FallbackEnumJsonAdapter<>(enumType, fallback);
+            //noinspection rawtypes
+            return new FallbackEnumJsonAdapter<>((Class<? extends Enum>) rawType, ((Fallback) annotation).value());
           }
         };
 
@@ -70,9 +69,9 @@ final class FallbackEnum {
     final JsonReader.Options options;
     final T defaultValue;
 
-    FallbackEnumJsonAdapter(Class<T> enumType, T defaultValue) {
+    FallbackEnumJsonAdapter(Class<T> enumType, String fallbackName) {
       this.enumType = enumType;
-      this.defaultValue = defaultValue;
+      this.defaultValue = Enum.valueOf(enumType, fallbackName);
       try {
         constants = enumType.getEnumConstants();
         nameStrings = new String[constants.length];

--- a/examples/src/main/java/com/squareup/moshi/recipes/FallbackEnum.java
+++ b/examples/src/main/java/com/squareup/moshi/recipes/FallbackEnum.java
@@ -59,7 +59,8 @@ final class FallbackEnum {
               return null;
             }
             //noinspection rawtypes
-            return new FallbackEnumJsonAdapter<>((Class<? extends Enum>) rawType, ((Fallback) annotation).value());
+            return new FallbackEnumJsonAdapter<>(
+                (Class<? extends Enum>) rawType, ((Fallback) annotation).value());
           }
         };
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,6 +29,20 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 \
   --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
+kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8 \
+  --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED  \
+  --add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+
 kapt.include.compile.classpath=false
 
 GROUP=com.squareup.moshi

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,18 +16,18 @@
 
 # For Dokka https://github.com/Kotlin/dokka/issues/1405
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 \
-  --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
-  --add-opens jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
-  --add-opens jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
-  --add-opens jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED  \
-  --add-opens jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
-  --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED \
-  --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+  --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED  \
+  --add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
 kapt.include.compile.classpath=false
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 \
   --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
-kapt.includeCompileClasspath=false
+kapt.include.compile.classpath=false
 
 GROUP=com.squareup.moshi
 VERSION_NAME=1.13.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,6 +29,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 \
   --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
   --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
+# TODO move this to DSL in Kotlin 1.5.30 https://youtrack.jetbrains.com/issue/KT-44266
 kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8 \
   --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
   --add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,19 @@
 #
 
 # For Dokka https://github.com/Kotlin/dokka/issues/1405
-org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 \
+  --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  --add-opens jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-opens jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
+  --add-opens jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED  \
+  --add-opens jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
+  --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED \
+  --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
 kapt.includeCompileClasspath=false
 

--- a/kotlin/codegen/build.gradle.kts
+++ b/kotlin/codegen/build.gradle.kts
@@ -34,6 +34,22 @@ tasks.withType<KotlinCompile>().configureEach {
   }
 }
 
+tasks.withType<Test>().configureEach {
+  // For kapt to work with kotlin-compile-testing
+  jvmArgs(
+    "--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+  )
+}
+
 val shade: Configuration = configurations.maybeCreate("compileShaded")
 configurations.getByName("compileOnly").extendsFrom(shade)
 dependencies {

--- a/kotlin/codegen/build.gradle.kts
+++ b/kotlin/codegen/build.gradle.kts
@@ -27,18 +27,11 @@ plugins {
 
 tasks.withType<KotlinCompile>().configureEach {
   kotlinOptions {
-    jvmTarget = "1.8"
     @Suppress("SuspiciousCollectionReassignment")
     freeCompilerArgs += listOf(
       "-Xopt-in=com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview"
     )
   }
-}
-
-// To make Gradle happy
-java {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 val shade: Configuration = configurations.maybeCreate("compileShaded")

--- a/kotlin/tests/build.gradle.kts
+++ b/kotlin/tests/build.gradle.kts
@@ -21,6 +21,11 @@ plugins {
   kotlin("kapt")
 }
 
+tasks.withType<Test>().configureEach {
+  // ExtendsPlatformClassWithProtectedField tests a case where we set a protected ByteArrayOutputStream.buf field
+  jvmArgs("--add-opens=java.base/java.io=ALL-UNNAMED")
+}
+
 tasks.withType<KotlinCompile>().configureEach {
   kotlinOptions {
     @Suppress("SuspiciousCollectionReassignment")

--- a/moshi/build.gradle.kts
+++ b/moshi/build.gradle.kts
@@ -37,13 +37,12 @@ tasks.named<JavaCompile>("compileJava16Java") {
   options.release.set(16)
 }
 
-// We need to include our actual RecordJsonAdapter from java16 sources and replace the shim
+// Package our actual RecordJsonAdapter from java16 sources in and denote it as an MRJAR
 tasks.named<Jar>("jar") {
   from(java16.output) {
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    into("META-INF/versions/16")
   }
   manifest {
-    // Indicate that this is a multi release jar
     attributes("Multi-Release" to "true")
   }
 }

--- a/moshi/build.gradle.kts
+++ b/moshi/build.gradle.kts
@@ -37,7 +37,7 @@ tasks.named<JavaCompile>("compileJava16Java") {
   options.release.set(16)
 }
 
-// We need to include our actual RecordJsonAdapter from java16 sources and replace the shime
+// We need to include our actual RecordJsonAdapter from java16 sources and replace the shim
 tasks.named<Jar>("jar") {
   from(java16.output) {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE

--- a/moshi/build.gradle.kts
+++ b/moshi/build.gradle.kts
@@ -30,9 +30,11 @@ val java16 by sourceSets.creating {
 }
 
 tasks.named<JavaCompile>("compileJava16Java") {
-  javaCompiler.set(javaToolchains.compilerFor {
-    languageVersion.set(JavaLanguageVersion.of(16))
-  })
+  javaCompiler.set(
+    javaToolchains.compilerFor {
+      languageVersion.set(JavaLanguageVersion.of(16))
+    }
+  )
   options.release.set(16)
 }
 

--- a/moshi/build.gradle.kts
+++ b/moshi/build.gradle.kts
@@ -55,6 +55,11 @@ configurations {
   }
 }
 
+tasks.withType<Test>().configureEach {
+  // ExtendsPlatformClassWithProtectedField tests a case where we set a protected ByteArrayOutputStream.buf field
+  jvmArgs("--add-opens=java.base/java.io=ALL-UNNAMED")
+}
+
 tasks.withType<KotlinCompile>()
   .configureEach {
     kotlinOptions {

--- a/moshi/build.gradle.kts
+++ b/moshi/build.gradle.kts
@@ -42,10 +42,6 @@ tasks.named<Jar>("jar") {
   from(java16.output) {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
   }
-  manifest {
-    // Indicate that this is a multi release jar
-    attributes("Multi-Release" to "true")
-  }
 }
 
 configurations {

--- a/moshi/build.gradle.kts
+++ b/moshi/build.gradle.kts
@@ -22,11 +22,41 @@ plugins {
   id("ru.vyarus.animalsniffer")
 }
 
+val mainSourceSet by sourceSets.named("main")
+val java16 by sourceSets.creating {
+  java {
+    srcDir("src/main/java16")
+  }
+}
+
+tasks.named<JavaCompile>("compileJava16Java") {
+  javaCompiler.set(javaToolchains.compilerFor {
+    languageVersion.set(JavaLanguageVersion.of(16))
+  })
+  options.release.set(16)
+}
+
+tasks.named<Jar>("jar") {
+  from(java16.output) {
+//    into("META-INF/versions/9")
+//    include("module-info.class")
+    duplicatesStrategy = DuplicatesStrategy.WARN
+  }
+  manifest {
+    attributes("Multi-Release" to "true")
+  }
+}
+
+configurations {
+  "java16Implementation" {
+    extendsFrom(api.get())
+    extendsFrom(implementation.get())
+  }
+}
+
 tasks.withType<KotlinCompile>()
   .configureEach {
     kotlinOptions {
-      jvmTarget = "1.6"
-
       if (name.contains("test", true)) {
         @Suppress("SuspiciousCollectionReassignment") // It's not suspicious
         freeCompilerArgs += listOf("-Xopt-in=kotlin.ExperimentalStdlibApi")
@@ -35,6 +65,7 @@ tasks.withType<KotlinCompile>()
   }
 
 dependencies {
+  "java16Implementation"(mainSourceSet.output)
   compileOnly(Dependencies.jsr305)
   api(Dependencies.okio)
 

--- a/moshi/build.gradle.kts
+++ b/moshi/build.gradle.kts
@@ -42,6 +42,10 @@ tasks.named<Jar>("jar") {
   from(java16.output) {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
   }
+  manifest {
+    // Indicate that this is a multi release jar
+    attributes("Multi-Release" to "true")
+  }
 }
 
 configurations {

--- a/moshi/build.gradle.kts
+++ b/moshi/build.gradle.kts
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   kotlin("jvm")
   id("com.vanniktech.maven.publish")
-  id("ru.vyarus.animalsniffer")
 }
 
 val mainSourceSet by sourceSets.named("main")

--- a/moshi/build.gradle.kts
+++ b/moshi/build.gradle.kts
@@ -38,13 +38,13 @@ tasks.named<JavaCompile>("compileJava16Java") {
   options.release.set(16)
 }
 
+// We need to include our actual RecordJsonAdapter from java16 sources and replace the shime
 tasks.named<Jar>("jar") {
   from(java16.output) {
-//    into("META-INF/versions/9")
-//    include("module-info.class")
-    duplicatesStrategy = DuplicatesStrategy.WARN
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
   }
   manifest {
+    // Indicate that this is a multi release jar
     attributes("Multi-Release" to "true")
   }
 }
@@ -67,6 +67,7 @@ tasks.withType<KotlinCompile>()
   }
 
 dependencies {
+  // So the j16 source set can "see" main Moshi sources
   "java16Implementation"(mainSourceSet.output)
   compileOnly(Dependencies.jsr305)
   api(Dependencies.okio)

--- a/moshi/records-tests/build.gradle.kts
+++ b/moshi/records-tests/build.gradle.kts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+  `java-library`
+}
+
+java {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(16))
+  }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+  options.release.set(16)
+}
+
+dependencies {
+  testImplementation(project(":moshi"))
+  testCompileOnly(Dependencies.jsr305)
+  testImplementation(Dependencies.Testing.junit)
+  testImplementation(Dependencies.Testing.truth)
+}

--- a/moshi/records-tests/build.gradle.kts
+++ b/moshi/records-tests/build.gradle.kts
@@ -18,12 +18,6 @@ plugins {
   `java-library`
 }
 
-java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(16))
-  }
-}
-
 tasks.withType<JavaCompile>().configureEach {
   options.release.set(16)
 }

--- a/moshi/records-tests/src/test/java/com/squareup/moshi/RecordsTest.java
+++ b/moshi/records-tests/src/test/java/com/squareup/moshi/RecordsTest.java
@@ -16,9 +16,11 @@
 package com.squareup.moshi;
 
 import java.io.IOException;
+import java.lang.annotation.Retention;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 public final class RecordsTest {
 
@@ -37,8 +39,42 @@ public final class RecordsTest {
       Integer.class));
     assertThat(adapter.fromJson("{\"value\":4}")).isEqualTo(new GenericBoundedRecord<>(4));
   }
+
+  @Test public void qualifiedValues() throws IOException {
+    var adapter = moshi
+      .newBuilder()
+      .add(new ColorAdapter())
+      .build()
+      .adapter(QualifiedValues.class);
+    assertThat(adapter.fromJson("{\"value\":\"#ff0000\"}")).isEqualTo(new QualifiedValues(16711680));
+  }
+
+  @Test public void jsonName() throws IOException {
+    var adapter = moshi.adapter(JsonName.class);
+    assertThat(adapter.fromJson("{\"actualValue\":3}")).isEqualTo(new JsonName(3));
+  }
 }
 
 record GenericBoundedRecord<T extends Number>(T value) {}
 
 record GenericRecord<T>(T value) {}
+
+record QualifiedValues(@HexColor int value) {}
+
+@Retention(RUNTIME)
+@JsonQualifier
+@interface HexColor {
+}
+
+/** Converts strings like #ff0000 to the corresponding color ints. */
+class ColorAdapter {
+  @ToJson String toJson(@HexColor int rgb) {
+    return String.format("#%06x", rgb);
+  }
+
+  @FromJson @HexColor int fromJson(String rgb) {
+    return Integer.parseInt(rgb.substring(1), 16);
+  }
+}
+
+record JsonName(@Json(name = "actualValue") int value) {}

--- a/moshi/records-tests/src/test/java/com/squareup/moshi/RecordsTest.java
+++ b/moshi/records-tests/src/test/java/com/squareup/moshi/RecordsTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.moshi;
+
+import java.io.IOException;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public final class RecordsTest {
+
+  private final Moshi moshi = new Moshi.Builder().build();
+
+  @Test public void genericRecord() throws IOException {
+    var adapter =
+      moshi.<GenericRecord<String>>adapter(Types.newParameterizedType(GenericRecord.class,
+        String.class));
+    assertThat(adapter.fromJson("{\"value\":\"Okay!\"}")).isEqualTo(new GenericRecord<>("Okay!"));
+  }
+
+  @Test public void genericBoundedRecord() throws IOException {
+    var adapter = moshi.<GenericBoundedRecord<Integer>>adapter(Types.newParameterizedType(
+      GenericBoundedRecord.class,
+      Integer.class));
+    assertThat(adapter.fromJson("{\"value\":4}")).isEqualTo(new GenericBoundedRecord<>(4));
+  }
+}
+
+record GenericBoundedRecord<T extends Number>(T value) {}
+
+record GenericRecord<T>(T value) {}

--- a/moshi/records-tests/src/test/java/com/squareup/moshi/RecordsTest.java
+++ b/moshi/records-tests/src/test/java/com/squareup/moshi/RecordsTest.java
@@ -15,41 +15,42 @@
  */
 package com.squareup.moshi;
 
+import static com.google.common.truth.Truth.assertThat;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import java.io.IOException;
 import java.lang.annotation.Retention;
 import org.junit.Test;
-
-import static com.google.common.truth.Truth.assertThat;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 public final class RecordsTest {
 
   private final Moshi moshi = new Moshi.Builder().build();
 
-  @Test public void genericRecord() throws IOException {
+  @Test
+  public void genericRecord() throws IOException {
     var adapter =
-      moshi.<GenericRecord<String>>adapter(Types.newParameterizedType(GenericRecord.class,
-        String.class));
+        moshi.<GenericRecord<String>>adapter(
+            Types.newParameterizedType(GenericRecord.class, String.class));
     assertThat(adapter.fromJson("{\"value\":\"Okay!\"}")).isEqualTo(new GenericRecord<>("Okay!"));
   }
 
-  @Test public void genericBoundedRecord() throws IOException {
-    var adapter = moshi.<GenericBoundedRecord<Integer>>adapter(Types.newParameterizedType(
-      GenericBoundedRecord.class,
-      Integer.class));
+  @Test
+  public void genericBoundedRecord() throws IOException {
+    var adapter =
+        moshi.<GenericBoundedRecord<Integer>>adapter(
+            Types.newParameterizedType(GenericBoundedRecord.class, Integer.class));
     assertThat(adapter.fromJson("{\"value\":4}")).isEqualTo(new GenericBoundedRecord<>(4));
   }
 
-  @Test public void qualifiedValues() throws IOException {
-    var adapter = moshi
-      .newBuilder()
-      .add(new ColorAdapter())
-      .build()
-      .adapter(QualifiedValues.class);
-    assertThat(adapter.fromJson("{\"value\":\"#ff0000\"}")).isEqualTo(new QualifiedValues(16711680));
+  @Test
+  public void qualifiedValues() throws IOException {
+    var adapter = moshi.newBuilder().add(new ColorAdapter()).build().adapter(QualifiedValues.class);
+    assertThat(adapter.fromJson("{\"value\":\"#ff0000\"}"))
+        .isEqualTo(new QualifiedValues(16711680));
   }
 
-  @Test public void jsonName() throws IOException {
+  @Test
+  public void jsonName() throws IOException {
     var adapter = moshi.adapter(JsonName.class);
     assertThat(adapter.fromJson("{\"actualValue\":3}")).isEqualTo(new JsonName(3));
   }
@@ -63,16 +64,18 @@ record QualifiedValues(@HexColor int value) {}
 
 @Retention(RUNTIME)
 @JsonQualifier
-@interface HexColor {
-}
+@interface HexColor {}
 
 /** Converts strings like #ff0000 to the corresponding color ints. */
 class ColorAdapter {
-  @ToJson String toJson(@HexColor int rgb) {
+  @ToJson
+  String toJson(@HexColor int rgb) {
     return String.format("#%06x", rgb);
   }
 
-  @FromJson @HexColor int fromJson(String rgb) {
+  @FromJson
+  @HexColor
+  int fromJson(String rgb) {
     return Integer.parseInt(rgb.substring(1), 16);
   }
 }

--- a/moshi/records-tests/src/test/java/com/squareup/moshi/records/RecordsTest.java
+++ b/moshi/records-tests/src/test/java/com/squareup/moshi/records/RecordsTest.java
@@ -26,11 +26,116 @@ import com.squareup.moshi.ToJson;
 import com.squareup.moshi.Types;
 import java.io.IOException;
 import java.lang.annotation.Retention;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import org.junit.Test;
 
 public final class RecordsTest {
 
   private final Moshi moshi = new Moshi.Builder().build();
+
+  @Test
+  public void smokeTest() throws IOException {
+    var stringAdapter = moshi.adapter(String.class);
+    var adapter =
+        moshi
+            .newBuilder()
+            .add(CharSequence.class, stringAdapter)
+            .add(Types.subtypeOf(CharSequence.class), stringAdapter)
+            .add(Types.supertypeOf(CharSequence.class), stringAdapter)
+            .build()
+            .adapter(SmokeTestType.class);
+    var instance =
+        new SmokeTestType(
+            "John",
+            "Smith",
+            25,
+            List.of("American"),
+            70.5f,
+            null,
+            true,
+            List.of("super wildcards!"),
+            List.of("extend wildcards!"),
+            List.of("unbounded"),
+            List.of("objectList"),
+            new int[] {1, 2, 3},
+            new String[] {"fav", "arrays"},
+            Map.of("italian", "pasta"),
+            Set.of(List.of(Map.of("someKey", new int[] {1}))),
+            new Map[] {Map.of("Hello", "value")});
+    var json = adapter.toJson(instance);
+    var deserialized = adapter.fromJson(json);
+    assertThat(deserialized).isEqualTo(instance);
+  }
+
+  public static record SmokeTestType(
+      @Json(name = "first_name") String firstName,
+      @Json(name = "last_name") String lastName,
+      int age,
+      List<String> nationalities,
+      float weight,
+      Boolean tattoos, // Boxed primitive test
+      boolean hasChildren,
+      List<? super CharSequence> superWildcard,
+      List<? extends CharSequence> extendsWildcard,
+      List<?> unboundedWildcard,
+      List<Object> objectList,
+      int[] favoriteThreeNumbers,
+      String[] favoriteArrayValues,
+      Map<String, String> foodPreferences,
+      Set<List<Map<String, int[]>>> setListMapArrayInt,
+      // Regression test for https://github.com/square/moshi/issues/1272
+      Map<String, Object>[] nestedArray) {
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      SmokeTestType that = (SmokeTestType) o;
+      return age == that.age
+          && Float.compare(that.weight, weight) == 0
+          && hasChildren == that.hasChildren
+          && firstName.equals(that.firstName)
+          && lastName.equals(that.lastName)
+          && nationalities.equals(that.nationalities)
+          && Objects.equals(tattoos, that.tattoos)
+          && superWildcard.equals(that.superWildcard)
+          && extendsWildcard.equals(that.extendsWildcard)
+          && unboundedWildcard.equals(that.unboundedWildcard)
+          && objectList.equals(that.objectList)
+          && Arrays.equals(favoriteThreeNumbers, that.favoriteThreeNumbers)
+          && Arrays.equals(favoriteArrayValues, that.favoriteArrayValues)
+          && foodPreferences.equals(that.foodPreferences)
+          // && setListMapArrayInt.equals(that.setListMapArrayInt) // Nested array equality doesn't
+          // carry over
+          && Arrays.equals(nestedArray, that.nestedArray);
+    }
+
+    @Override
+    public int hashCode() {
+      int result =
+          Objects.hash(
+              firstName,
+              lastName,
+              age,
+              nationalities,
+              weight,
+              tattoos,
+              hasChildren,
+              superWildcard,
+              extendsWildcard,
+              unboundedWildcard,
+              objectList,
+              foodPreferences,
+              setListMapArrayInt);
+      result = 31 * result + Arrays.hashCode(favoriteThreeNumbers);
+      result = 31 * result + Arrays.hashCode(favoriteArrayValues);
+      result = 31 * result + Arrays.hashCode(nestedArray);
+      return result;
+    }
+  }
 
   @Test
   public void genericRecord() throws IOException {

--- a/moshi/records-tests/src/test/java/com/squareup/moshi/records/RecordsTest.java
+++ b/moshi/records-tests/src/test/java/com/squareup/moshi/records/RecordsTest.java
@@ -13,11 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.squareup.moshi;
+package com.squareup.moshi.records;
 
 import static com.google.common.truth.Truth.assertThat;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.Json;
+import com.squareup.moshi.JsonQualifier;
+import com.squareup.moshi.Moshi;
+import com.squareup.moshi.ToJson;
+import com.squareup.moshi.Types;
 import java.io.IOException;
 import java.lang.annotation.Retention;
 import org.junit.Test;

--- a/moshi/records-tests/src/test/java/com/squareup/moshi/records/RecordsTest.java
+++ b/moshi/records-tests/src/test/java/com/squareup/moshi/records/RecordsTest.java
@@ -87,7 +87,6 @@ public final class RecordsTest {
       String[] favoriteArrayValues,
       Map<String, String> foodPreferences,
       Set<List<Map<String, int[]>>> setListMapArrayInt,
-      // Regression test for https://github.com/square/moshi/issues/1272
       Map<String, Object>[] nestedArray) {
     @Override
     public boolean equals(Object o) {

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -51,9 +51,7 @@ public final class Moshi {
     BUILT_IN_FACTORIES.add(CollectionJsonAdapter.FACTORY);
     BUILT_IN_FACTORIES.add(MapJsonAdapter.FACTORY);
     BUILT_IN_FACTORIES.add(ArrayJsonAdapter.FACTORY);
-    if (Util.recordsAvailable()) {
-      BUILT_IN_FACTORIES.add(RecordJsonAdapter.FACTORY);
-    }
+    BUILT_IN_FACTORIES.add(RecordJsonAdapter.FACTORY);
     BUILT_IN_FACTORIES.add(ClassJsonAdapter.FACTORY);
   }
 

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -51,6 +51,9 @@ public final class Moshi {
     BUILT_IN_FACTORIES.add(CollectionJsonAdapter.FACTORY);
     BUILT_IN_FACTORIES.add(MapJsonAdapter.FACTORY);
     BUILT_IN_FACTORIES.add(ArrayJsonAdapter.FACTORY);
+    if (Util.recordsAvailable()) {
+      BUILT_IN_FACTORIES.add(RecordJsonAdapter.FACTORY);
+    }
     BUILT_IN_FACTORIES.add(ClassJsonAdapter.FACTORY);
   }
 

--- a/moshi/src/main/java/com/squareup/moshi/RecordJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/RecordJsonAdapter.java
@@ -1,0 +1,27 @@
+package com.squareup.moshi;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Set;
+import org.jetbrains.annotations.Nullable;
+
+// This is just a simple shim for linking in StandardJsonAdapters and excluded from the final jar.
+final class RecordJsonAdapter<T> extends JsonAdapter<T> {
+
+  static final JsonAdapter.Factory FACTORY = new JsonAdapter.Factory() {
+
+    @Nullable @Override
+    public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {
+      throw new AssertionError();
+    }
+  };
+
+  @Nullable @Override public T fromJson(JsonReader reader) throws IOException {
+    throw new AssertionError();
+  }
+
+  @Override public void toJson(JsonWriter writer, @Nullable T value) throws IOException {
+    throw new AssertionError();
+  }
+}

--- a/moshi/src/main/java/com/squareup/moshi/RecordJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/RecordJsonAdapter.java
@@ -13,7 +13,7 @@ final class RecordJsonAdapter<T> extends JsonAdapter<T> {
 
     @Nullable @Override
     public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {
-      throw new AssertionError();
+      return null;
     }
   };
 

--- a/moshi/src/main/java/com/squareup/moshi/RecordJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/RecordJsonAdapter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.moshi;
 
 import java.io.IOException;
@@ -12,19 +27,25 @@ import javax.annotation.Nullable;
  */
 final class RecordJsonAdapter<T> extends JsonAdapter<T> {
 
-  static final JsonAdapter.Factory FACTORY = new JsonAdapter.Factory() {
+  static final JsonAdapter.Factory FACTORY =
+      new JsonAdapter.Factory() {
 
-    @Nullable @Override
-    public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {
-      return null;
-    }
-  };
+        @Nullable
+        @Override
+        public JsonAdapter<?> create(
+            Type type, Set<? extends Annotation> annotations, Moshi moshi) {
+          return null;
+        }
+      };
 
-  @Nullable @Override public T fromJson(JsonReader reader) throws IOException {
+  @Nullable
+  @Override
+  public T fromJson(JsonReader reader) throws IOException {
     throw new AssertionError();
   }
 
-  @Override public void toJson(JsonWriter writer, @Nullable T value) throws IOException {
+  @Override
+  public void toJson(JsonWriter writer, @Nullable T value) throws IOException {
     throw new AssertionError();
   }
 }

--- a/moshi/src/main/java/com/squareup/moshi/RecordJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/RecordJsonAdapter.java
@@ -4,9 +4,12 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Set;
-import org.jetbrains.annotations.Nullable;
+import javax.annotation.Nullable;
 
-// This is just a simple shim for linking in StandardJsonAdapters and excluded from the final jar.
+/**
+ * This is just a simple shim for linking in {@link StandardJsonAdapters} and swapped with a real
+ * implementation in Java 16 via MR Jar.
+ */
 final class RecordJsonAdapter<T> extends JsonAdapter<T> {
 
   static final JsonAdapter.Factory FACTORY = new JsonAdapter.Factory() {

--- a/moshi/src/main/java/com/squareup/moshi/internal/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/Util.java
@@ -44,7 +44,6 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
 public final class Util {

--- a/moshi/src/main/java/com/squareup/moshi/internal/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/Util.java
@@ -44,6 +44,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
 public final class Util {
@@ -54,6 +55,8 @@ public final class Util {
 
   /** A map from primitive types to their corresponding wrapper types. */
   private static final Map<Class<?>, Class<?>> PRIMITIVE_TO_WRAPPER_TYPE;
+
+  private static final AtomicBoolean RECORDS_AVAILABLE = new AtomicBoolean(false);
 
   static {
     Class<? extends Annotation> metadata = null;
@@ -86,6 +89,12 @@ public final class Util {
     primToWrap.put(void.class, Void.class);
 
     PRIMITIVE_TO_WRAPPER_TYPE = Collections.unmodifiableMap(primToWrap);
+
+    try {
+      Class.forName("java.lang.reflect.RecordComponent");
+      RECORDS_AVAILABLE.set(true);
+    } catch (ClassNotFoundException ignored) {
+    }
   }
 
   // Extracted as a method with a keep rule to prevent R8 from keeping Kotlin Metada
@@ -669,5 +678,9 @@ public final class Util {
     @SuppressWarnings("unchecked")
     Class<T> wrapped = (Class<T>) PRIMITIVE_TO_WRAPPER_TYPE.get(type);
     return (wrapped == null) ? type : wrapped;
+  }
+
+  public static boolean recordsAvailable() {
+    return RECORDS_AVAILABLE.get();
   }
 }

--- a/moshi/src/main/java/com/squareup/moshi/internal/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/Util.java
@@ -56,8 +56,6 @@ public final class Util {
   /** A map from primitive types to their corresponding wrapper types. */
   private static final Map<Class<?>, Class<?>> PRIMITIVE_TO_WRAPPER_TYPE;
 
-  private static final AtomicBoolean RECORDS_AVAILABLE = new AtomicBoolean(false);
-
   static {
     Class<? extends Annotation> metadata = null;
     try {
@@ -89,12 +87,6 @@ public final class Util {
     primToWrap.put(void.class, Void.class);
 
     PRIMITIVE_TO_WRAPPER_TYPE = Collections.unmodifiableMap(primToWrap);
-
-    try {
-      Class.forName("java.lang.reflect.RecordComponent");
-      RECORDS_AVAILABLE.set(true);
-    } catch (ClassNotFoundException ignored) {
-    }
   }
 
   // Extracted as a method with a keep rule to prevent R8 from keeping Kotlin Metada
@@ -678,9 +670,5 @@ public final class Util {
     @SuppressWarnings("unchecked")
     Class<T> wrapped = (Class<T>) PRIMITIVE_TO_WRAPPER_TYPE.get(type);
     return (wrapped == null) ? type : wrapped;
-  }
-
-  public static boolean recordsAvailable() {
-    return RECORDS_AVAILABLE.get();
   }
 }

--- a/moshi/src/main/java16/com/squareup/moshi/RecordJsonAdapter.java
+++ b/moshi/src/main/java16/com/squareup/moshi/RecordJsonAdapter.java
@@ -113,6 +113,7 @@ final class RecordJsonAdapter<T> extends JsonAdapter<T> {
     try {
       //noinspection unchecked
       constructor = (Constructor<Object>) rawType.getDeclaredConstructor(constructorParams);
+      constructor.setAccessible(true);
     } catch (NoSuchMethodException e) {
       throw new AssertionError(e);
     }

--- a/moshi/src/main/java16/com/squareup/moshi/RecordJsonAdapter.java
+++ b/moshi/src/main/java16/com/squareup/moshi/RecordJsonAdapter.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.moshi;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.RecordComponent;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A {@link JsonAdapter} that supports Java {@code record} classes via reflection.
+ * <p>
+ * <em>NOTE:</em> Java records require JDK 16 or higher.
+ */
+final class RecordJsonAdapter<T> extends JsonAdapter<T> {
+
+  static final JsonAdapter.Factory FACTORY = (type, annotations, moshi) -> {
+    if (!annotations.isEmpty()) { return null; }
+
+    if (!(type instanceof Class) && !(type instanceof ParameterizedType)) {
+      return null;
+    }
+
+    var rawType = Types.getRawType(type);
+    if (!rawType.isRecord()) { return null; }
+
+    Map<String, Type> mappedTypeArgs = null;
+    if (type instanceof ParameterizedType parameterizedType) {
+      Type[] typeArgs = parameterizedType.getActualTypeArguments();
+      var typeVars = rawType.getTypeParameters();
+      mappedTypeArgs = new LinkedHashMap<>(typeArgs.length);
+      for (int i = 0; i < typeArgs.length; ++i) {
+        var typeVarName = typeVars[i].getName();
+        var materialized = typeArgs[i];
+        mappedTypeArgs.put(typeVarName, materialized);
+      }
+    }
+    var components = rawType.getRecordComponents();
+    var bindings = new LinkedHashMap<String, ComponentBinding<?>>();
+    var constructorParams = new Class<?>[components.length];
+    for (int i = 0, componentsLength = components.length; i < componentsLength; i++) {
+      RecordComponent component = components[i];
+      constructorParams[i] = component.getType();
+      var name = component.getName();
+      var componentType = component.getGenericType();
+      if (componentType instanceof TypeVariable<?> typeVariable) {
+        var typeVarName = typeVariable.getName();
+        if (mappedTypeArgs == null) {
+          throw new AssertionError("No mapped type arguments found for type '" + typeVarName + "'");
+        }
+        var mappedType = mappedTypeArgs.get(typeVarName);
+        if (mappedType == null) {
+          throw new AssertionError("No materialized type argument found for type '" + typeVarName + "'");
+        }
+        componentType = mappedType;
+      }
+      var jsonName = name;
+      Set<Annotation> qualifiers = null;
+      for (var annotation : component.getDeclaredAnnotations()) {
+        if (annotation instanceof Json jsonAnnotation) {
+          jsonName = jsonAnnotation.name();
+        } else {
+          if (annotation.annotationType().isAnnotationPresent(JsonQualifier.class)) {
+            if (qualifiers == null) {
+              qualifiers = new LinkedHashSet<>();
+            }
+            qualifiers.add(annotation);
+          }
+        }
+      }
+      var adapter = moshi.adapter(componentType, annotations);
+      var accessor = component.getAccessor();
+      var componentBinding = new ComponentBinding<>(name, jsonName, adapter, accessor);
+      var replaced = bindings.put(jsonName, componentBinding);
+      if (replaced != null) {
+        throw new IllegalArgumentException(
+            "Conflicting components:\n"
+                + "    "
+                + replaced.name
+                + "\n"
+                + "    "
+                + componentBinding.name);
+      }
+    }
+    Constructor<Object> constructor;
+    try {
+      //noinspection unchecked
+      constructor = (Constructor<Object>) rawType.getDeclaredConstructor(constructorParams);
+    } catch (NoSuchMethodException e) {
+      throw new AssertionError(e);
+    }
+    return new RecordJsonAdapter<>(constructor, bindings).nullSafe();
+  };
+
+  private static record ComponentBinding<T>(String name, String jsonName, JsonAdapter<T> adapter, Method accessor) {
+    <R> R invokeGet(T instance) throws IllegalAccessException, InvocationTargetException {
+      var initialAccess = accessor.canAccess(instance);
+      try {
+        if (!initialAccess) {
+          accessor.setAccessible(true);
+        }
+        //noinspection unchecked
+        return (R) accessor.invoke(instance);
+      } finally {
+        accessor.setAccessible(false);
+      }
+    }
+  }
+
+    private final String targetClass;
+    private final Constructor<T> constructor;
+    private final ComponentBinding<Object>[] componentBindingsArray;
+    private final JsonReader.Options options;
+
+    @SuppressWarnings("ToArrayCallWithZeroLengthArrayArgument")
+    public RecordJsonAdapter(
+        Constructor<T> constructor,
+        Map<String, ComponentBinding<?>> componentBindings
+    ) {
+      this.constructor = constructor;
+      this.targetClass = constructor.getDeclaringClass().getSimpleName();
+      //noinspection unchecked
+      this.componentBindingsArray = componentBindings.values().toArray(new ComponentBinding[componentBindings.size()]);
+      this.options = JsonReader.Options.of(componentBindings.keySet().toArray(new String[componentBindings.size()]));
+    }
+
+    @Override
+    public T fromJson(JsonReader reader) throws IOException {
+      var resultsArray = new Object[componentBindingsArray.length];
+
+      reader.beginObject();
+      while (reader.hasNext()) {
+        int index = reader.selectName(options);
+        if (index == -1) {
+          reader.skipName();
+          reader.skipValue();
+          continue;
+        }
+        var result = componentBindingsArray[index].adapter.fromJson(reader);
+        resultsArray[index] = result;
+      }
+      reader.endObject();
+
+      var initialAccess = constructor.canAccess(null);
+      try {
+        if (!initialAccess) {
+          constructor.setAccessible(true);
+        }
+        return constructor.newInstance(resultsArray);
+      } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+        throw new AssertionError(e);
+      } finally {
+        constructor.setAccessible(false);
+      }
+    }
+
+    @Override
+    public void toJson(JsonWriter writer, T value) throws IOException {
+      writer.beginObject();
+
+      for (var binding : componentBindingsArray) {
+        writer.name(binding.jsonName);
+        try {
+          binding.adapter.toJson(writer, binding.invokeGet(value));
+        } catch (IllegalAccessException | InvocationTargetException e) {
+          throw new AssertionError(e);
+        }
+      }
+
+      writer.endObject();
+    }
+
+    @Override
+    public String toString() {
+      return "JsonAdapter(" + targetClass + ")";
+    }
+}

--- a/moshi/src/main/java16/com/squareup/moshi/RecordJsonAdapter.java
+++ b/moshi/src/main/java16/com/squareup/moshi/RecordJsonAdapter.java
@@ -24,6 +24,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.RecordComponent;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -90,7 +91,10 @@ final class RecordJsonAdapter<T> extends JsonAdapter<T> {
           }
         }
       }
-      var adapter = moshi.adapter(componentType, annotations);
+      if (qualifiers == null) {
+        qualifiers = Collections.emptySet();
+      }
+      var adapter = moshi.adapter(componentType, qualifiers);
       var accessor = component.getAccessor();
       accessor.setAccessible(true);
       var componentBinding = new ComponentBinding<>(name, jsonName, adapter, accessor);

--- a/moshi/src/main/java16/com/squareup/moshi/RecordJsonAdapter.java
+++ b/moshi/src/main/java16/com/squareup/moshi/RecordJsonAdapter.java
@@ -32,162 +32,170 @@ import java.util.Set;
 
 /**
  * A {@link JsonAdapter} that supports Java {@code record} classes via reflection.
- * <p>
- * <em>NOTE:</em> Java records require JDK 16 or higher.
+ *
+ * <p><em>NOTE:</em> Java records require JDK 16 or higher.
  */
 final class RecordJsonAdapter<T> extends JsonAdapter<T> {
 
-  static final JsonAdapter.Factory FACTORY = (type, annotations, moshi) -> {
-    if (!annotations.isEmpty()) { return null; }
-
-    if (!(type instanceof Class) && !(type instanceof ParameterizedType)) {
-      return null;
-    }
-
-    var rawType = Types.getRawType(type);
-    if (!rawType.isRecord()) { return null; }
-
-    Map<String, Type> mappedTypeArgs = null;
-    if (type instanceof ParameterizedType parameterizedType) {
-      Type[] typeArgs = parameterizedType.getActualTypeArguments();
-      var typeVars = rawType.getTypeParameters();
-      mappedTypeArgs = new LinkedHashMap<>(typeArgs.length);
-      for (int i = 0; i < typeArgs.length; ++i) {
-        var typeVarName = typeVars[i].getName();
-        var materialized = typeArgs[i];
-        mappedTypeArgs.put(typeVarName, materialized);
-      }
-    }
-    var components = rawType.getRecordComponents();
-    var bindings = new LinkedHashMap<String, ComponentBinding<?>>();
-    var constructorParams = new Class<?>[components.length];
-    for (int i = 0, componentsLength = components.length; i < componentsLength; i++) {
-      RecordComponent component = components[i];
-      constructorParams[i] = component.getType();
-      var name = component.getName();
-      var componentType = component.getGenericType();
-      if (componentType instanceof TypeVariable<?> typeVariable) {
-        var typeVarName = typeVariable.getName();
-        if (mappedTypeArgs == null) {
-          throw new AssertionError("No mapped type arguments found for type '" + typeVarName + "'");
+  static final JsonAdapter.Factory FACTORY =
+      (type, annotations, moshi) -> {
+        if (!annotations.isEmpty()) {
+          return null;
         }
-        var mappedType = mappedTypeArgs.get(typeVarName);
-        if (mappedType == null) {
-          throw new AssertionError("No materialized type argument found for type '" + typeVarName + "'");
+
+        if (!(type instanceof Class) && !(type instanceof ParameterizedType)) {
+          return null;
         }
-        componentType = mappedType;
-      }
-      var jsonName = name;
-      Set<Annotation> qualifiers = null;
-      for (var annotation : component.getDeclaredAnnotations()) {
-        if (annotation instanceof Json jsonAnnotation) {
-          jsonName = jsonAnnotation.name();
-        } else {
-          if (annotation.annotationType().isAnnotationPresent(JsonQualifier.class)) {
-            if (qualifiers == null) {
-              qualifiers = new LinkedHashSet<>();
-            }
-            qualifiers.add(annotation);
+
+        var rawType = Types.getRawType(type);
+        if (!rawType.isRecord()) {
+          return null;
+        }
+
+        Map<String, Type> mappedTypeArgs = null;
+        if (type instanceof ParameterizedType parameterizedType) {
+          Type[] typeArgs = parameterizedType.getActualTypeArguments();
+          var typeVars = rawType.getTypeParameters();
+          mappedTypeArgs = new LinkedHashMap<>(typeArgs.length);
+          for (int i = 0; i < typeArgs.length; ++i) {
+            var typeVarName = typeVars[i].getName();
+            var materialized = typeArgs[i];
+            mappedTypeArgs.put(typeVarName, materialized);
           }
         }
-      }
-      if (qualifiers == null) {
-        qualifiers = Collections.emptySet();
-      }
-      var adapter = moshi.adapter(componentType, qualifiers);
-      var accessor = component.getAccessor();
-      accessor.setAccessible(true);
-      var componentBinding = new ComponentBinding<>(name, jsonName, adapter, accessor);
-      var replaced = bindings.put(jsonName, componentBinding);
-      if (replaced != null) {
-        throw new IllegalArgumentException(
-            "Conflicting components:\n"
-                + "    "
-                + replaced.name
-                + "\n"
-                + "    "
-                + componentBinding.name);
-      }
-    }
-    Constructor<Object> constructor;
-    try {
-      //noinspection unchecked
-      constructor = (Constructor<Object>) rawType.getDeclaredConstructor(constructorParams);
-      constructor.setAccessible(true);
-    } catch (NoSuchMethodException e) {
-      throw new AssertionError(e);
-    }
-    return new RecordJsonAdapter<>(constructor, bindings).nullSafe();
-  };
-
-  private static record ComponentBinding<T>(String name, String jsonName, JsonAdapter<T> adapter, Method accessor) {
-  }
-
-    private final String targetClass;
-    private final Constructor<T> constructor;
-    private final ComponentBinding<Object>[] componentBindingsArray;
-    private final JsonReader.Options options;
-
-    @SuppressWarnings("ToArrayCallWithZeroLengthArrayArgument")
-    public RecordJsonAdapter(
-        Constructor<T> constructor,
-        Map<String, ComponentBinding<?>> componentBindings
-    ) {
-      this.constructor = constructor;
-      this.targetClass = constructor.getDeclaringClass().getSimpleName();
-      //noinspection unchecked
-      this.componentBindingsArray = componentBindings.values().toArray(new ComponentBinding[componentBindings.size()]);
-      this.options = JsonReader.Options.of(componentBindings.keySet().toArray(new String[componentBindings.size()]));
-    }
-
-    @Override
-    public T fromJson(JsonReader reader) throws IOException {
-      var resultsArray = new Object[componentBindingsArray.length];
-
-      reader.beginObject();
-      while (reader.hasNext()) {
-        int index = reader.selectName(options);
-        if (index == -1) {
-          reader.skipName();
-          reader.skipValue();
-          continue;
+        var components = rawType.getRecordComponents();
+        var bindings = new LinkedHashMap<String, ComponentBinding<?>>();
+        var constructorParams = new Class<?>[components.length];
+        for (int i = 0, componentsLength = components.length; i < componentsLength; i++) {
+          RecordComponent component = components[i];
+          constructorParams[i] = component.getType();
+          var name = component.getName();
+          var componentType = component.getGenericType();
+          if (componentType instanceof TypeVariable<?> typeVariable) {
+            var typeVarName = typeVariable.getName();
+            if (mappedTypeArgs == null) {
+              throw new AssertionError(
+                  "No mapped type arguments found for type '" + typeVarName + "'");
+            }
+            var mappedType = mappedTypeArgs.get(typeVarName);
+            if (mappedType == null) {
+              throw new AssertionError(
+                  "No materialized type argument found for type '" + typeVarName + "'");
+            }
+            componentType = mappedType;
+          }
+          var jsonName = name;
+          Set<Annotation> qualifiers = null;
+          for (var annotation : component.getDeclaredAnnotations()) {
+            if (annotation instanceof Json jsonAnnotation) {
+              jsonName = jsonAnnotation.name();
+            } else {
+              if (annotation.annotationType().isAnnotationPresent(JsonQualifier.class)) {
+                if (qualifiers == null) {
+                  qualifiers = new LinkedHashSet<>();
+                }
+                qualifiers.add(annotation);
+              }
+            }
+          }
+          if (qualifiers == null) {
+            qualifiers = Collections.emptySet();
+          }
+          var adapter = moshi.adapter(componentType, qualifiers);
+          var accessor = component.getAccessor();
+          accessor.setAccessible(true);
+          var componentBinding = new ComponentBinding<>(name, jsonName, adapter, accessor);
+          var replaced = bindings.put(jsonName, componentBinding);
+          if (replaced != null) {
+            throw new IllegalArgumentException(
+                "Conflicting components:\n"
+                    + "    "
+                    + replaced.name
+                    + "\n"
+                    + "    "
+                    + componentBinding.name);
+          }
         }
-        var result = componentBindingsArray[index].adapter.fromJson(reader);
-        resultsArray[index] = result;
-      }
-      reader.endObject();
-
-      var initialAccess = constructor.canAccess(null);
-      try {
-        if (!initialAccess) {
-          constructor.setAccessible(true);
-        }
-        return constructor.newInstance(resultsArray);
-      } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-        throw new AssertionError(e);
-      } finally {
-        constructor.setAccessible(false);
-      }
-    }
-
-    @Override
-    public void toJson(JsonWriter writer, T value) throws IOException {
-      writer.beginObject();
-
-      for (var binding : componentBindingsArray) {
-        writer.name(binding.jsonName);
+        Constructor<Object> constructor;
         try {
-          binding.adapter.toJson(writer, binding.accessor.invoke(value));
-        } catch (IllegalAccessException | InvocationTargetException e) {
+          //noinspection unchecked
+          constructor = (Constructor<Object>) rawType.getDeclaredConstructor(constructorParams);
+          constructor.setAccessible(true);
+        } catch (NoSuchMethodException e) {
           throw new AssertionError(e);
         }
+        return new RecordJsonAdapter<>(constructor, bindings).nullSafe();
+      };
+
+  private static record ComponentBinding<T>(
+      String name, String jsonName, JsonAdapter<T> adapter, Method accessor) {}
+
+  private final String targetClass;
+  private final Constructor<T> constructor;
+  private final ComponentBinding<Object>[] componentBindingsArray;
+  private final JsonReader.Options options;
+
+  @SuppressWarnings("ToArrayCallWithZeroLengthArrayArgument")
+  public RecordJsonAdapter(
+      Constructor<T> constructor, Map<String, ComponentBinding<?>> componentBindings) {
+    this.constructor = constructor;
+    this.targetClass = constructor.getDeclaringClass().getSimpleName();
+    //noinspection unchecked
+    this.componentBindingsArray =
+        componentBindings.values().toArray(new ComponentBinding[componentBindings.size()]);
+    this.options =
+        JsonReader.Options.of(
+            componentBindings.keySet().toArray(new String[componentBindings.size()]));
+  }
+
+  @Override
+  public T fromJson(JsonReader reader) throws IOException {
+    var resultsArray = new Object[componentBindingsArray.length];
+
+    reader.beginObject();
+    while (reader.hasNext()) {
+      int index = reader.selectName(options);
+      if (index == -1) {
+        reader.skipName();
+        reader.skipValue();
+        continue;
       }
+      var result = componentBindingsArray[index].adapter.fromJson(reader);
+      resultsArray[index] = result;
+    }
+    reader.endObject();
 
-      writer.endObject();
+    var initialAccess = constructor.canAccess(null);
+    try {
+      if (!initialAccess) {
+        constructor.setAccessible(true);
+      }
+      return constructor.newInstance(resultsArray);
+    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+      throw new AssertionError(e);
+    } finally {
+      constructor.setAccessible(false);
+    }
+  }
+
+  @Override
+  public void toJson(JsonWriter writer, T value) throws IOException {
+    writer.beginObject();
+
+    for (var binding : componentBindingsArray) {
+      writer.name(binding.jsonName);
+      try {
+        binding.adapter.toJson(writer, binding.accessor.invoke(value));
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        throw new AssertionError(e);
+      }
     }
 
-    @Override
-    public String toString() {
-      return "JsonAdapter(" + targetClass + ")";
-    }
+    writer.endObject();
+  }
+
+  @Override
+  public String toString() {
+    return "JsonAdapter(" + targetClass + ")";
+  }
 }

--- a/moshi/src/main/java16/com/squareup/moshi/RecordJsonAdapter.java
+++ b/moshi/src/main/java16/com/squareup/moshi/RecordJsonAdapter.java
@@ -171,7 +171,12 @@ final class RecordJsonAdapter<T> extends JsonAdapter<T> {
         constructor.setAccessible(true);
       }
       return constructor.newInstance(resultsArray);
-    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof RuntimeException) throw (RuntimeException) cause;
+      if (cause instanceof Error) throw (Error) cause;
+      throw new RuntimeException(cause);
+    } catch (InstantiationException | IllegalAccessException e) {
       throw new AssertionError(e);
     } finally {
       constructor.setAccessible(false);
@@ -186,7 +191,12 @@ final class RecordJsonAdapter<T> extends JsonAdapter<T> {
       writer.name(binding.jsonName);
       try {
         binding.adapter.toJson(writer, binding.accessor.invoke(value));
-      } catch (IllegalAccessException | InvocationTargetException e) {
+      } catch (InvocationTargetException e) {
+        Throwable cause = e.getCause();
+        if (cause instanceof RuntimeException) throw (RuntimeException) cause;
+        if (cause instanceof Error) throw (Error) cause;
+        throw new RuntimeException(cause);
+      } catch (IllegalAccessException e) {
         throw new AssertionError(e);
       }
     }

--- a/moshi/src/test/java/com/squareup/moshi/JsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonAdapterTest.java
@@ -126,7 +126,7 @@ public final class JsonAdapterTest {
       fail();
     } catch (JsonDataException expected) {
       assertThat(expected).hasMessageThat().isEqualTo("Unexpected null at $[1]");
-      assertThat(reader.nextNull()).isNull();
+      assertThat(reader.<Object>nextNull()).isNull();
     }
     assertThat(toUpperCase.fromJson(reader)).isEqualTo("C");
     reader.endArray();

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
@@ -565,7 +565,7 @@ public final class JsonReaderTest {
     assertThat(reader2.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
 
     JsonReader reader3 = newReader("null");
-    assertThat(reader3.nextNull()).isNull();
+    assertThat(reader3.<Object>nextNull()).isNull();
     assertThat(reader3.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
 
     JsonReader reader4 = newReader("123");

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
@@ -59,7 +59,7 @@ public final class JsonValueReaderTest {
 
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.NULL);
-    assertThat(reader.nextNull()).isNull();
+    assertThat(reader.<Object>nextNull()).isNull();
 
     assertThat(reader.hasNext()).isFalse();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_ARRAY);
@@ -103,7 +103,7 @@ public final class JsonValueReaderTest {
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.NAME);
     assertThat(reader.nextName()).isEqualTo("d");
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.NULL);
-    assertThat(reader.nextNull()).isNull();
+    assertThat(reader.<Object>nextNull()).isNull();
 
     assertThat(reader.hasNext()).isFalse();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_OBJECT);

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueWriterTest.java
@@ -152,10 +152,10 @@ public final class JsonValueWriterTest {
   public void primitiveIntegerTypesEmitLong() throws Exception {
     JsonValueWriter writer = new JsonValueWriter();
     writer.beginArray();
-    writer.value(new Byte(Byte.MIN_VALUE));
-    writer.value(new Short(Short.MIN_VALUE));
-    writer.value(new Integer(Integer.MIN_VALUE));
-    writer.value(new Long(Long.MIN_VALUE));
+    writer.value(Byte.valueOf(Byte.MIN_VALUE));
+    writer.value(Short.valueOf(Short.MIN_VALUE));
+    writer.value(Integer.valueOf(Integer.MIN_VALUE));
+    writer.value(Long.valueOf(Long.MIN_VALUE));
     writer.endArray();
 
     List<Number> numbers =
@@ -167,8 +167,8 @@ public final class JsonValueWriterTest {
   public void primitiveFloatingPointTypesEmitDouble() throws Exception {
     JsonValueWriter writer = new JsonValueWriter();
     writer.beginArray();
-    writer.value(new Float(0.5f));
-    writer.value(new Double(0.5d));
+    writer.value(Float.valueOf(0.5f));
+    writer.value(Double.valueOf(0.5d));
     writer.endArray();
 
     List<Number> numbers = Arrays.<Number>asList(0.5d, 0.5d);

--- a/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
@@ -236,17 +236,17 @@ public final class JsonWriterTest {
     JsonWriter writer = factory.newWriter();
     writer.beginArray();
     try {
-      writer.value(new Double(Double.NaN));
+      writer.value(Double.valueOf(Double.NaN));
       fail();
     } catch (IllegalArgumentException expected) {
     }
     try {
-      writer.value(new Double(Double.NEGATIVE_INFINITY));
+      writer.value(Double.valueOf(Double.NEGATIVE_INFINITY));
       fail();
     } catch (IllegalArgumentException expected) {
     }
     try {
-      writer.value(new Double(Double.POSITIVE_INFINITY));
+      writer.value(Double.valueOf(Double.POSITIVE_INFINITY));
       fail();
     } catch (IllegalArgumentException expected) {
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ pluginManagement {
 rootProject.name = "moshi-root"
 include(":moshi")
 include(":moshi:japicmp")
+include(":moshi:records-tests")
 include(":adapters")
 include(":adapters:japicmp")
 include(":examples")


### PR DESCRIPTION
Porting from https://github.com/ZacSweers/MoshiX/tree/main/moshi-records-reflect

This makes a few changes along the way to make the build all happy with how we're doing this:
- Standardizing around Java 8 (which is the minimum supported by gradle toolchains and also soon to be the minimum supported by Kotlin)
- Create a separate Java 16 source set for hosting the actual adapter implementation. This is compiled with Java 16 but is then packaged into the main Moshi jar and denoted as a Multi-Release JAR.
- We gate access to this record adapter at runtime by checking if the requisite record APIs are available.
- We separately have a shim copy of the record adapter in the `main` source set for linking in `BUILT_IN_FACTORIES`, but this is booted out by the real one during packaging.
- Replace animal sniffer with `-release 8`, which functionally accomplishes the same
- Tests are in a dedicated separate `records-test` subproject, making it easier to both write new ones and also ensure our packaging rules for the jar is working correctly (we've had success with this in the past with the codegen artifact's shading being tested in a dedicated tests project)

Resolves #1278

Tests are a little skimpy right now, happy to take suggestions on more we should add! Can also look at fleshing them out more in a followup PR