### PR TITLE
EventJsonAdapter Kotlin sample update in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,19 +349,21 @@ class EventJsonAdapter {
 
 ```kotlin
 class EventJsonAdapter {
-  @FromJson fun eventFromJson(eventJson: EventJson): Event {
-    val event = Event()
-    event.title = eventJson.title
-    event.beginDateAndTime = "${eventJson.begin_date} ${eventJson.begin_time}"
-    return event
+  @FromJson
+  fun eventFromJson(eventJson: EventJson): Event {
+    return Event(
+      title = eventJson.title,
+      beginDateAndTime = "${eventJson.begin_date} ${eventJson.begin_time}"
+    )
   }
 
-  @ToJson fun eventToJson(event: Event): EventJson {
-    val json = EventJson()
-    json.title = event.title
-    json.begin_date = event.beginDateAndTime.substring(0, 8)
-    json.begin_time = event.beginDateAndTime.substring(9, 14)
-    return json
+  @ToJson
+  fun eventToJson(event: Event): EventJson {
+    return EventJson(
+      title = event.title,
+      begin_date = event.beginDateAndTime.substring(0, 8),
+      begin_time = event.beginDateAndTime.substring(9, 14),
+    )
   }
 }
 ```


### PR DESCRIPTION
`val` is readonly in Kotlin. They can be assigned a value only once. The example was showing error when I tried to use it.