### PR TITLE
Submit to Javadoc's draconion heading ordering rule

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
 /**
  * Emits a regular class as a JSON object by mapping Java fields to JSON object properties.
  *
- * <h3>Platform Types</h3>
+ * <h1>Platform Types</h1>
  *
  * Fields from platform classes are omitted from both serialization and deserialization unless they
  * are either public or protected. This includes the following packages and their subpackages:

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -37,7 +37,7 @@ import okio.ByteString;
  * depth-first order, the same order that they appear in the JSON document. Within JSON objects,
  * name/value pairs are represented by a single token.
  *
- * <h3>Parsing JSON</h3>
+ * <h1>Parsing JSON</h1>
  *
  * To create a recursive descent parser for your own JSON streams, first create an entry point
  * method that creates a {@code JsonReader}.
@@ -65,7 +65,7 @@ import okio.ByteString;
  * <p>If a value may be null, you should first check using {@link #peek()}. Null literals can be
  * consumed using either {@link #nextNull()} or {@link #skipValue()}.
  *
- * <h3>Example</h3>
+ * <h1>Example</h1>
  *
  * Suppose we'd like to parse a stream of messages such as the following:
  *
@@ -171,7 +171,7 @@ import okio.ByteString;
  * }
  * }</pre>
  *
- * <h3>Number Handling</h3>
+ * <h1>Number Handling</h1>
  *
  * This reader permits numeric values to be read as strings and string values to be read as numbers.
  * For example, both elements of the JSON array {@code [1, "1"]} may be read using either {@link

--- a/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
@@ -37,7 +37,7 @@ import okio.BufferedSource;
  * stream, one token at a time. The stream includes both literal values (strings, numbers, booleans
  * and nulls) as well as the begin and end delimiters of objects and arrays.
  *
- * <h3>Encoding JSON</h3>
+ * <h1>Encoding JSON</h1>
  *
  * To encode your data as JSON, create a new {@code JsonWriter}. Each JSON document must contain one
  * top-level array or object. Call methods on the writer as you walk the structure's contents,
@@ -53,7 +53,7 @@ import okio.BufferedSource;
  *       arrays. Finally close the object using {@link #endObject()}.
  * </ul>
  *
- * <h3>Example</h3>
+ * <h1>Example</h1>
  *
  * Suppose we'd like to encode a stream of messages such as the following:
  *


### PR DESCRIPTION
Whoever thought this was a good idea is wrong.

    > Task :moshi:javadoc
    /home/runner/work/moshi/moshi/moshi/src/main/java/com/squareup/moshi/JsonWriter.java:40: error: heading used out of sequence: <H3>, compared to implicit preceding heading: <H1>
     * <h3>Encoding JSON</h3>
       ^
    /home/runner/work/moshi/moshi/moshi/src/main/java/com/squareup/moshi/JsonReader.java:40: error: heading used out of sequence: <H3>, compared to implicit preceding heading: <H1>
     * <h3>Parsing JSON</h3>
       ^