### PR TITLE
Support externally-compiled transient property recognition in KSP

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/ksp/TargetTypes.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/ksp/TargetTypes.kt
@@ -39,6 +39,7 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.jvm.transient
 import com.squareup.kotlinpoet.ksp.TypeParameterResolver
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toKModifier
@@ -258,8 +259,11 @@ private fun KSPropertyDeclaration.toPropertySpec(
     .mutable(isMutable)
     .addModifiers(modifiers.map { KModifier.valueOf(it.name) })
     .apply {
-      if (isAnnotationPresent(Transient::class)) {
-        addAnnotation(Transient::class)
+      // Check modifiers and annotation since annotation is source-only
+      val isTransient = Modifier.JAVA_TRANSIENT in this@toPropertySpec.modifiers ||
+        isAnnotationPresent(Transient::class)
+      if (isTransient) {
+        transient()
       }
       addAnnotations(
         this@toPropertySpec.annotations

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/ksp/TargetTypes.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/ksp/TargetTypes.kt
@@ -260,6 +260,7 @@ private fun KSPropertyDeclaration.toPropertySpec(
     .addModifiers(modifiers.map { KModifier.valueOf(it.name) })
     .apply {
       // Check modifiers and annotation since annotation is source-only
+      // Note that this won't work properly until https://github.com/google/ksp/issues/710 is fixed
       val isTransient = Modifier.JAVA_TRANSIENT in this@toPropertySpec.modifiers ||
         isAnnotationPresent(Transient::class)
       if (isTransient) {

--- a/kotlin/tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/CompileOnlyTests.kt
+++ b/kotlin/tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/CompileOnlyTests.kt
@@ -17,6 +17,9 @@ package com.squareup.moshi.kotlin.codegen
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import com.squareup.moshi.JsonQualifier
+import com.squareup.moshi.kotlin.codegen.test.extra.AbstractClassInModuleA
+import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.TYPE
 
 /*
@@ -117,3 +120,23 @@ data class SmokeTestType(
 
 typealias TypeAliasName = String
 typealias GenericTypeAlias = List<String>
+
+// Regression test for enum constants in annotations and array types
+// https://github.com/ZacSweers/MoshiX/issues/103
+@Retention(RUNTIME)
+@JsonQualifier
+annotation class UpperCase(val foo: Array<Foo>)
+
+enum class Foo { BAR }
+
+@JsonClass(generateAdapter = true)
+data class ClassWithQualifier(
+  @UpperCase(foo = [Foo.BAR])
+  val a: Int
+)
+
+// Regression for https://github.com/ZacSweers/MoshiX/issues/120
+@JsonClass(generateAdapter = true)
+data class DataClassInModuleB(
+  val id: String
+) : AbstractClassInModuleA()

--- a/kotlin/tests/extra-moshi-test-module/src/main/kotlin/com/squareup/moshi/kotlin/codegen/test/extra/AbstractClassInModuleA.kt
+++ b/kotlin/tests/extra-moshi-test-module/src/main/kotlin/com/squareup/moshi/kotlin/codegen/test/extra/AbstractClassInModuleA.kt
@@ -16,11 +16,9 @@
 package com.squareup.moshi.kotlin.codegen.test.extra
 
 public abstract class AbstractClassInModuleA {
-  // Transients to ensure compiler sees them across module boundaries since @Transient is
+  // Transients to ensure processor sees them across module boundaries since @Transient is
   // SOURCE-only
-  @Transient
-  private lateinit var stringId: String
-
-  @Transient
-  private var alreadySet: String = "alreadySet"
+  // TODO uncomment these when https://github.com/google/ksp/issues/710 is fixed
+//  @Transient private lateinit var lateinitTransient: String
+//  @Transient private var regularTransient: String = "regularTransient"
 }

--- a/kotlin/tests/extra-moshi-test-module/src/main/kotlin/com/squareup/moshi/kotlin/codegen/test/extra/AbstractClassInModuleA.kt
+++ b/kotlin/tests/extra-moshi-test-module/src/main/kotlin/com/squareup/moshi/kotlin/codegen/test/extra/AbstractClassInModuleA.kt
@@ -15,4 +15,12 @@
  */
 package com.squareup.moshi.kotlin.codegen.test.extra
 
-public abstract class AbstractClassInModuleA
+public abstract class AbstractClassInModuleA {
+  // Transients to ensure compiler sees them across module boundaries since @Transient is
+  // SOURCE-only
+  @Transient
+  private lateinit var stringId: String
+
+  @Transient
+  private var alreadySet: String = "alreadySet"
+}

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -20,12 +20,10 @@ import com.squareup.moshi.FromJson
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.JsonDataException
-import com.squareup.moshi.JsonQualifier
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.ToJson
 import com.squareup.moshi.Types
 import com.squareup.moshi.adapter
-import com.squareup.moshi.kotlin.codegen.test.extra.AbstractClassInModuleA
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import org.intellij.lang.annotations.Language
 import org.junit.Assert.fail

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -648,23 +648,3 @@ typealias NullableB = B?
 typealias C = NullableA
 typealias D = C
 typealias E = D
-
-// Regression test for enum constants in annotations and array types
-// https://github.com/ZacSweers/MoshiX/issues/103
-@Retention(RUNTIME)
-@JsonQualifier
-annotation class UpperCase(val foo: Array<Foo>)
-
-enum class Foo { BAR }
-
-@JsonClass(generateAdapter = true)
-data class ClassWithQualifier(
-  @UpperCase(foo = [Foo.BAR])
-  val a: Int
-)
-
-// Regression for https://github.com/ZacSweers/MoshiX/issues/120
-@JsonClass(generateAdapter = true)
-data class DataClassInModuleB(
-  val id: String
-) : AbstractClassInModuleA()


### PR DESCRIPTION
For now it doesn't work due to https://github.com/google/ksp/issues/710, but it will eventually work once that's fixed. This puts in a check and a toe-hold comment in tests for it