### PR TITLE
Update dokka to 1.6.10

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,14 +3,13 @@ autoService = "1.0"
 gjf = "1.11.0"
 jvmTarget = "1.8"
 kotlin = "1.6.10"
-dokka = "1.6.10"
 kotlinCompileTesting = "1.4.6"
 kotlinpoet = "1.10.2"
 ksp = "1.6.0-1.0.1"
 ktlint = "0.41.0"
 
 [plugins]
-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "kotlin" }
 japicmp = { id = "me.champeau.gradle.japicmp", version = "0.2.9" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.18.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ ksp = "1.6.0-1.0.1"
 ktlint = "0.41.0"
 
 [plugins]
-dokka = { id = "org.jetbrains.dokka", version = "1.5.31" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "kotlin" }
 japicmp = { id = "me.champeau.gradle.japicmp", version = "0.2.9" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.18.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,14 +2,15 @@
 autoService = "1.0"
 gjf = "1.11.0"
 jvmTarget = "1.8"
-kotlin = "1.6.0"
+kotlin = "1.6.10"
+dokka = "1.6.10"
 kotlinCompileTesting = "1.4.6"
 kotlinpoet = "1.10.2"
 ksp = "1.6.0-1.0.1"
 ktlint = "0.41.0"
 
 [plugins]
-dokka = { id = "org.jetbrains.dokka", version.ref = "kotlin" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 japicmp = { id = "me.champeau.gradle.japicmp", version = "0.2.9" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.18.0" }


### PR DESCRIPTION
`Dokka` is a documentation engine for Kotlin. So, it make sense to keep the same version as Kotlin.

https://github.com/Kotlin/dokka/releases