### PR TITLE
Revert "Omit adapter field names now that we directly instantiate annotations"

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -270,7 +270,8 @@ public class AdapterGenerator(
         uniqueAdapter.delegateKey.generateProperty(
           nameAllocator,
           typeRenderer,
-          moshiParam
+          moshiParam,
+          uniqueAdapter.name
         )
       )
     }

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/DelegateKey.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/DelegateKey.kt
@@ -45,7 +45,8 @@ public data class DelegateKey(
   internal fun generateProperty(
     nameAllocator: NameAllocator,
     typeRenderer: TypeRenderer,
-    moshiParameter: ParameterSpec
+    moshiParameter: ParameterSpec,
+    propertyName: String
   ): PropertySpec {
     val qualifierNames = jsonQualifiers.joinToString("") {
       "At${it.typeName.rawType().simpleName}"
@@ -67,10 +68,10 @@ public data class DelegateKey(
         ", setOf(%L)" to arrayOf(jsonQualifiers.map { it.asInstantiationExpression() }.joinToCode())
       }
     }
-    val finalArgs = arrayOf(*standardArgs, *args)
+    val finalArgs = arrayOf(*standardArgs, *args, propertyName)
 
     return PropertySpec.builder(adapterName, adapterTypeName, KModifier.PRIVATE)
-      .initializer("%N.adapter(%L$initializerString)", *finalArgs)
+      .initializer("%N.adapter(%L$initializerString, %S)", *finalArgs)
       .build()
   }
 }

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.java
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.java
@@ -109,10 +109,7 @@ public final class Moshi {
   /**
    * @param fieldName An optional field name associated with this type. The field name is used as a
    *     hint for better adapter lookup error messages for nested structures.
-   * @deprecated this is no longer needed in Kotlin 1.6.0 (which has direct annotation
-   *     instantiation) and should no longer be used.
    */
-  @Deprecated
   @CheckReturnValue
   @SuppressWarnings("unchecked") // Factories are required to return only matching JsonAdapters.
   public <T> JsonAdapter<T> adapter(


### PR DESCRIPTION
Reverts square/moshi#1436