### PR TITLE
Keep `@FromJson`/`@ToJson`-annotated methods in proguard

### DIFF
--- a/moshi/src/main/resources/META-INF/proguard/moshi.pro
+++ b/moshi/src/main/resources/META-INF/proguard/moshi.pro
@@ -19,3 +19,9 @@
 -keepclassmembers class com.squareup.moshi.internal.Util {
     private static java.lang.String getKotlinMetadataClassName();
 }
+
+# Keep ToJson/FromJson-annotated methods
+-keepclassmembers class * {
+  @com.squareup.moshi.FromJson <methods>;
+  @com.squareup.moshi.ToJson <methods>;
+}


### PR DESCRIPTION
These are looked up reflectively and must be preserved