### PR TITLE
Suppress warning in generated code: `Parameter 'moshi' is never used`

### DIFF
--- a/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -71,6 +71,7 @@ public class AdapterGenerator(
       "DEPRECATION",
       // Because we look it up reflectively
       "unused",
+      "UNUSED_PARAMETER",
       // Because we include underscores
       "ClassName",
       // Because we generate redundant `out` variance for some generics and there's no way


### PR DESCRIPTION
We are getting this warning on generated type adapters with Kotlin `1.6.21` and moshi `1.14.0-SNAPSHOT` published from [this commit](https://github.com/square/moshi/commit/53bb46c20839fe155cdfcc042553d4acf6237344) :

`Parameter 'moshi' is never used`

`"unused"` doesn't seem to suppress that, but `"UNUSED_PARAMETER"` does work.

I couldn't figure out how to get `kotlin-compile-testing` to output the warning, so I could write a test to assert the warning is gone. 