### PR TITLE
Don't mangle property names that contain a dollar sign

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/apt/metadata.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/apt/metadata.kt
@@ -396,8 +396,7 @@ private fun declaredProperties(
       propertySpec = property,
       parameter = parameter,
       visibility = property.modifiers.visibility(),
-      jsonName = parameter?.jsonName ?: property.annotations.jsonName()
-        ?: name.escapeDollarSigns(),
+      jsonName = parameter?.jsonName ?: property.annotations.jsonName() ?: name,
       jsonIgnore = isIgnored
     )
   }
@@ -521,10 +520,6 @@ private fun <T> AnnotationSpec.elementValue(name: String): T? {
   return mirror.elementValues.entries.firstOrNull {
     it.key.simpleName.contentEquals(name)
   }?.value?.value as? T
-}
-
-private fun String.escapeDollarSigns(): String {
-  return replace("\$", "\${\'\$\'}")
 }
 
 internal val TypeElement.metadata: Metadata

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/ksp/TargetTypes.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/ksp/TargetTypes.kt
@@ -243,8 +243,7 @@ private fun declaredProperties(
       propertySpec = propertySpec,
       parameter = parameter,
       visibility = property.getVisibility().toKModifier() ?: KModifier.PUBLIC,
-      jsonName = parameter?.jsonName ?: property.jsonName()
-        ?: name.escapeDollarSigns(),
+      jsonName = parameter?.jsonName ?: property.jsonName() ?: name,
       jsonIgnore = isTransient || parameter?.jsonIgnore == true || property.jsonIgnore()
     )
   }
@@ -278,8 +277,4 @@ private fun KSPropertyDeclaration.toPropertySpec(
       )
     }
     .build()
-}
-
-private fun String.escapeDollarSigns(): String {
-  return replace("\$", "\${\'\$\'}")
 }

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -743,6 +743,22 @@ class DualKotlinTest {
       this.b = b
     }
   }
+
+  @Test fun propertyNameHasDollarSign() {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    val jsonAdapter = moshi.adapter<PropertyWithDollarSign>()
+
+    val value = PropertyWithDollarSign("apple", "banana")
+    val json = """{"${'$'}a":"apple","${'$'}b":"banana"}"""
+    assertThat(jsonAdapter.toJson(value)).isEqualTo(json)
+    assertThat(jsonAdapter.fromJson(json)).isEqualTo(value)
+  }
+
+  @JsonClass(generateAdapter = true)
+  data class PropertyWithDollarSign(
+    val `$a`: String,
+    @Json(name = "\$b") val b: String
+  )
 }
 
 typealias TypeAlias = Int


### PR DESCRIPTION
Without this fix the new test fails like this:

    value of: toJson(...)
    expected: {"$a":"apple","$b":"banana"}
    but was : {"${'$'}a":"apple","$b":"banana"}