### PR TITLE
Update proguard rules for R8 3.1

### DIFF
--- a/moshi/src/main/resources/META-INF/proguard/moshi.pro
+++ b/moshi/src/main/resources/META-INF/proguard/moshi.pro
@@ -5,7 +5,7 @@
     @com.squareup.moshi.* <methods>;
 }
 
--keep @com.squareup.moshi.JsonQualifier interface *
+-keep @com.squareup.moshi.JsonQualifier @interface *
 
 # Enum field names are used by the integrated EnumJsonAdapter.
 # values() is synthesized by the Kotlin compiler and is used by EnumJsonAdapter indirectly


### PR DESCRIPTION
R8 3.1 in full mode have made improvements to annotation removal.
Current rules are not enough to ensure that JsonQualifier  annotatated class are kept.

See https://issuetracker.google.com/issues/206656057

Proper change attributed to: Morten Krogh-Jespersen