### PR TITLE
Only assign setters if present

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -644,7 +644,8 @@ internal class AdapterGenerator(
       }
       if (property.hasLocalIsPresentName) {
         result.beginControlFlow("if (%N)", property.localIsPresentName)
-        result.addStatement("%N.%N = %N",
+        result.addStatement(
+          "%N.%N = %N",
           resultName,
           property.name,
           property.localName


### PR DESCRIPTION
Rather than generating

```kotlin
val result: Content
result = Content()
result.content = if (contentSet) content else result.content
result.text = if (textSet) text else result.text
```

This will now conditionally set

```kotlin
val result: Content
result = Content()
if (contentSet) {
  result.content = content
}
if (textSet) {
  result.text = text
}
```