### PR TITLE
Prototype support for Optional

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import javax.annotation.Nullable;
@@ -137,6 +138,7 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
 
             // Look up a type adapter for this type.
             Type fieldType = resolve(type, rawType, field.getGenericType());
+            boolean isOptional = Util.isOptionalType(fieldType);
             Set<? extends Annotation> annotations = Util.jsonAnnotations(field);
             String fieldName = field.getName();
             JsonAdapter<Object> adapter = moshi.adapter(fieldType, annotations, fieldName);
@@ -147,7 +149,8 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
             // Store it using the field's name. If there was already a field with this name, fail!
             Json jsonAnnotation = field.getAnnotation(Json.class);
             String name = jsonAnnotation != null ? jsonAnnotation.name() : fieldName;
-            FieldBinding<Object> fieldBinding = new FieldBinding<>(name, field, adapter);
+            FieldBinding<Object> fieldBinding =
+                new FieldBinding<>(name, field, adapter, isOptional);
             FieldBinding<?> replaced = fieldBindings.put(name, fieldBinding);
             if (replaced != null) {
               throw new IllegalArgumentException(
@@ -180,6 +183,10 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
 
   @Override
   public T fromJson(JsonReader reader) throws IOException {
+    // TODO optimize by using empty array if optional isn't supported
+    boolean checkOptionals = Util.SUPPORTS_OPTIONAL;
+    boolean[] setOptionalFields =
+        checkOptionals ? new boolean[fieldsArray.length] : Util.EMPTY_BOOLEAN_ARRAY;
     T result;
     try {
       result = classFactory.newInstance();
@@ -200,9 +207,26 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
           reader.skipValue();
           continue;
         }
+        if (checkOptionals) {
+          setOptionalFields[index] = true;
+        }
         fieldsArray[index].read(reader, result);
       }
       reader.endObject();
+      if (checkOptionals) {
+        for (int i = 0; i < setOptionalFields.length; i++) {
+          if (setOptionalFields[i]) continue;
+          // Unset. If it's optional, set it to empty. Note that we bypass the adapter from the
+          // field
+          // even if it's OptionalJsonAdapter in case it was short-circuited by another adapter, we
+          // only
+          // trust ours. Our OptionalJsonAdapter may be wrapped by NullSafeJsonAdapter too.
+          FieldBinding<?> fieldBinding = fieldsArray[i];
+          if (fieldBinding.isOptional) {
+            fieldBinding.field.set(result, Optional.empty());
+          }
+        }
+      }
       return result;
     } catch (IllegalAccessException e) {
       throw new AssertionError();
@@ -232,11 +256,13 @@ final class ClassJsonAdapter<T> extends JsonAdapter<T> {
     final String name;
     final Field field;
     final JsonAdapter<T> adapter;
+    final boolean isOptional;
 
-    FieldBinding(String name, Field field, JsonAdapter<T> adapter) {
+    FieldBinding(String name, Field field, JsonAdapter<T> adapter, boolean isOptional) {
       this.name = name;
       this.field = field;
       this.adapter = adapter;
+      this.isOptional = isOptional;
     }
 
     void read(JsonReader reader, Object value) throws IOException, IllegalAccessException {

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -52,6 +52,7 @@ public final class Moshi {
     BUILT_IN_FACTORIES.add(MapJsonAdapter.FACTORY);
     BUILT_IN_FACTORIES.add(ArrayJsonAdapter.FACTORY);
     BUILT_IN_FACTORIES.add(RecordJsonAdapter.FACTORY);
+    BUILT_IN_FACTORIES.add(OptionalJsonAdapterFactory.INSTANCE);
     BUILT_IN_FACTORIES.add(ClassJsonAdapter.FACTORY);
   }
 

--- a/moshi/src/main/java/com/squareup/moshi/OptionalJsonAdapterFactory.java
+++ b/moshi/src/main/java/com/squareup/moshi/OptionalJsonAdapterFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.moshi;
+
+import com.squareup.moshi.internal.OptionalJsonAdapter;
+import com.squareup.moshi.internal.Util;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+final class OptionalJsonAdapterFactory implements JsonAdapter.Factory {
+
+  static final JsonAdapter.Factory INSTANCE =
+      !Util.SUPPORTS_OPTIONAL ? null : new OptionalJsonAdapterFactory();
+
+  private OptionalJsonAdapterFactory() {}
+
+  @Nullable
+  @Override
+  public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {
+    if (type instanceof ParameterizedType && Util.isOptionalType(type)) {
+      return new OptionalJsonAdapter<>(
+          moshi.adapter(((ParameterizedType) type).getActualTypeArguments()[0]));
+    }
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return "OptionalJsonAdapterFactory";
+  }
+}

--- a/moshi/src/main/java/com/squareup/moshi/internal/NonNullJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/NonNullJsonAdapter.java
@@ -37,7 +37,7 @@ public final class NonNullJsonAdapter<T> extends JsonAdapter<T> {
   @Nullable
   @Override
   public T fromJson(JsonReader reader) throws IOException {
-    if (reader.peek() == JsonReader.Token.NULL) {
+    if (reader.peek() == JsonReader.Token.NULL && !(delegate instanceof OptionalJsonAdapter)) {
       throw new JsonDataException("Unexpected null at " + reader.getPath());
     } else {
       return delegate.fromJson(reader);

--- a/moshi/src/main/java/com/squareup/moshi/internal/OptionalJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/OptionalJsonAdapter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.moshi.internal;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import java.io.IOException;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link JsonAdapter} that serializes and deserializes {@link Optional}s.
+ *
+ * <p>This is one of two sides to supporting {@link Optional}s in Moshi and focuses solely on
+ * handling explicit null values. The other side is reflective support for setting absent values.
+ */
+public final class OptionalJsonAdapter<T> extends JsonAdapter<Optional<T>> {
+
+  private final JsonAdapter<T> delegate;
+
+  public OptionalJsonAdapter(JsonAdapter<T> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Optional<T> fromJson(JsonReader reader) throws IOException {
+    if (reader.peek() == JsonReader.Token.NULL) {
+      reader.nextNull();
+      return Optional.empty();
+    }
+    T value = delegate.fromJson(reader);
+    return Optional.ofNullable(value);
+  }
+
+  @Override
+  public void toJson(JsonWriter writer, @Nullable Optional<T> value) throws IOException {
+    if (value != null && value.isPresent()) {
+      delegate.toJson(writer, value.get());
+    } else {
+      writer.nullValue();
+    }
+  }
+}

--- a/moshi/src/main/java/com/squareup/moshi/internal/Util.java
+++ b/moshi/src/main/java/com/squareup/moshi/internal/Util.java
@@ -43,14 +43,17 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
 
 public final class Util {
   public static final Set<Annotation> NO_ANNOTATIONS = Collections.emptySet();
   public static final Type[] EMPTY_TYPE_ARRAY = new Type[] {};
+  public static final boolean[] EMPTY_BOOLEAN_ARRAY = new boolean[] {};
   @Nullable public static final Class<?> DEFAULT_CONSTRUCTOR_MARKER;
   @Nullable private static final Class<? extends Annotation> METADATA;
+  public static final boolean SUPPORTS_OPTIONAL;
 
   /** A map from primitive types to their corresponding wrapper types. */
   private static final Map<Class<?>, Class<?>> PRIMITIVE_TO_WRAPPER_TYPE;
@@ -86,6 +89,15 @@ public final class Util {
     primToWrap.put(void.class, Void.class);
 
     PRIMITIVE_TO_WRAPPER_TYPE = Collections.unmodifiableMap(primToWrap);
+
+    boolean localSupportsOptional;
+    try {
+      Class.forName("java.util.Optional");
+      localSupportsOptional = true;
+    } catch (ClassNotFoundException ignored) {
+      localSupportsOptional = false;
+    }
+    SUPPORTS_OPTIONAL = localSupportsOptional;
   }
 
   // Extracted as a method with a keep rule to prevent R8 from keeping Kotlin Metada
@@ -147,6 +159,10 @@ public final class Util {
         || name.startsWith("kotlin.")
         || name.startsWith("kotlinx.")
         || name.startsWith("scala.");
+  }
+
+  public static boolean isOptionalType(Type type) {
+    return SUPPORTS_OPTIONAL && Optional.class.isAssignableFrom(Types.getRawType(type));
   }
 
   /** Throws the cause of {@code e}, wrapping it if it is checked. */

--- a/moshi/src/test/java/com/squareup/moshi/OptionalTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/OptionalTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.moshi;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+import org.junit.Test;
+
+public final class OptionalTest {
+
+  private final Moshi moshi = new Moshi.Builder().build();
+
+  @Test
+  public void adapterBehavior() throws IOException {
+    JsonAdapter<Optional<String>> adapter =
+        moshi.adapter(Types.newParameterizedType(Optional.class, String.class));
+    assertThat(adapter.fromJson("\"foo\"")).isEqualTo(Optional.of("foo"));
+    assertThat(adapter.fromJson("null")).isEqualTo(Optional.empty());
+  }
+
+  @Test
+  public void smokeTest() throws IOException {
+    JsonAdapter<TestClass> adapter = moshi.adapter(TestClass.class);
+    assertThat(adapter.fromJson("{\"optionalString\":\"foo\",\"regular\":\"bar\"}"))
+        .isEqualTo(new TestClass(Optional.of("foo"), "bar"));
+    assertThat(adapter.fromJson("{\"optionalString\":null,\"regular\":\"bar\"}"))
+        .isEqualTo(new TestClass(Optional.empty(), "bar"));
+    assertThat(adapter.fromJson("{\"regular\":\"bar\"}"))
+        .isEqualTo(new TestClass(Optional.empty(), "bar"));
+
+    assertThat(adapter.toJson(new TestClass(Optional.of("foo"), "bar")))
+        .isEqualTo("{\"optionalString\":\"foo\",\"regular\":\"bar\"}");
+    assertThat(adapter.toJson(new TestClass(Optional.empty(), "bar")))
+        .isEqualTo("{\"regular\":\"bar\"}");
+    assertThat(adapter.toJson(new TestClass(Optional.empty(), "bar")))
+        .isEqualTo("{\"regular\":\"bar\"}");
+  }
+
+  static final class TestClass {
+
+    Optional<String> optionalString;
+    String regular;
+
+    public TestClass(Optional<String> optionalString, String regular) {
+      this.optionalString = optionalString;
+      this.regular = regular;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      TestClass testClass = (TestClass) o;
+      return optionalString.equals(testClass.optionalString)
+          && Objects.equals(regular, testClass.regular);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(optionalString, regular);
+    }
+
+    @Override
+    public String toString() {
+      return "TestClass{"
+          + "optionalString="
+          + optionalString
+          + ", regular='"
+          + regular
+          + '\''
+          + '}';
+    }
+  }
+}


### PR DESCRIPTION
This is a prototype of what `Optional` support would look like. This implements it in two parts:
1. A new `OptionalJsonAdapter` + associated factory. This essentially works by associating nulls with `Optional.absent()` and used for properties that are either present or explicitly `null`.
2. Reflective support in `ClassJsonAdapter` and `KotlinJsonAdapter` for supporting defaulting absent values to `Optional.empty()`.

Open questions:
1. Do we really want to support this in Kotlin? If so, how do we handle the following:
  a. `Optional<String>?`
  b. Do we support this in code gen too?
2. Do we support just `j.u.Optional` or do we want to do something more generic (to support Guava, KOptional, etc)? How would that look if so?
3. Do we want to generify absent properties in general? Maybe an optional `JsonAdapter.ifAbsent()` or separate `AbsenceHandler` interface?
  - This would obviate 1 and 2 as we just need to support this API and delegate to whatever adapters folks bring.
