### PR TITLE
Omit adapter field names now that we directly instantiate annotations

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -270,8 +270,7 @@ public class AdapterGenerator(
         uniqueAdapter.delegateKey.generateProperty(
           nameAllocator,
           typeRenderer,
-          moshiParam,
-          uniqueAdapter.name
+          moshiParam
         )
       )
     }

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/DelegateKey.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/DelegateKey.kt
@@ -45,8 +45,7 @@ public data class DelegateKey(
   internal fun generateProperty(
     nameAllocator: NameAllocator,
     typeRenderer: TypeRenderer,
-    moshiParameter: ParameterSpec,
-    propertyName: String
+    moshiParameter: ParameterSpec
   ): PropertySpec {
     val qualifierNames = jsonQualifiers.joinToString("") {
       "At${it.typeName.rawType().simpleName}"
@@ -68,10 +67,10 @@ public data class DelegateKey(
         ", setOf(%L)" to arrayOf(jsonQualifiers.map { it.asInstantiationExpression() }.joinToCode())
       }
     }
-    val finalArgs = arrayOf(*standardArgs, *args, propertyName)
+    val finalArgs = arrayOf(*standardArgs, *args)
 
     return PropertySpec.builder(adapterName, adapterTypeName, KModifier.PRIVATE)
-      .initializer("%N.adapter(%L$initializerString, %S)", *finalArgs)
+      .initializer("%N.adapter(%L$initializerString)", *finalArgs)
       .build()
   }
 }

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -109,7 +109,10 @@ public final class Moshi {
   /**
    * @param fieldName An optional field name associated with this type. The field name is used as a
    *     hint for better adapter lookup error messages for nested structures.
+   * @deprecated this is no longer needed in Kotlin 1.6.0 (which has direct annotation
+   *     instantiation) and should no longer be used.
    */
+  @Deprecated
   @CheckReturnValue
   @SuppressWarnings("unchecked") // Factories are required to return only matching JsonAdapters.
   public <T> JsonAdapter<T> adapter(


### PR DESCRIPTION
This is no longer necessary!