### PR TITLE
Explicitly denote util public APIs in japicmp

### DIFF
--- a/moshi/japicmp/build.gradle.kts
+++ b/moshi/japicmp/build.gradle.kts
@@ -26,16 +26,25 @@ val japicmp = tasks.register<JapicmpTask>("japicmp") {
   isIgnoreMissingClasses = true
   isIncludeSynthetic = true
   classExcludes = listOf(
-    "com.squareup.moshi.internal.NonNullJsonAdapter", // Internal.
-    "com.squareup.moshi.internal.NullSafeJsonAdapter", // Internal.
-    "com.squareup.moshi.internal.Util", // Internal.
-    "com.squareup.moshi.StandardJsonAdapters", // Package-private
-    "com.squareup.moshi.RecordJsonAdapter\$ComponentBinding", // Package-private
     "com.squareup.moshi.AdapterMethodsFactory", // Internal.
     "com.squareup.moshi.ClassJsonAdapter", // Internal.
+    "com.squareup.moshi.RecordJsonAdapter\$ComponentBinding", // Package-private
+    "com.squareup.moshi.StandardJsonAdapters", // Package-private
+    "com.squareup.moshi.internal.NonNullJsonAdapter", // Internal.
+    "com.squareup.moshi.internal.NullSafeJsonAdapter", // Internal.
+    "com.squareup.moshi.internal.Util\$GenericArrayTypeImpl", // Internal.
+    "com.squareup.moshi.internal.Util\$ParameterizedTypeImpl", // Internal.
+    "com.squareup.moshi.internal.Util\$WildcardTypeImpl", // Internal.
   )
   methodExcludes = listOf(
     "com.squareup.moshi.JsonAdapter#indent(java.lang.String)", // Was unintentionally open before
+    "com.squareup.moshi.internal.Util#hasNullable(java.lang.annotation.Annotation[])",
+    "com.squareup.moshi.internal.Util#jsonAnnotations(java.lang.annotation.Annotation[])",
+    "com.squareup.moshi.internal.Util#jsonAnnotations(java.lang.reflect.AnnotatedElement)",
+    "com.squareup.moshi.internal.Util#jsonName(java.lang.String, com.squareup.moshi.Json)",
+    "com.squareup.moshi.internal.Util#jsonName(java.lang.String, java.lang.reflect.AnnotatedElement)",
+    "com.squareup.moshi.internal.Util#resolve(java.lang.reflect.Type, java.lang.Class, java.lang.reflect.Type)",
+    "com.squareup.moshi.internal.Util#typeAnnotatedWithAnnotations(java.lang.reflect.Type, java.util.Set)",
   )
   fieldExcludes = listOf(
     "com.squareup.moshi.CollectionJsonAdapter#FACTORY", // False-positive, class is not public anyway

--- a/moshi/src/main/java/com/squareup/moshi/internal/Util.kt
+++ b/moshi/src/main/java/com/squareup/moshi/internal/Util.kt
@@ -60,6 +60,7 @@ private val METADATA: Class<out Annotation>? = try {
 
 // We look up the constructor marker separately because Metadata might be (justifiably)
 // stripped by R8/Proguard but the DefaultConstructorMarker is still present.
+@JvmField
 public val DEFAULT_CONSTRUCTOR_MARKER: Class<*>? = try {
   Class.forName("kotlin.jvm.internal.DefaultConstructorMarker")
 } catch (ignored: ClassNotFoundException) {


### PR DESCRIPTION
This is used occasionally from generated code so we have to be explicit about what members of `Util` are part of the effective public API. This exposed a missing `@JvmField` along the way.