### PR TITLE
Fix javadoc task and snapshots

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.java
@@ -37,7 +37,7 @@ import okio.ByteString;
  * depth-first order, the same order that they appear in the JSON document. Within JSON objects,
  * name/value pairs are represented by a single token.
  *
- * <h1>Parsing JSON</h1>
+ * <h2>Parsing JSON</h2>
  *
  * To create a recursive descent parser for your own JSON streams, first create an entry point
  * method that creates a {@code JsonReader}.
@@ -65,7 +65,7 @@ import okio.ByteString;
  * <p>If a value may be null, you should first check using {@link #peek()}. Null literals can be
  * consumed using either {@link #nextNull()} or {@link #skipValue()}.
  *
- * <h1>Example</h1>
+ * <h2>Example</h2>
  *
  * Suppose we'd like to parse a stream of messages such as the following:
  *
@@ -171,7 +171,7 @@ import okio.ByteString;
  * }
  * }</pre>
  *
- * <h1>Number Handling</h1>
+ * <h2>Number Handling</h2>
  *
  * This reader permits numeric values to be read as strings and string values to be read as numbers.
  * For example, both elements of the JSON array {@code [1, "1"]} may be read using either {@link

--- a/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
+++ b/moshi/src/main/java/com/squareup/moshi/JsonWriter.java
@@ -37,7 +37,7 @@ import okio.BufferedSource;
  * stream, one token at a time. The stream includes both literal values (strings, numbers, booleans
  * and nulls) as well as the begin and end delimiters of objects and arrays.
  *
- * <h1>Encoding JSON</h1>
+ * <h2>Encoding JSON</h2>
  *
  * To encode your data as JSON, create a new {@code JsonWriter}. Each JSON document must contain one
  * top-level array or object. Call methods on the writer as you walk the structure's contents,
@@ -53,7 +53,7 @@ import okio.BufferedSource;
  *       arrays. Finally close the object using {@link #endObject()}.
  * </ul>
  *
- * <h1>Example</h1>
+ * <h2>Example</h2>
  *
  * Suppose we'd like to encode a stream of messages such as the following:
  *


### PR DESCRIPTION
The javadoc task assumes every doc starts with h1 and thus using them anywhere in the body after the start is an error ¯\_(ツ)_/¯. This just changes them to h2