### PR TITLE
KSP error messaging: Include name of the type being processed when creating the adapterGenerator fails

### DIFF
--- a/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/ksp/JsonClassSymbolProcessorProvider.kt
+++ b/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/ksp/JsonClassSymbolProcessorProvider.kt
@@ -87,9 +87,9 @@ private class JsonClassSymbolProcessor(
 
       if (!jsonClassAnnotation.generateAdapter) continue
 
-      val originatingFile = type.containingFile!!
-      val adapterGenerator = adapterGenerator(logger, resolver, type) ?: return emptyList()
       try {
+        val originatingFile = type.containingFile!!
+        val adapterGenerator = adapterGenerator(logger, resolver, type) ?: return emptyList()
         val preparedAdapter = adapterGenerator
           .prepare(generateProguardRules) { spec ->
             spec.toBuilder()

--- a/moshi-kotlin-codegen/src/test/java/com/squareup/moshi/kotlin/codegen/ksp/JsonClassSymbolProcessorTest.kt
+++ b/moshi-kotlin-codegen/src/test/java/com/squareup/moshi/kotlin/codegen/ksp/JsonClassSymbolProcessorTest.kt
@@ -539,6 +539,24 @@ class JsonClassSymbolProcessorTest {
   }
 
   @Test
+  fun invalidGenericSyntaxErrorMessaging() {
+    val result = compile(
+      kotlin(
+        "source.kt",
+        """
+          package test
+          import com.squareup.moshi.JsonClass
+
+          @JsonClass(generateAdapter = true)
+          data class ElementEnvelope(val elements: List)
+          """,
+      ),
+    )
+    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertThat(result.messages).contains("Error preparing ElementEnvelope")
+  }
+
+  @Test
   fun `TypeAliases with the same backing type should share the same adapter`() {
     val result = compile(
       kotlin(


### PR DESCRIPTION
Follow up to the error/stack I posted in #1522 
After poking around on my project I realized I had some bad generics syntax in my test source set causing the intrinsic null check failure in the ksp task.

Messaging now at least provides a hint as to where to start investigating