### PR TITLE
Overhaul internals to use `KType`

### DIFF
--- a/examples/src/main/java/com/squareup/moshi/recipes/JsonString.kt
+++ b/examples/src/main/java/com/squareup/moshi/recipes/JsonString.kt
@@ -48,8 +48,8 @@ class JsonStringJsonAdapterFactory : JsonAdapter.Factory {
     override fun fromJson(reader: JsonReader): String =
       reader.nextSource().use(BufferedSource::readUtf8)
 
-    override fun toJson(writer: JsonWriter, value: String?) {
-      writer.valueSink().use { sink -> sink.writeUtf8(checkNotNull(value)) }
+    override fun toJson(writer: JsonWriter, value: String) {
+      writer.valueSink().use { sink -> sink.writeUtf8(value) }
     }
   }
 }
@@ -62,7 +62,7 @@ fun main() {
     .add(JsonStringJsonAdapterFactory())
     .build()
 
-  val example: ExampleClass = moshi.adapter(ExampleClass::class.java).fromJson(json)!!
+  val example: ExampleClass = moshi.adapter(ExampleClass::class.java).fromJson(json)
 
   check(example.type == 1)
 

--- a/examples/src/main/java/com/squareup/moshi/recipes/ReadJsonListKt.kt
+++ b/examples/src/main/java/com/squareup/moshi/recipes/ReadJsonListKt.kt
@@ -16,7 +16,6 @@
 package com.squareup.moshi.recipes
 
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.adapter
 import com.squareup.moshi.recipes.models.Card
 
 class ReadJsonListKt {
@@ -36,7 +35,7 @@ class ReadJsonListKt {
 
   fun readJsonList() {
     val jsonAdapter = Moshi.Builder().build().adapter<List<Card>>()
-    val cards = jsonAdapter.fromJson(jsonString)!!
+    val cards = jsonAdapter.fromJson(jsonString)
     println(cards)
     cards[0].run {
       println(rank)

--- a/moshi-adapters/src/main/java/com/squareup/moshi/Rfc3339DateJsonAdapter.kt
+++ b/moshi-adapters/src/main/java/com/squareup/moshi/Rfc3339DateJsonAdapter.kt
@@ -25,7 +25,7 @@ import java.util.Date
   replaceWith = ReplaceWith("com.squareup.moshi.adapters.Rfc3339DateJsonAdapter"),
   level = DeprecationLevel.ERROR
 )
-public class Rfc3339DateJsonAdapter : JsonAdapter<Date>() {
+public class Rfc3339DateJsonAdapter : JsonAdapter<Date?>() {
 
   private val delegate = Rfc3339DateJsonAdapter()
 

--- a/moshi-adapters/src/main/java/com/squareup/moshi/adapters/EnumJsonAdapter.kt
+++ b/moshi-adapters/src/main/java/com/squareup/moshi/adapters/EnumJsonAdapter.kt
@@ -41,7 +41,7 @@ public class EnumJsonAdapter<T : Enum<T>> internal constructor(
   private val enumType: Class<T>,
   private val fallbackValue: T?,
   private val useFallbackValue: Boolean,
-) : JsonAdapter<T>() {
+) : JsonAdapter<T?>() {
 
   private val constants: Array<T>
   private val options: Options

--- a/moshi-adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.kt
+++ b/moshi-adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.kt
@@ -103,7 +103,7 @@ public class PolymorphicJsonAdapterFactory<T> internal constructor(
   private val labelKey: String,
   private val labels: List<String>,
   private val subtypes: List<Type>,
-  private val fallbackJsonAdapter: JsonAdapter<Any>?
+  private val fallbackJsonAdapter: JsonAdapter<Any?>?
 ) : Factory {
   /** Returns a new factory that decodes instances of `subtype`. */
   public fun withSubtype(subtype: Class<out T>, label: String): PolymorphicJsonAdapterFactory<T> {
@@ -133,7 +133,7 @@ public class PolymorphicJsonAdapterFactory<T> internal constructor(
    * it within your implementation of [JsonAdapter.fromJson]
    */
   public fun withFallbackJsonAdapter(
-    fallbackJsonAdapter: JsonAdapter<Any>?
+    fallbackJsonAdapter: JsonAdapter<Any?>?
   ): PolymorphicJsonAdapterFactory<T> {
     return PolymorphicJsonAdapterFactory(
       baseType = baseType,
@@ -152,8 +152,8 @@ public class PolymorphicJsonAdapterFactory<T> internal constructor(
     return withFallbackJsonAdapter(buildFallbackJsonAdapter(defaultValue))
   }
 
-  private fun buildFallbackJsonAdapter(defaultValue: T?): JsonAdapter<Any> {
-    return object : JsonAdapter<Any>() {
+  private fun buildFallbackJsonAdapter(defaultValue: T?): JsonAdapter<Any?> {
+    return object : JsonAdapter<Any?>() {
       override fun fromJson(reader: JsonReader): Any? {
         reader.skipValue()
         return defaultValue
@@ -181,8 +181,8 @@ public class PolymorphicJsonAdapterFactory<T> internal constructor(
     private val labels: List<String>,
     private val subtypes: List<Type>,
     private val jsonAdapters: List<JsonAdapter<Any>>,
-    private val fallbackJsonAdapter: JsonAdapter<Any>?
-  ) : JsonAdapter<Any>() {
+    private val fallbackJsonAdapter: JsonAdapter<Any?>?
+  ) : JsonAdapter<Any?>() {
     /** Single-element options containing the label's key only.  */
     private val labelKeyOptions: Options = Options.of(labelKey)
 
@@ -223,12 +223,13 @@ public class PolymorphicJsonAdapterFactory<T> internal constructor(
     override fun toJson(writer: JsonWriter, value: Any?) {
       val type: Class<*> = value!!.javaClass
       val labelIndex = subtypes.indexOf(type)
-      val adapter: JsonAdapter<Any> = if (labelIndex == -1) {
+      val adapter: JsonAdapter<Any?> = if (labelIndex == -1) {
         requireNotNull(fallbackJsonAdapter) {
           "Expected one of $subtypes but found $value, a ${value.javaClass}. Register this subtype."
         }
       } else {
-        jsonAdapters[labelIndex]
+        @Suppress("UNCHECKED_CAST")
+        jsonAdapters[labelIndex] as JsonAdapter<Any?>
       }
       writer.beginObject()
       if (adapter !== fallbackJsonAdapter) {

--- a/moshi-adapters/src/main/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapter.kt
+++ b/moshi-adapters/src/main/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapter.kt
@@ -33,7 +33,7 @@ import java.util.Date
  *   .build();
  * ```
  */
-public class Rfc3339DateJsonAdapter : JsonAdapter<Date>() {
+public class Rfc3339DateJsonAdapter : JsonAdapter<Date?>() {
   @Synchronized
   @Throws(IOException::class)
   override fun fromJson(reader: JsonReader): Date? {

--- a/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -260,7 +260,8 @@ public class AdapterGenerator(
 
     val typeRenderer: TypeRenderer = object : TypeRenderer() {
       override fun renderTypeVariable(typeVariable: TypeVariableName): CodeBlock {
-        val index = typeVariables.indexOfFirst { it == typeVariable }
+        val nonNull = typeVariable.copy(nullable = false)
+        val index = typeVariables.indexOfFirst { it == nonNull }
         check(index != -1) { "Unexpected type variable $typeVariable" }
         return CodeBlock.of("%N[%L]", typesParam, index)
       }

--- a/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/TypeRenderer.kt
+++ b/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/TypeRenderer.kt
@@ -49,7 +49,7 @@ internal abstract class TypeRenderer {
         if (typeName.rawType == ARRAY) {
           val arg = typeName.typeArguments[0]
           CodeBlock.of(
-            "%L.%M(%L)",
+            "%L.%M(variance·=·%L)",
             render(arg),
             MemberName("com.squareup.moshi", "asArrayKType"),
             arg.kVarianceBlock
@@ -62,7 +62,7 @@ internal abstract class TypeRenderer {
             typeName.typeArguments
               .map {
                 CodeBlock.of(
-                  "%L.%M(%L)",
+                  "%L.%M(variance·=·%L)",
                   render(it),
                   MemberName("com.squareup.moshi", "asKTypeProjection"),
                   it.kVarianceBlock
@@ -95,7 +95,7 @@ internal abstract class TypeRenderer {
 
   private fun renderKType(className: ClassName): CodeBlock {
     return CodeBlock.of(
-      "%T::class.%M(isMarkedNullable = %L)",
+      "%T::class.%M(isMarkedNullable·=·%L)",
       className.copy(nullable = false),
       MemberName("com.squareup.moshi", "asKType"),
       className.isNullable

--- a/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/TypeRenderer.kt
+++ b/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/TypeRenderer.kt
@@ -16,21 +16,15 @@
 package com.squareup.moshi.kotlin.codegen.api
 
 import com.squareup.kotlinpoet.ARRAY
-import com.squareup.kotlinpoet.BOOLEAN
-import com.squareup.kotlinpoet.BYTE
-import com.squareup.kotlinpoet.CHAR
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
-import com.squareup.kotlinpoet.DOUBLE
-import com.squareup.kotlinpoet.FLOAT
-import com.squareup.kotlinpoet.INT
-import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterizedTypeName
-import com.squareup.kotlinpoet.SHORT
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.WildcardTypeName
-import com.squareup.moshi.Types
+import com.squareup.kotlinpoet.joinToCode
+import kotlin.reflect.KVariance
 
 /**
  * Renders literals like `Types.newParameterizedType(List::class.java, String::class.java)`.
@@ -44,63 +38,53 @@ internal abstract class TypeRenderer {
     if (typeName.annotations.isNotEmpty()) {
       return render(typeName.copy(annotations = emptyList()), forceBox)
     }
-    if (typeName.isNullable) {
-      return renderObjectType(typeName.copy(nullable = false))
-    }
 
     return when (typeName) {
       is ClassName -> {
-        if (forceBox) {
-          renderObjectType(typeName)
-        } else {
-          CodeBlock.of("%T::class.java", typeName)
-        }
+        renderKType(typeName)
       }
 
       is ParameterizedTypeName -> {
         // If it's an Array type, we shortcut this to return Types.arrayOf()
         if (typeName.rawType == ARRAY) {
+          val arg = typeName.typeArguments[0]
           CodeBlock.of(
-            "%T.arrayOf(%L)",
-            Types::class,
-            renderObjectType(typeName.typeArguments[0])
+            "%L.%M(%L)",
+            render(arg),
+            MemberName("com.squareup.moshi", "asArrayKType"),
+            arg.kVarianceBlock
           )
         } else {
-          val builder = CodeBlock.builder().apply {
-            add("%T.", Types::class)
-            val enclosingClassName = typeName.rawType.enclosingClassName()
-            if (enclosingClassName != null) {
-              add("newParameterizedTypeWithOwner(%L, ", render(enclosingClassName))
-            } else {
-              add("newParameterizedType(")
-            }
-            add("%T::class.java", typeName.rawType)
-            for (typeArgument in typeName.typeArguments) {
-              add(", %L", renderObjectType(typeArgument))
-            }
-            add(")")
-          }
-          builder.build()
+          CodeBlock.of(
+            "%T::class.%M(%L)",
+            typeName.rawType,
+            MemberName("com.squareup.moshi", "parameterizedBy"),
+            typeName.typeArguments
+              .map {
+                CodeBlock.of(
+                  "%L.%M(%L)",
+                  render(it),
+                  MemberName("com.squareup.moshi", "asKTypeProjection"),
+                  it.kVarianceBlock
+                )
+              }
+              .joinToCode(", ")
+          )
         }
       }
-
       is WildcardTypeName -> {
-        val target: TypeName
-        val method: String
-        when {
+        val target = when {
           typeName.inTypes.size == 1 -> {
-            target = typeName.inTypes[0]
-            method = "supertypeOf"
+            typeName.inTypes[0]
           }
           typeName.outTypes.size == 1 -> {
-            target = typeName.outTypes[0]
-            method = "subtypeOf"
+            typeName.outTypes[0]
           }
           else -> throw IllegalArgumentException(
             "Unrepresentable wildcard type. Cannot have more than one bound: $typeName"
           )
         }
-        CodeBlock.of("%T.%L(%L)", Types::class, method, render(target, forceBox = true))
+        render(target)
       }
 
       is TypeVariableName -> renderTypeVariable(typeName)
@@ -109,18 +93,29 @@ internal abstract class TypeRenderer {
     }
   }
 
-  private fun renderObjectType(typeName: TypeName): CodeBlock {
-    return if (typeName.isPrimitive()) {
-      CodeBlock.of("%T::class.javaObjectType", typeName)
-    } else {
-      render(typeName)
-    }
+  private fun renderKType(className: ClassName): CodeBlock {
+    return CodeBlock.of(
+      "%T::class.%M(isMarkedNullable = %L)",
+      className.copy(nullable = false),
+      MemberName("com.squareup.moshi", "asKType"),
+      className.isNullable
+    )
   }
 
-  private fun TypeName.isPrimitive(): Boolean {
-    return when (this) {
-      BOOLEAN, BYTE, SHORT, INT, LONG, CHAR, FLOAT, DOUBLE -> true
-      else -> false
+  private val TypeName.kVarianceBlock: CodeBlock get() {
+    val variance = if (this is WildcardTypeName) {
+      if (outTypes.isNotEmpty()) {
+        KVariance.IN
+      } else {
+        KVariance.OUT
+      }
+    } else {
+      KVariance.INVARIANT
     }
+    return CodeBlock.of(
+      "%T.%L",
+      KVariance::class,
+      variance.name
+    )
   }
 }

--- a/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/TypeRenderer.kt
+++ b/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/TypeRenderer.kt
@@ -27,7 +27,7 @@ import com.squareup.kotlinpoet.joinToCode
 import kotlin.reflect.KVariance
 
 /**
- * Renders literals like `Types.newParameterizedType(List::class.java, String::class.java)`.
+ * Renders literals like `List::class.parameterizedBy(String::class.asKTypeProjection(...))`.
  * Rendering is pluggable so that type variables can either be resolved or emitted as other code
  * blocks.
  */

--- a/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/ComplexGenericsInheritanceTest.kt
+++ b/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/ComplexGenericsInheritanceTest.kt
@@ -35,7 +35,7 @@ class ComplexGenericsInheritanceTest {
     val json =
       """{"data":{"name":"foo"},"data2":"bar","data3":"baz"}"""
 
-    val instance = adapter.fromJson(json)!!
+    val instance = adapter.fromJson(json)
     val testInstance = PersonResponse().apply {
       data = Person("foo")
     }
@@ -51,7 +51,7 @@ class ComplexGenericsInheritanceTest {
     val json =
       """{"data":{"name":"foo"},"data2":"bar","data3":"baz"}"""
 
-    val instance = adapter.fromJson(json)!!
+    val instance = adapter.fromJson(json)
     val testInstance = NestedPersonResponse().apply {
       data = Person("foo")
     }
@@ -67,7 +67,7 @@ class ComplexGenericsInheritanceTest {
     val json =
       """{"data":{"name":"foo"},"data2":"bar","data3":"baz"}"""
 
-    val instance = adapter.fromJson(json)!!
+    val instance = adapter.fromJson(json)
     val testInstance = UntypedNestedPersonResponse<Person>().apply {
       data = Person("foo")
     }
@@ -83,7 +83,7 @@ class ComplexGenericsInheritanceTest {
     val json =
       """{"layer4E":{"name":"layer4E"},"layer4F":{"data":{"name":"layer4F"},"data2":"layer4F","data3":"layer4F"},"layer3C":[1,2,3],"layer3D":"layer3D","layer2":"layer2","layer1":"layer1"}"""
 
-    val instance = adapter.fromJson(json)!!
+    val instance = adapter.fromJson(json)
     val testInstance = Layer4(
       layer4E = Person("layer4E"),
       layer4F = UntypedNestedPersonResponse<Person>().apply {

--- a/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/DefaultConstructorTest.kt
+++ b/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/DefaultConstructorTest.kt
@@ -26,7 +26,7 @@ class DefaultConstructorTest {
     val json =
       """{"required":"requiredClass"}"""
     val instance = Moshi.Builder().build().adapter<TestClass>()
-      .fromJson(json)!!
+      .fromJson(json)
     check(instance == expected) {
       "No match:\nActual  : $instance\nExpected: $expected"
     }
@@ -37,7 +37,7 @@ class DefaultConstructorTest {
     val json =
       """{"required":"requiredClass","optional":"customOptional","optional2":4,"dynamicSelfReferenceOptional":"setDynamic","dynamicOptional":5,"dynamicInlineOptional":6}"""
     val instance = Moshi.Builder().build().adapter<TestClass>()
-      .fromJson(json)!!
+      .fromJson(json)
     check(instance == expected) {
       "No match:\nActual  : $instance\nExpected: $expected"
     }
@@ -48,7 +48,7 @@ class DefaultConstructorTest {
     val json =
       """{"required":"requiredClass","optional":"customOptional"}"""
     val instance = Moshi.Builder().build().adapter<TestClass>()
-      .fromJson(json)!!
+      .fromJson(json)
     check(instance == expected) {
       "No match:\nActual  : $instance\nExpected: $expected"
     }

--- a/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -30,7 +30,6 @@ import com.squareup.moshi.internal.NullSafeJsonAdapter
 import com.squareup.moshi.kotlin.codegen.annotation.UppercaseInAnnotationPackage
 import com.squareup.moshi.kotlin.codegen.annotation.UppercaseInAnnotationPackageJsonAdapter
 import org.intellij.lang.annotations.Language
-import org.junit.Assert.assertNull
 import org.junit.Assert.fail
 import org.junit.Ignore
 import org.junit.Test
@@ -1091,38 +1090,6 @@ class GeneratedAdaptersTest {
     fun writeA(a: Int) {
       this.a = a
     }
-  }
-
-  @Test fun propertyIsNothing() {
-    val moshi = Moshi.Builder()
-      .add(NothingAdapter())
-      .build()
-    val jsonAdapter = moshi.adapter<HasNothingProperty>().serializeNulls()
-
-    val toJson = HasNothingProperty()
-    toJson.a = "1"
-    assertThat(jsonAdapter.toJson(toJson)).isEqualTo("""{"a":"1","b":null}""")
-
-    val fromJson = jsonAdapter.fromJson("""{"a":"3","b":null}""")
-    assertThat(fromJson.a).isEqualTo("3")
-    assertNull(fromJson.b)
-  }
-
-  class NothingAdapter {
-    @ToJson fun toJson(jsonWriter: JsonWriter, unused: Nothing?) {
-      jsonWriter.nullValue()
-    }
-
-    @FromJson fun fromJson(jsonReader: JsonReader): Nothing? {
-      jsonReader.skipValue()
-      return null
-    }
-  }
-
-  @JsonClass(generateAdapter = true)
-  class HasNothingProperty {
-    var a: String? = null
-    var b: Nothing? = null
   }
 
   @Test fun enclosedParameterizedType() {

--- a/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -1203,6 +1203,7 @@ class GeneratedAdaptersTest {
   @JsonClass(generateAdapter = true)
   data class HasNullableBoolean(val boolean: Boolean?)
 
+  @Ignore("TODO this is possibly no longer relevant in KType land")
   @Test fun nullablePrimitivesUseBoxedPrimitiveAdapters() {
     val moshi = Moshi.Builder()
       .add(

--- a/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -52,7 +52,7 @@ class GeneratedAdaptersTest {
     val json =
       """{"foo": "bar"}"""
 
-    val instance = adapter.fromJson(json)!!
+    val instance = adapter.fromJson(json)
     assertThat(instance.bar).isEqualTo("bar")
 
     // Write
@@ -77,7 +77,7 @@ class GeneratedAdaptersTest {
     // Read
     val json = "{\"\$foo\": \"bar\"}"
 
-    val instance = adapter.fromJson(json)!!
+    val instance = adapter.fromJson(json)
     assertThat(instance.bar).isEqualTo("bar")
 
     // Write
@@ -101,7 +101,7 @@ class GeneratedAdaptersTest {
     val json =
       """{"\"foo\"": "bar"}"""
 
-    val instance = adapter.fromJson(json)!!
+    val instance = adapter.fromJson(json)
     assertThat(instance.bar).isEqualTo("bar")
 
     // Write
@@ -127,7 +127,7 @@ class GeneratedAdaptersTest {
     val json =
       """{"foo":"fooString"}"""
 
-    val instance = adapter.fromJson(json)!!
+    val instance = adapter.fromJson(json)
     assertThat(instance.foo).isEqualTo("fooString")
     assertThat(instance.bar).isEqualTo("")
     assertThat(instance.nullableBar).isNull()
@@ -151,7 +151,7 @@ class GeneratedAdaptersTest {
       {"foo":"fooString","bar":"barString","nullableBar":"bar","bazList":["baz"]}
       """.trimIndent()
 
-    val instance2 = adapter.fromJson(json2)!!
+    val instance2 = adapter.fromJson(json2)
     assertThat(instance2.foo).isEqualTo("fooString")
     assertThat(instance2.bar).isEqualTo("barString")
     assertThat(instance2.nullableBar).isEqualTo("bar")
@@ -175,7 +175,7 @@ class GeneratedAdaptersTest {
     val json =
       """{"data":[null,"why"]}"""
 
-    val instance = adapter.fromJson(json)!!
+    val instance = adapter.fromJson(json)
     assertThat(instance.data).asList().containsExactly(null, "why").inOrder()
     assertThat(adapter.toJson(instance)).isEqualTo(json)
   }
@@ -191,7 +191,7 @@ class GeneratedAdaptersTest {
     val json =
       """{"ints":[0,1]}"""
 
-    val instance = adapter.fromJson(json)!!
+    val instance = adapter.fromJson(json)
     assertThat(instance.ints).asList().containsExactly(0, 1).inOrder()
     assertThat(adapter.toJson(instance)).isEqualTo(json)
   }
@@ -210,7 +210,7 @@ class GeneratedAdaptersTest {
     val invalidJson =
       """{"foo":null,"nullableString":null}"""
 
-    val instance = adapter.fromJson(json)!!
+    val instance = adapter.fromJson(json)
     assertThat(instance.foo).isEqualTo("foo")
     assertThat(instance.nullableString).isNull()
 
@@ -356,7 +356,7 @@ class GeneratedAdaptersTest {
     )
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -373,7 +373,7 @@ class GeneratedAdaptersTest {
     encoded.b = 5
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":3,"b":5}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":3,"b":5}""")
     assertThat(decoded.a).isEqualTo(3)
     assertThat(decoded.b).isEqualTo(5)
   }
@@ -394,7 +394,7 @@ class GeneratedAdaptersTest {
     encoded.b = 5
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -414,7 +414,7 @@ class GeneratedAdaptersTest {
     )
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -429,7 +429,7 @@ class GeneratedAdaptersTest {
     val encoded = ImmutableProperties(3, 5)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":3,"b":5}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":3,"b":5}""")
     assertThat(decoded.a).isEqualTo(3)
     assertThat(decoded.b).isEqualTo(5)
   }
@@ -450,7 +450,7 @@ class GeneratedAdaptersTest {
     )
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"b":6}""")
     assertThat(decoded.a).isEqualTo(-1)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -466,7 +466,7 @@ class GeneratedAdaptersTest {
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
     assertThat(jsonAdapter.serializeNulls().toJson(encoded)).isEqualTo("""{"a":null,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":null,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":null,"b":6}""")
     assertThat(decoded.a).isEqualTo(null)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -482,7 +482,7 @@ class GeneratedAdaptersTest {
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
     assertThat(jsonAdapter.serializeNulls().toJson(encoded)).isEqualTo("""{"a":null,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"b":6}""")
     assertThat(decoded.a).isNull()
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -502,7 +502,7 @@ class GeneratedAdaptersTest {
     )
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":"ANDROID","b":"Banana"}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":"Android","b":"Banana"}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":"Android","b":"Banana"}""")
     assertThat(decoded.a).isEqualTo("android")
     assertThat(decoded.b).isEqualTo("Banana")
   }
@@ -519,7 +519,7 @@ class GeneratedAdaptersTest {
     val encoded = ConstructorParameterWithQualifierInAnnotationPackage("Android")
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":"ANDROID"}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":"Android"}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":"Android"}""")
     assertThat(decoded.a).isEqualTo("android")
   }
 
@@ -537,7 +537,7 @@ class GeneratedAdaptersTest {
     encoded.b = "Banana"
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":"ANDROID","b":"Banana"}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":"Android","b":"Banana"}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":"Android","b":"Banana"}""")
     assertThat(decoded.a).isEqualTo("android")
     assertThat(decoded.b).isEqualTo("Banana")
   }
@@ -558,7 +558,7 @@ class GeneratedAdaptersTest {
     )
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"key a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"key a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"key a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -575,7 +575,7 @@ class GeneratedAdaptersTest {
     encoded.b = 5
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"key a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"key a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"key a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -596,7 +596,7 @@ class GeneratedAdaptersTest {
     )
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(-1)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -611,7 +611,7 @@ class GeneratedAdaptersTest {
     val encoded = MultipleTransientConstructorParameters(3, 5, 7)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(-1)
     assertThat(decoded.b).isEqualTo(6)
     assertThat(decoded.c).isEqualTo(-1)
@@ -630,7 +630,7 @@ class GeneratedAdaptersTest {
     encoded.c = 5
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"c":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":5,"c":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":5,"c":6}""")
     assertThat(decoded.a).isEqualTo(-1)
     assertThat(decoded.getB()).isEqualTo(-1)
     assertThat(decoded.c).isEqualTo(6)
@@ -658,7 +658,7 @@ class GeneratedAdaptersTest {
     encoded.c = 5
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"c":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":5,"c":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":5,"c":6}""")
     assertThat(decoded.a).isEqualTo(-1)
     assertThat(decoded.getB()).isEqualTo(-1)
     assertThat(decoded.c).isEqualTo(6)
@@ -710,7 +710,7 @@ class GeneratedAdaptersTest {
 
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo(json)
 
-    val decoded = jsonAdapter.fromJson(json)!!
+    val decoded = jsonAdapter.fromJson(json)
     assertThat(decoded.v01).isEqualTo(101)
     assertThat(decoded.v32).isEqualTo(132)
   }
@@ -780,7 +780,7 @@ class GeneratedAdaptersTest {
 
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo(json)
 
-    val decoded = jsonAdapter.fromJson(json)!!
+    val decoded = jsonAdapter.fromJson(json)
     assertThat(decoded.v01).isEqualTo(101)
     assertThat(decoded.v32).isEqualTo(132)
     assertThat(decoded.v33).isEqualTo(133)
@@ -831,7 +831,7 @@ class GeneratedAdaptersTest {
     encoded.b = 5
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(-1)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -849,7 +849,7 @@ class GeneratedAdaptersTest {
     val encoded = GetterOnly(3, 5)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.b).isEqualTo(6)
     assertThat(decoded.total).isEqualTo(10)
@@ -869,13 +869,13 @@ class GeneratedAdaptersTest {
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5,"total":8}""")
 
     // Whether b is 6 or 7 is an implementation detail. Currently we call constructors then setters.
-    val decoded1 = jsonAdapter.fromJson("""{"a":4,"b":6,"total":11}""")!!
+    val decoded1 = jsonAdapter.fromJson("""{"a":4,"b":6,"total":11}""")
     assertThat(decoded1.a).isEqualTo(4)
     assertThat(decoded1.b).isEqualTo(7)
     assertThat(decoded1.total).isEqualTo(11)
 
     // Whether b is 6 or 7 is an implementation detail. Currently we call constructors then setters.
-    val decoded2 = jsonAdapter.fromJson("""{"a":4,"total":11,"b":6}""")!!
+    val decoded2 = jsonAdapter.fromJson("""{"a":4,"total":11,"b":6}""")
     assertThat(decoded2.a).isEqualTo(4)
     assertThat(decoded2.b).isEqualTo(7)
     assertThat(decoded2.total).isEqualTo(11)
@@ -900,7 +900,7 @@ class GeneratedAdaptersTest {
     )
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -919,7 +919,7 @@ class GeneratedAdaptersTest {
     encoded.b = 5
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5,"a":3}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -973,7 +973,7 @@ class GeneratedAdaptersTest {
     val encoded = ExtensionProperty(3)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(4)
   }
 
@@ -1026,7 +1026,7 @@ class GeneratedAdaptersTest {
       )
     ).isEqualTo("""[1,2]""")
 
-    val fromJson = jsonAdapter.fromJson("""{"a":3,"b":4}""")!!
+    val fromJson = jsonAdapter.fromJson("""{"a":3,"b":4}""")
     assertThat(fromJson.a).isEqualTo(3)
     assertThat(fromJson.b).isEqualTo(4)
   }
@@ -1052,7 +1052,7 @@ class GeneratedAdaptersTest {
       )
     ).isEqualTo("""{"a":1,"b":2}""")
 
-    val fromJson = jsonAdapter.fromJson("""[3,4]""")!!
+    val fromJson = jsonAdapter.fromJson("""[3,4]""")
     assertThat(fromJson.a).isEqualTo(3)
     assertThat(fromJson.b).isEqualTo(4)
   }
@@ -1074,7 +1074,7 @@ class GeneratedAdaptersTest {
     privateTransient.b = 2
     assertThat(jsonAdapter.toJson(privateTransient)).isEqualTo("""{"b":2}""")
 
-    val fromJson = jsonAdapter.fromJson("""{"a":3,"b":4}""")!!
+    val fromJson = jsonAdapter.fromJson("""{"a":3,"b":4}""")
     assertThat(fromJson.readA()).isEqualTo(-1)
     assertThat(fromJson.b).isEqualTo(4)
   }
@@ -1103,7 +1103,7 @@ class GeneratedAdaptersTest {
     toJson.a = "1"
     assertThat(jsonAdapter.toJson(toJson)).isEqualTo("""{"a":"1","b":null}""")
 
-    val fromJson = jsonAdapter.fromJson("""{"a":"3","b":null}""")!!
+    val fromJson = jsonAdapter.fromJson("""{"a":"3","b":null}""")
     assertThat(fromJson.a).isEqualTo("3")
     assertNull(fromJson.b)
   }
@@ -1137,7 +1137,7 @@ class GeneratedAdaptersTest {
     )
       .isEqualTo("""{"twins":{"a":"1","b":"2"}}""")
 
-    val hasParameterizedProperty = jsonAdapter.fromJson("""{"twins":{"a":"3","b":"4"}}""")!!
+    val hasParameterizedProperty = jsonAdapter.fromJson("""{"twins":{"a":"3","b":"4"}}""")
     assertThat(hasParameterizedProperty.twins.a).isEqualTo("3")
     assertThat(hasParameterizedProperty.twins.b).isEqualTo("4")
   }
@@ -1151,7 +1151,7 @@ class GeneratedAdaptersTest {
   @Test fun uppercasePropertyName() {
     val adapter = moshi.adapter<UppercasePropertyName>()
 
-    val instance = adapter.fromJson("""{"AAA":1,"BBB":2}""")!!
+    val instance = adapter.fromJson("""{"AAA":1,"BBB":2}""")
     assertThat(instance.AAA).isEqualTo(1)
     assertThat(instance.BBB).isEqualTo(2)
 
@@ -1169,7 +1169,7 @@ class GeneratedAdaptersTest {
   @Test fun mutableUppercasePropertyName() {
     val adapter = moshi.adapter<MutableUppercasePropertyName>()
 
-    val instance = adapter.fromJson("""{"AAA":1,"BBB":2}""")!!
+    val instance = adapter.fromJson("""{"AAA":1,"BBB":2}""")
     assertThat(instance.AAA).isEqualTo(1)
     assertThat(instance.BBB).isEqualTo(2)
 
@@ -1238,7 +1238,7 @@ class GeneratedAdaptersTest {
 
   @Test fun adaptersAreNullSafe() {
     val moshi = Moshi.Builder().build()
-    val adapter = moshi.adapter<HasNullableBoolean>()
+    val adapter = moshi.adapter<HasNullableBoolean?>()
     assertThat(adapter.fromJson("null")).isNull()
     assertThat(adapter.toJson(null)).isEqualTo("null")
   }
@@ -1255,7 +1255,7 @@ class GeneratedAdaptersTest {
     )
     assertThat(adapter.toJson(encoded)).isEqualTo("""{"listOfInts":[1,2,-3]}""")
 
-    val decoded = adapter.fromJson("""{"listOfInts":[4,-5,6]}""")!!
+    val decoded = adapter.fromJson("""{"listOfInts":[4,-5,6]}""")
     assertThat(decoded).isEqualTo(
       HasCollectionOfPrimitives(
         listOf(4, -5, 6)
@@ -1269,6 +1269,7 @@ class GeneratedAdaptersTest {
   @Test fun customGenerator_withClassPresent() {
     val moshi = Moshi.Builder().build()
     val adapter = moshi.adapter<CustomGeneratedClass>()
+    @Suppress("UNCHECKED_CAST")
     val unwrapped = (adapter as NullSafeJsonAdapter<CustomGeneratedClass>).delegate
     assertThat(unwrapped).isInstanceOf(
       GeneratedAdaptersTest_CustomGeneratedClassJsonAdapter::class.java
@@ -1295,7 +1296,7 @@ class GeneratedAdaptersTest {
     val test = InternalPropertyWithoutBackingField()
     assertThat(adapter.toJson(test)).isEqualTo("""{"bar":5}""")
 
-    assertThat(adapter.fromJson("""{"bar":6}""")!!.bar).isEqualTo(6)
+    assertThat(adapter.fromJson("""{"bar":6}""").bar).isEqualTo(6)
   }
 
   @JsonClass(generateAdapter = true)
@@ -1323,7 +1324,7 @@ class GeneratedAdaptersTest {
     val moshi = Moshi.Builder().build()
     val adapter = moshi.adapter<ClassWithFieldJson>()
     //language=JSON
-    val instance = adapter.fromJson("""{"_links": "link", "_ids": "id" }""")!!
+    val instance = adapter.fromJson("""{"_links": "link", "_ids": "id" }""")
     assertThat(instance).isEqualTo(ClassWithFieldJson("link").apply { ids = "id" })
   }
 

--- a/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest_CustomGeneratedClassJsonAdapter.kt
+++ b/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest_CustomGeneratedClassJsonAdapter.kt
@@ -22,11 +22,11 @@ import com.squareup.moshi.kotlin.codegen.GeneratedAdaptersTest.CustomGeneratedCl
 
 // This also tests custom generated types with no moshi constructor
 class GeneratedAdaptersTest_CustomGeneratedClassJsonAdapter : JsonAdapter<CustomGeneratedClass>() {
-  override fun fromJson(reader: JsonReader): CustomGeneratedClass? {
+  override fun fromJson(reader: JsonReader): CustomGeneratedClass {
     TODO()
   }
 
-  override fun toJson(writer: JsonWriter, value: CustomGeneratedClass?) {
+  override fun toJson(writer: JsonWriter, value: CustomGeneratedClass) {
     TODO()
   }
 }

--- a/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/MoshiKspTest.kt
+++ b/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/MoshiKspTest.kt
@@ -31,7 +31,7 @@ class MoshiKspTest {
     //language=JSON
     val json = """{"a":"aValue","b":"bValue"}"""
     val expected = SimpleImpl("aValue", "bValue")
-    val instance = adapter.fromJson(json)!!
+    val instance = adapter.fromJson(json)
     assertThat(instance).isEqualTo(expected)
     val encoded = adapter.toJson(instance)
     assertThat(encoded).isEqualTo(json)

--- a/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/MultipleMasksTest.kt
+++ b/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/MultipleMasksTest.kt
@@ -42,7 +42,7 @@ class MultipleMasksTest {
       """{"arg50":500,"arg3":34,"arg11":11,"arg65":67}"""
 
     val instance = Moshi.Builder().build().adapter<MultipleMasks>()
-      .fromJson(json)!!
+      .fromJson(json)
 
     assertEquals(instance.arg2, 2)
     assertEquals(instance.arg3, 34)

--- a/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -238,7 +238,7 @@ class DualKotlinTest {
     assertThat(adapter.serializeNulls().toJson(encoded)).isEqualTo("""{"a":null}""")
 
     //language=JSON
-    val decoded = adapter.fromJson("""{"a":null}""")!!
+    val decoded = adapter.fromJson("""{"a":null}""")
     assertThat(decoded.a).isEqualTo(null)
   }
 
@@ -253,7 +253,7 @@ class DualKotlinTest {
 
     val testJson =
       """{"i":6}"""
-    val result = adapter.fromJson(testJson)!!
+    val result = adapter.fromJson(testJson)
     assertThat(result.i).isEqualTo(6)
 
     // TODO doesn't work yet. https://github.com/square/moshi/issues/1170
@@ -280,7 +280,7 @@ class DualKotlinTest {
     @Language("JSON")
     val testJson =
       """{"inline":{"i":42}}"""
-    val result = adapter.fromJson(testJson)!!
+    val result = adapter.fromJson(testJson)
     assertThat(result.inline.i).isEqualTo(42)
   }
 
@@ -294,7 +294,7 @@ class DualKotlinTest {
 
     assertThat(adapter.toJson(TextAssetMetaData("text"))).isEqualTo(testJson)
 
-    val result = adapter.fromJson(testJson)!!
+    val result = adapter.fromJson(testJson)
     assertThat(result.text).isEqualTo("text")
   }
 
@@ -361,7 +361,7 @@ class DualKotlinTest {
 
     assertThat(adapter.toJson(InternalAbstractProperty("text"))).isEqualTo(testJson)
 
-    val result = adapter.fromJson(testJson)!!
+    val result = adapter.fromJson(testJson)
     assertThat(result.test).isEqualTo("text")
   }
 
@@ -389,7 +389,7 @@ class DualKotlinTest {
     @Language("JSON")
     val testJson =
       """{"b":6}"""
-    val result = adapter.fromJson(testJson)!!
+    val result = adapter.fromJson(testJson)
     assertThat(result.b).isEqualTo(6)
   }
 
@@ -410,7 +410,7 @@ class DualKotlinTest {
 
     assertThat(adapter.toJson(MultipleNonPropertyParameters(7))).isEqualTo(testJson)
 
-    val result = adapter.fromJson(testJson)!!
+    val result = adapter.fromJson(testJson)
     assertThat(result.prop).isEqualTo(7)
   }
 
@@ -438,7 +438,7 @@ class DualKotlinTest {
     assertThat(adapter.toJson(OnlyMultipleNonPropertyParameters().apply { prop = 7 }))
       .isEqualTo(testJson)
 
-    val result = adapter.fromJson(testJson)!!
+    val result = adapter.fromJson(testJson)
     assertThat(result.prop).isEqualTo(7)
   }
 
@@ -476,7 +476,7 @@ class DualKotlinTest {
     )
     assertThat(adapter.toJson(testValue)).isEqualTo(testJson)
 
-    val result = adapter.fromJson(testJson)!!
+    val result = adapter.fromJson(testJson)
     assertThat(result).isEqualTo(testValue)
   }
 
@@ -511,7 +511,7 @@ class DualKotlinTest {
     assertThat(adapter.toJson(instance))
       .isEqualTo(testJson)
 
-    val result = adapter.fromJson(testJson)!!
+    val result = adapter.fromJson(testJson)
     assertThat(result).isEqualTo(instance)
   }
 
@@ -547,7 +547,7 @@ class DualKotlinTest {
     assertThat(adapter.serializeNulls().toJson(NullableList(null)))
       .isEqualTo(testJson)
 
-    val result = adapter.fromJson(testJson)!!
+    val result = adapter.fromJson(testJson)
     assertThat(result.nullableList).isNull()
   }
 
@@ -565,7 +565,7 @@ class DualKotlinTest {
     assertThat(adapter.serializeNulls().toJson(instance))
       .isEqualTo(testJson)
 
-    val result = adapter.fromJson(testJson)!!
+    val result = adapter.fromJson(testJson)
     assertThat(result).isEqualTo(instance)
   }
 
@@ -592,7 +592,7 @@ class DualKotlinTest {
     assertThat(adapter.serializeNulls().toJson(instance))
       .isEqualTo(testJson)
 
-    val result = adapter.fromJson(testJson)!!
+    val result = adapter.fromJson(testJson)
     assertThat(result).isEqualTo(instance)
   }
 
@@ -610,7 +610,7 @@ class DualKotlinTest {
     assertThat(adapter.serializeNulls().toJson(instance))
       .isEqualTo(testJson)
 
-    val result = adapter.fromJson(testJson)!!
+    val result = adapter.fromJson(testJson)
     assertThat(result).isEqualTo(instance)
   }
 
@@ -632,7 +632,7 @@ class DualKotlinTest {
     val encoded = TransientConstructorParameter(3, 5)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(-1)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -646,7 +646,7 @@ class DualKotlinTest {
     val encoded = MultipleTransientConstructorParameters(3, 5, 7)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(-1)
     assertThat(decoded.b).isEqualTo(6)
     assertThat(decoded.c).isEqualTo(-1)
@@ -664,7 +664,7 @@ class DualKotlinTest {
     encoded.c = 5
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"c":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":5,"c":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":5,"c":6}""")
     assertThat(decoded.a).isEqualTo(-1)
     assertThat(decoded.getB()).isEqualTo(-1)
     assertThat(decoded.c).isEqualTo(6)
@@ -689,7 +689,7 @@ class DualKotlinTest {
     val encoded = IgnoredConstructorParameter(3, 5)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(-1)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -703,7 +703,7 @@ class DualKotlinTest {
     val encoded = MultipleIgnoredConstructorParameters(3, 5, 7)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(-1)
     assertThat(decoded.b).isEqualTo(6)
     assertThat(decoded.c).isEqualTo(-1)
@@ -725,7 +725,7 @@ class DualKotlinTest {
     encoded.c = 5
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"c":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":5,"c":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":5,"c":6}""")
     assertThat(decoded.a).isEqualTo(-1)
     assertThat(decoded.getB()).isEqualTo(-1)
     assertThat(decoded.c).isEqualTo(6)

--- a/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -45,7 +45,7 @@ class KotlinJsonAdapterTest {
     val encoded = ConstructorParameters(3, 5)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -61,7 +61,7 @@ class KotlinJsonAdapterTest {
     encoded.b = 5
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":3,"b":5}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":3,"b":5}""")
     assertThat(decoded.a).isEqualTo(3)
     assertThat(decoded.b).isEqualTo(5)
   }
@@ -79,7 +79,7 @@ class KotlinJsonAdapterTest {
     encoded.b = 5
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -95,7 +95,7 @@ class KotlinJsonAdapterTest {
     val encoded = ImmutableConstructorParameters(3, 5)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -109,7 +109,7 @@ class KotlinJsonAdapterTest {
     val encoded = ImmutableProperties(3, 5)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":3,"b":5}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":3,"b":5}""")
     assertThat(decoded.a).isEqualTo(3)
     assertThat(decoded.b).isEqualTo(5)
   }
@@ -126,7 +126,7 @@ class KotlinJsonAdapterTest {
     val encoded = ConstructorDefaultValues(3, 5)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"b":6}""")
     assertThat(decoded.a).isEqualTo(-1)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -172,7 +172,7 @@ class KotlinJsonAdapterTest {
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
     assertThat(jsonAdapter.serializeNulls().toJson(encoded)).isEqualTo("""{"a":null,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":null,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":null,"b":6}""")
     assertThat(decoded.a).isEqualTo(null)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -187,7 +187,7 @@ class KotlinJsonAdapterTest {
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
     assertThat(jsonAdapter.serializeNulls().toJson(encoded)).isEqualTo("""{"a":null,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"b":6}""")
     assertThat(decoded.a).isNull()
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -218,7 +218,7 @@ class KotlinJsonAdapterTest {
     val encoded = ConstructorParameterWithQualifier("Android", "Banana")
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":"ANDROID","b":"Banana"}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":"Android","b":"Banana"}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":"Android","b":"Banana"}""")
     assertThat(decoded.a).isEqualTo("android")
     assertThat(decoded.b).isEqualTo("Banana")
   }
@@ -237,7 +237,7 @@ class KotlinJsonAdapterTest {
     encoded.b = "Banana"
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":"ANDROID","b":"Banana"}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":"Android","b":"Banana"}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":"Android","b":"Banana"}""")
     assertThat(decoded.a).isEqualTo("android")
     assertThat(decoded.b).isEqualTo("Banana")
   }
@@ -254,7 +254,7 @@ class KotlinJsonAdapterTest {
     val encoded = ConstructorParameterWithJsonName(3, 5)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"key a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"key a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"key a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -270,7 +270,7 @@ class KotlinJsonAdapterTest {
     encoded.b = 5
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"key a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"key a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"key a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -336,7 +336,7 @@ class KotlinJsonAdapterTest {
     val encoded = SubtypeConstructorParameters(3, 5)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -354,7 +354,7 @@ class KotlinJsonAdapterTest {
     encoded.b = 5
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5,"a":3}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -374,7 +374,7 @@ class KotlinJsonAdapterTest {
     val encoded = ExtendsPlatformClassWithPrivateField(3)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"id":"B"}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"id":"B"}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.id).isEqualTo("C")
   }
@@ -388,7 +388,7 @@ class KotlinJsonAdapterTest {
     val encoded = ExtendsPlatformClassWithProtectedField(3)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"buf":[0,0],"count":0}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"buf":[0,0],"size":0}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"buf":[0,0],"size":0}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.buf()).isEqualTo(ByteArray(2) { 0 })
     assertThat(decoded.count()).isEqualTo(0)
@@ -418,7 +418,7 @@ class KotlinJsonAdapterTest {
     val encoded = PrivateConstructorParameters(3, 5)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a()).isEqualTo(4)
     assertThat(decoded.b()).isEqualTo(6)
   }
@@ -435,7 +435,7 @@ class KotlinJsonAdapterTest {
     val encoded = PrivateConstructor.newInstance(3, 5)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a()).isEqualTo(4)
     assertThat(decoded.b()).isEqualTo(6)
   }
@@ -457,7 +457,7 @@ class KotlinJsonAdapterTest {
     encoded.b(5)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a()).isEqualTo(4)
     assertThat(decoded.b()).isEqualTo(6)
   }
@@ -487,7 +487,7 @@ class KotlinJsonAdapterTest {
     encoded.b = 5
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(-1)
     assertThat(decoded.b).isEqualTo(6)
   }
@@ -504,7 +504,7 @@ class KotlinJsonAdapterTest {
     val encoded = GetterOnly(3, 5)
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
+    val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")
     assertThat(decoded.a).isEqualTo(4)
     assertThat(decoded.b).isEqualTo(6)
     assertThat(decoded.total).isEqualTo(10)
@@ -523,13 +523,13 @@ class KotlinJsonAdapterTest {
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5,"total":8}""")
 
     // Whether b is 6 or 7 is an implementation detail. Currently we call constructors then setters.
-    val decoded1 = jsonAdapter.fromJson("""{"a":4,"b":6,"total":11}""")!!
+    val decoded1 = jsonAdapter.fromJson("""{"a":4,"b":6,"total":11}""")
     assertThat(decoded1.a).isEqualTo(4)
     assertThat(decoded1.b).isEqualTo(7)
     assertThat(decoded1.total).isEqualTo(11)
 
     // Whether b is 6 or 7 is an implementation detail. Currently we call constructors then setters.
-    val decoded2 = jsonAdapter.fromJson("""{"a":4,"total":11,"b":6}""")!!
+    val decoded2 = jsonAdapter.fromJson("""{"a":4,"total":11,"b":6}""")
     assertThat(decoded2.a).isEqualTo(4)
     assertThat(decoded2.b).isEqualTo(7)
     assertThat(decoded2.total).isEqualTo(11)
@@ -578,8 +578,7 @@ class KotlinJsonAdapterTest {
       fail()
     } catch (e: IllegalArgumentException) {
       assertThat(e).hasMessageThat().isEqualTo(
-        "No JsonAdapter for interface " +
-          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$Interface (with no annotations)"
+        "No JsonAdapter for com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest.Interface (with no annotations)"
       )
     }
   }
@@ -700,7 +699,7 @@ class KotlinJsonAdapterTest {
 
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo(json)
 
-    val decoded = jsonAdapter.fromJson(json)!!
+    val decoded = jsonAdapter.fromJson(json)
     assertThat(decoded.v01).isEqualTo(101)
     assertThat(decoded.v32).isEqualTo(132)
   }
@@ -769,7 +768,7 @@ class KotlinJsonAdapterTest {
 
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo(json)
 
-    val decoded = jsonAdapter.fromJson(json)!!
+    val decoded = jsonAdapter.fromJson(json)
     assertThat(decoded.v01).isEqualTo(101)
     assertThat(decoded.v32).isEqualTo(132)
     assertThat(decoded.v33).isEqualTo(133)

--- a/moshi-kotlin/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterFactory.kt
+++ b/moshi-kotlin/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterFactory.kt
@@ -27,9 +27,9 @@ import com.squareup.moshi.internal.isPlatformType
 import com.squareup.moshi.internal.jsonAnnotations
 import com.squareup.moshi.internal.missingProperty
 import com.squareup.moshi.internal.resolve
-import com.squareup.moshi.internal.toKType
 import com.squareup.moshi.internal.unexpectedNull
 import com.squareup.moshi.rawType
+import com.squareup.moshi.toKType
 import java.lang.reflect.Modifier
 import java.lang.reflect.Type
 import kotlin.reflect.KClass

--- a/moshi-kotlin/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterFactory.kt
+++ b/moshi-kotlin/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterFactory.kt
@@ -27,6 +27,7 @@ import com.squareup.moshi.internal.isPlatformType
 import com.squareup.moshi.internal.jsonAnnotations
 import com.squareup.moshi.internal.missingProperty
 import com.squareup.moshi.internal.resolve
+import com.squareup.moshi.internal.toKType
 import com.squareup.moshi.internal.unexpectedNull
 import com.squareup.moshi.rawType
 import java.lang.reflect.Modifier
@@ -62,7 +63,7 @@ internal class KotlinJsonAdapter<T>(
   val allBindings: List<Binding<T, Any?>?>,
   val nonIgnoredBindings: List<Binding<T, Any?>>,
   val options: JsonReader.Options
-) : JsonAdapter<T>() {
+) : JsonAdapter<T?>() {
 
   override fun fromJson(reader: JsonReader): T {
     val constructorSize = constructor.parameters.size
@@ -293,7 +294,8 @@ public class KotlinJsonAdapterFactory : JsonAdapter.Factory {
       }
       val resolvedPropertyType = propertyType.resolve(type, rawType)
       val adapter = moshi.adapter<Any?>(
-        resolvedPropertyType,
+        // TODO can we just use property.returnType directly now?
+        resolvedPropertyType.toKType(isMarkedNullable = property.returnType.isMarkedNullable),
         allAnnotations.toTypedArray().jsonAnnotations,
         property.name
       )

--- a/moshi/japicmp/build.gradle.kts
+++ b/moshi/japicmp/build.gradle.kts
@@ -45,6 +45,7 @@ val japicmp = tasks.register<JapicmpTask>("japicmp") {
     "com.squareup.moshi.internal.Util#jsonName(java.lang.String, java.lang.reflect.AnnotatedElement)",
     "com.squareup.moshi.internal.Util#resolve(java.lang.reflect.Type, java.lang.Class, java.lang.reflect.Type)",
     "com.squareup.moshi.internal.Util#typeAnnotatedWithAnnotations(java.lang.reflect.Type, java.util.Set)",
+    "com.squareup.moshi.internal.Util#removeSubtypeWildcard(java.lang.reflect.Type)",
   )
   fieldExcludes = listOf(
     "com.squareup.moshi.CollectionJsonAdapter#FACTORY", // False-positive, class is not public anyway

--- a/moshi/records-tests/src/test/java/com/squareup/moshi/records/RecordsTest.java
+++ b/moshi/records-tests/src/test/java/com/squareup/moshi/records/RecordsTest.java
@@ -268,7 +268,7 @@ public final class RecordsTest {
       adapter.fromJson("{\"s\":\"\",\"i\":null}");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected an int but was NULL at path $.i");
+      assertThat(expected).hasMessageThat().isEqualTo("Non-null value was null at $.i");
     }
   }
 

--- a/moshi/src/main/java/com/squareup/moshi/-MoshiKotlinExtensions.kt
+++ b/moshi/src/main/java/com/squareup/moshi/-MoshiKotlinExtensions.kt
@@ -17,8 +17,6 @@
 
 package com.squareup.moshi
 
-import com.squareup.moshi.internal.NonNullJsonAdapter
-import com.squareup.moshi.internal.NullSafeJsonAdapter
 import kotlin.reflect.KType
 import kotlin.reflect.javaType
 import kotlin.reflect.typeOf
@@ -42,13 +40,5 @@ public inline fun <reified T> Moshi.Builder.addAdapter(adapter: JsonAdapter<T>):
 @Deprecated("Use the Moshi instance version instead", level = DeprecationLevel.HIDDEN)
 @ExperimentalStdlibApi
 public fun <T> Moshi.adapter(ktype: KType): JsonAdapter<T> {
-  val adapter = adapter<T>(ktype.javaType)
-  return if (adapter is NullSafeJsonAdapter || adapter is NonNullJsonAdapter) {
-    // TODO CR - Assume that these know what they're doing? Or should we defensively avoid wrapping for matching nullability?
-    adapter
-  } else if (ktype.isMarkedNullable) {
-    adapter.nullSafe()
-  } else {
-    adapter.nonNull()
-  }
+  return this.adapter(ktype)
 }

--- a/moshi/src/main/java/com/squareup/moshi/-MoshiKotlinExtensions.kt
+++ b/moshi/src/main/java/com/squareup/moshi/-MoshiKotlinExtensions.kt
@@ -18,7 +18,6 @@
 package com.squareup.moshi
 
 import kotlin.reflect.KType
-import kotlin.reflect.javaType
 import kotlin.reflect.typeOf
 
 /**
@@ -26,19 +25,16 @@ import kotlin.reflect.typeOf
  *         itself is handled, nested types (such as in generics) are not resolved.
  */
 @Deprecated("Use the Moshi instance version instead", level = DeprecationLevel.HIDDEN)
-@ExperimentalStdlibApi
 public inline fun <reified T> Moshi.adapter(): JsonAdapter<T> = adapter(typeOf<T>())
 
 @Deprecated("Use the Moshi instance version instead", level = DeprecationLevel.HIDDEN)
-@ExperimentalStdlibApi
-public inline fun <reified T> Moshi.Builder.addAdapter(adapter: JsonAdapter<T>): Moshi.Builder = add(typeOf<T>().javaType, adapter)
+public inline fun <reified T> Moshi.Builder.addAdapter(adapter: JsonAdapter<T>): Moshi.Builder = add(typeOf<T>(), adapter)
 
 /**
  * @return a [JsonAdapter] for [ktype], creating it if necessary. Note that while nullability of
  *         [ktype] itself is handled, nested types (such as in generics) are not resolved.
  */
 @Deprecated("Use the Moshi instance version instead", level = DeprecationLevel.HIDDEN)
-@ExperimentalStdlibApi
 public fun <T> Moshi.adapter(ktype: KType): JsonAdapter<T> {
   return this.adapter(ktype)
 }

--- a/moshi/src/main/java/com/squareup/moshi/AdapterMethodsFactory.kt
+++ b/moshi/src/main/java/com/squareup/moshi/AdapterMethodsFactory.kt
@@ -40,13 +40,13 @@ internal class AdapterMethodsFactory(
     val fromAdapter = get(fromAdapters, type, annotations)
     if (toAdapter == null && fromAdapter == null) return null
 
-    val delegate: JsonAdapter<Any>? = if (toAdapter == null || fromAdapter == null) {
+    val delegate: JsonAdapter<Any?>? = if (toAdapter == null || fromAdapter == null) {
       try {
         moshi.nextAdapter(this, type, annotations)
       } catch (e: IllegalArgumentException) {
         val missingAnnotation = if (toAdapter == null) "@ToJson" else "@FromJson"
         throw IllegalArgumentException(
-          "No $missingAnnotation adapter for ${type.toStringWithAnnotations(annotations)}",
+          "No $missingAnnotation adapter for ${type.canonicalize().toStringWithAnnotations(annotations)}",
           e
         )
       }
@@ -57,7 +57,7 @@ internal class AdapterMethodsFactory(
     toAdapter?.bind(moshi, this)
     fromAdapter?.bind(moshi, this)
 
-    return object : JsonAdapter<Any>() {
+    return object : JsonAdapter<Any?>() {
       override fun toJson(writer: JsonWriter, value: Any?) {
         when {
           toAdapter == null -> knownNotNull(delegate).toJson(writer, value)
@@ -176,7 +176,7 @@ internal class AdapterMethodsFactory(
             nullable = nullable
           ) {
 
-            private lateinit var delegate: JsonAdapter<Any>
+            private lateinit var delegate: JsonAdapter<Any?>
 
             override fun bind(moshi: Moshi, factory: JsonAdapter.Factory) {
               super.bind(moshi, factory)

--- a/moshi/src/main/java/com/squareup/moshi/AdapterMethodsFactory.kt
+++ b/moshi/src/main/java/com/squareup/moshi/AdapterMethodsFactory.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.moshi
 
+import com.squareup.moshi.internal.NullAwareJsonAdapter
 import com.squareup.moshi.internal.canonicalize
 import com.squareup.moshi.internal.checkNull
 import com.squareup.moshi.internal.hasNullable
@@ -57,7 +58,7 @@ internal class AdapterMethodsFactory(
     toAdapter?.bind(moshi, this)
     fromAdapter?.bind(moshi, this)
 
-    return object : JsonAdapter<Any?>() {
+    return object : NullAwareJsonAdapter<Any?>() {
       override fun toJson(writer: JsonWriter, value: Any?) {
         when {
           toAdapter == null -> knownNotNull(delegate).toJson(writer, value)

--- a/moshi/src/main/java/com/squareup/moshi/ArrayJsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/ArrayJsonAdapter.kt
@@ -24,10 +24,10 @@ import java.lang.reflect.Array as JavaArray
  */
 internal class ArrayJsonAdapter(
   private val elementClass: Class<*>,
-  private val elementAdapter: JsonAdapter<Any>
-) : JsonAdapter<Any?>() {
+  private val elementAdapter: JsonAdapter<Any?>
+) : JsonAdapter<Any>() {
   override fun fromJson(reader: JsonReader): Any {
-    val list = buildList<Any?> {
+    val list = buildList {
       reader.beginArray()
       while (reader.hasNext()) {
         add(elementAdapter.fromJson(reader))
@@ -41,7 +41,7 @@ internal class ArrayJsonAdapter(
     return array
   }
 
-  override fun toJson(writer: JsonWriter, value: Any?) {
+  override fun toJson(writer: JsonWriter, value: Any) {
     writer.beginArray()
     when (value) {
       is BooleanArray -> {
@@ -100,7 +100,7 @@ internal class ArrayJsonAdapter(
       val elementType = Types.arrayComponentType(type) ?: return null
       if (annotations.isNotEmpty()) return null
       val elementClass = elementType.rawType
-      val elementAdapter = moshi.adapter<Any>(elementType)
+      val elementAdapter = moshi.adapter<Any?>(elementType)
       return ArrayJsonAdapter(elementClass, elementAdapter).nullSafe()
     }
   }

--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.kt
@@ -22,6 +22,7 @@ import com.squareup.moshi.internal.jsonAnnotations
 import com.squareup.moshi.internal.jsonName
 import com.squareup.moshi.internal.resolve
 import com.squareup.moshi.internal.rethrowCause
+import com.squareup.moshi.internal.toKType
 import java.lang.reflect.Field
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Modifier.isAbstract
@@ -83,7 +84,7 @@ internal class ClassJsonAdapter<T>(
     }
   }
 
-  override fun toJson(writer: JsonWriter, value: T?) {
+  override fun toJson(writer: JsonWriter, value: T) {
     try {
       writer.beginObject()
       for (fieldBinding in fieldsArray) {
@@ -199,7 +200,7 @@ internal class ClassJsonAdapter<T>(
         val annotations = field.jsonAnnotations
         val fieldName = field.name
         val adapter = moshi.adapter<Any>(
-          type = fieldType,
+          type = fieldType.toKType(isMarkedNullable = true), // TODO check for nullable annotations?
           annotations = annotations,
           fieldName = fieldName
         )

--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.kt
@@ -22,7 +22,7 @@ import com.squareup.moshi.internal.jsonAnnotations
 import com.squareup.moshi.internal.jsonName
 import com.squareup.moshi.internal.resolve
 import com.squareup.moshi.internal.rethrowCause
-import com.squareup.moshi.internal.toKType
+import com.squareup.moshi.toKType
 import java.lang.reflect.Field
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Modifier.isAbstract

--- a/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/ClassJsonAdapter.kt
@@ -22,7 +22,6 @@ import com.squareup.moshi.internal.jsonAnnotations
 import com.squareup.moshi.internal.jsonName
 import com.squareup.moshi.internal.resolve
 import com.squareup.moshi.internal.rethrowCause
-import com.squareup.moshi.toKType
 import java.lang.reflect.Field
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Modifier.isAbstract

--- a/moshi/src/main/java/com/squareup/moshi/CollectionJsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/CollectionJsonAdapter.kt
@@ -15,12 +15,11 @@
  */
 package com.squareup.moshi
 
-import com.squareup.moshi.internal.markNotNull
 import java.lang.reflect.Type
 
 /** Converts collection types to JSON arrays containing their converted contents. */
 internal abstract class CollectionJsonAdapter<C : MutableCollection<T?>, T> private constructor(
-  private val elementAdapter: JsonAdapter<T>
+  private val elementAdapter: JsonAdapter<T?>
 ) : JsonAdapter<C>() {
 
   abstract fun newCollection(): C
@@ -35,8 +34,7 @@ internal abstract class CollectionJsonAdapter<C : MutableCollection<T?>, T> priv
     return result
   }
 
-  override fun toJson(writer: JsonWriter, value: C?) {
-    markNotNull(value) // Always wrapped in nullSafe()
+  override fun toJson(writer: JsonWriter, value: C) {
     writer.beginArray()
     for (element in value) {
       elementAdapter.toJson(writer, element)
@@ -62,7 +60,7 @@ internal abstract class CollectionJsonAdapter<C : MutableCollection<T?>, T> priv
 
     private fun <T> newArrayListAdapter(type: Type, moshi: Moshi): JsonAdapter<MutableCollection<T?>> {
       val elementType = Types.collectionElementType(type, Collection::class.java)
-      val elementAdapter = moshi.adapter<T>(elementType)
+      val elementAdapter = moshi.adapter<T?>(elementType)
       return object : CollectionJsonAdapter<MutableCollection<T?>, T>(elementAdapter) {
         override fun newCollection(): MutableCollection<T?> = ArrayList()
       }
@@ -70,7 +68,7 @@ internal abstract class CollectionJsonAdapter<C : MutableCollection<T?>, T> priv
 
     private fun <T> newLinkedHashSetAdapter(type: Type, moshi: Moshi): JsonAdapter<MutableSet<T?>> {
       val elementType = Types.collectionElementType(type, Collection::class.java)
-      val elementAdapter = moshi.adapter<T>(elementType)
+      val elementAdapter = moshi.adapter<T?>(elementType)
       return object : CollectionJsonAdapter<MutableSet<T?>, T>(elementAdapter) {
         override fun newCollection(): MutableSet<T?> = LinkedHashSet()
       }

--- a/moshi/src/main/java/com/squareup/moshi/JsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/JsonAdapter.kt
@@ -25,6 +25,7 @@ import org.intellij.lang.annotations.Language
 import java.lang.reflect.Type
 import javax.annotation.CheckReturnValue
 import kotlin.Throws
+import kotlin.reflect.KType
 
 /**
  * Converts Java values to JSON, and JSON values to Java.
@@ -283,7 +284,7 @@ public abstract class JsonAdapter<T> {
 
   public fun interface Factory {
     /**
-     * Attempts to create an adapter for `type` annotated with `annotations`. This
+     * Attempts to create an adapter for [type] annotated with [annotations]. This
      * returns the adapter if one was created, or null if this factory isn't capable of creating
      * such an adapter.
      *
@@ -293,4 +294,20 @@ public abstract class JsonAdapter<T> {
     @CheckReturnValue
     public fun create(type: Type, annotations: Set<Annotation>, moshi: Moshi): JsonAdapter<*>?
   }
+
+  public fun interface KFactory {
+    /**
+     * Attempts to create an adapter for [type] annotated with [annotations]. This
+     * returns the adapter if one was created, or null if this factory isn't capable of creating
+     * such an adapter.
+     *
+     * Implementations may use [Moshi.adapter] to compose adapters of other types, or
+     * [Moshi.nextAdapter] to delegate to the underlying adapter of the same type.
+     */
+    @CheckReturnValue
+    public fun create(type: KType, annotations: Set<Annotation>, moshi: Moshi): JsonAdapter<*>?
+  }
 }
+
+/** Returns a new [JsonAdapter.KFactory] wrapper around this [JsonAdapter.Factory]. */
+public fun JsonAdapter.Factory.asKFactory(): JsonAdapter.KFactory = InteropKFactory(this)

--- a/moshi/src/main/java/com/squareup/moshi/JsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/JsonAdapter.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.moshi
 
+import com.squareup.moshi.internal.InteropKFactory
 import com.squareup.moshi.internal.NonNullJsonAdapter
 import com.squareup.moshi.internal.NullSafeJsonAdapter
 import okio.Buffer
@@ -44,7 +45,7 @@ public abstract class JsonAdapter<T> {
    */
   @CheckReturnValue
   @Throws(IOException::class)
-  public abstract fun fromJson(reader: JsonReader): T?
+  public abstract fun fromJson(reader: JsonReader): T
 
   /**
    * Decodes a nullable instance of type [T] from the given [source].
@@ -54,7 +55,7 @@ public abstract class JsonAdapter<T> {
    */
   @CheckReturnValue
   @Throws(IOException::class)
-  public fun fromJson(source: BufferedSource): T? = fromJson(JsonReader.of(source))
+  public fun fromJson(source: BufferedSource): T = fromJson(JsonReader.of(source))
 
   /**
    * Decodes a nullable instance of type [T] from the given `string`.
@@ -64,7 +65,7 @@ public abstract class JsonAdapter<T> {
    */
   @CheckReturnValue
   @Throws(IOException::class)
-  public fun fromJson(@Language("JSON") string: String): T? {
+  public fun fromJson(@Language("JSON") string: String): T {
     val reader = JsonReader.of(Buffer().writeUtf8(string))
     val result = fromJson(reader)
     if (!isLenient && reader.peek() != JsonReader.Token.END_DOCUMENT) {
@@ -75,17 +76,17 @@ public abstract class JsonAdapter<T> {
 
   /** Encodes the given [value] with the given [writer]. */
   @Throws(IOException::class)
-  public abstract fun toJson(writer: JsonWriter, value: T?)
+  public abstract fun toJson(writer: JsonWriter, value: T)
 
   @Throws(IOException::class)
-  public fun toJson(sink: BufferedSink, value: T?) {
+  public fun toJson(sink: BufferedSink, value: T) {
     val writer = JsonWriter.of(sink)
     toJson(writer, value)
   }
 
   /** Encodes the given [value] into a String and returns it. */
   @CheckReturnValue
-  public fun toJson(value: T?): String {
+  public fun toJson(value: T): String {
     val buffer = Buffer()
     try {
       toJson(buffer, value)
@@ -105,7 +106,7 @@ public abstract class JsonAdapter<T> {
    * and as a [java.math.BigDecimal] for all other types.
    */
   @CheckReturnValue
-  public fun toJsonValue(value: T?): Any? {
+  public fun toJsonValue(value: T): Any? {
     val writer = JsonValueWriter()
     return try {
       toJson(writer, value)
@@ -139,7 +140,7 @@ public abstract class JsonAdapter<T> {
     return object : JsonAdapter<T>() {
       override fun fromJson(reader: JsonReader) = delegate.fromJson(reader)
 
-      override fun toJson(writer: JsonWriter, value: T?) {
+      override fun toJson(writer: JsonWriter, value: T) {
         val serializeNulls = writer.serializeNulls
         writer.serializeNulls = true
         try {
@@ -161,9 +162,10 @@ public abstract class JsonAdapter<T> {
    * nulls.
    */
   @CheckReturnValue
-  public fun nullSafe(): JsonAdapter<T> {
+  public fun nullSafe(): JsonAdapter<T?> {
+    @Suppress("UNCHECKED_CAST")
     return when (this) {
-      is NullSafeJsonAdapter<*> -> this
+      is NullSafeJsonAdapter<*> -> this as JsonAdapter<T?>
       else -> NullSafeJsonAdapter(this)
     }
   }
@@ -176,10 +178,11 @@ public abstract class JsonAdapter<T> {
    * handled elsewhere. This should only be used to fail on explicit nulls.
    */
   @CheckReturnValue
-  public fun nonNull(): JsonAdapter<T> {
+  public fun nonNull(): JsonAdapter<T & Any> {
+    @Suppress("UNCHECKED_CAST")
     return when (this) {
-      is NonNullJsonAdapter<*> -> this
-      else -> NonNullJsonAdapter(this)
+      is NonNullJsonAdapter<*> -> this as JsonAdapter<T & Any>
+      else -> NonNullJsonAdapter(this) as JsonAdapter<T & Any>
     }
   }
 
@@ -188,7 +191,7 @@ public abstract class JsonAdapter<T> {
   public fun lenient(): JsonAdapter<T> {
     val delegate: JsonAdapter<T> = this
     return object : JsonAdapter<T>() {
-      override fun fromJson(reader: JsonReader): T? {
+      override fun fromJson(reader: JsonReader): T {
         val lenient = reader.lenient
         reader.lenient = true
         return try {
@@ -198,7 +201,7 @@ public abstract class JsonAdapter<T> {
         }
       }
 
-      override fun toJson(writer: JsonWriter, value: T?) {
+      override fun toJson(writer: JsonWriter, value: T) {
         val lenient = writer.isLenient
         writer.isLenient = true
         try {
@@ -217,7 +220,7 @@ public abstract class JsonAdapter<T> {
 
   /**
    * Returns a JSON adapter equal to this, but that throws a [JsonDataException] when
-   * [unknown names and values][JsonReader.setFailOnUnknown] are encountered.
+   * [unknown names and values][JsonReader.failOnUnknown] are encountered.
    * This constraint applies to both the top-level message handled by this type adapter as well as
    * to nested messages.
    */
@@ -225,7 +228,7 @@ public abstract class JsonAdapter<T> {
   public fun failOnUnknown(): JsonAdapter<T> {
     val delegate: JsonAdapter<T> = this
     return object : JsonAdapter<T>() {
-      override fun fromJson(reader: JsonReader): T? {
+      override fun fromJson(reader: JsonReader): T {
         val skipForbidden = reader.failOnUnknown
         reader.failOnUnknown = true
         return try {
@@ -235,7 +238,7 @@ public abstract class JsonAdapter<T> {
         }
       }
 
-      override fun toJson(writer: JsonWriter, value: T?) {
+      override fun toJson(writer: JsonWriter, value: T) {
         delegate.toJson(writer, value)
       }
 
@@ -258,11 +261,11 @@ public abstract class JsonAdapter<T> {
   public fun indent(indent: String): JsonAdapter<T> {
     val delegate: JsonAdapter<T> = this
     return object : JsonAdapter<T>() {
-      override fun fromJson(reader: JsonReader): T? {
+      override fun fromJson(reader: JsonReader): T {
         return delegate.fromJson(reader)
       }
 
-      override fun toJson(writer: JsonWriter, value: T?) {
+      override fun toJson(writer: JsonWriter, value: T) {
         val originalIndent = writer.indent
         writer.indent = indent
         try {

--- a/moshi/src/main/java/com/squareup/moshi/KTypes.kt
+++ b/moshi/src/main/java/com/squareup/moshi/KTypes.kt
@@ -1,0 +1,74 @@
+@file:JvmName("KTypes")
+package com.squareup.moshi
+
+import com.squareup.moshi.internal.KTypeImpl
+import com.squareup.moshi.internal.KTypeParameterImpl
+import com.squareup.moshi.internal.stripWildcards
+import java.lang.reflect.GenericArrayType
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.lang.reflect.TypeVariable
+import java.lang.reflect.WildcardType
+import kotlin.reflect.KType
+import kotlin.reflect.KTypeProjection
+import kotlin.reflect.KVariance.INVARIANT
+
+/**
+ * Creates a new [KType] representation of this [Type] for use with Moshi serialization. Note that
+ * [wildcards][WildcardType] are stripped away in [type projections][KTypeProjection] as they are
+ * not relevant for serialization and are also not standalone [KType] subtypes in Kotlin.
+ */
+public fun Type.toKType(
+  isMarkedNullable: Boolean = false,
+  annotations: List<Annotation> = emptyList()
+): KType {
+  return when (this) {
+    is Class<*> -> KTypeImpl(kotlin, emptyList(), isMarkedNullable, annotations)
+    is ParameterizedType -> KTypeImpl(
+      classifier = (rawType as Class<*>).kotlin,
+      arguments = actualTypeArguments.map { it.toKTypeProjection() },
+      isMarkedNullable = isMarkedNullable,
+      annotations = annotations
+    )
+    is GenericArrayType -> {
+      KTypeImpl(
+        classifier = rawType.kotlin,
+        arguments = listOf(genericComponentType.toKTypeProjection()),
+        isMarkedNullable = isMarkedNullable,
+        annotations = annotations
+      )
+    }
+    is WildcardType -> stripWildcards().toKType(isMarkedNullable, annotations)
+    is TypeVariable<*> -> KTypeImpl(
+      classifier = KTypeParameterImpl(false, name, bounds.map { it.toKType() }, INVARIANT),
+      arguments = emptyList(),
+      isMarkedNullable = isMarkedNullable,
+      annotations = annotations
+    )
+    else -> throw IllegalArgumentException("Unsupported type: $this")
+  }
+}
+
+/**
+ * Creates a new [KTypeProjection] representation of this [Type] for use in [KType.arguments].
+ */
+public fun Type.toKTypeProjection(): KTypeProjection {
+  return when (this) {
+    is Class<*>, is ParameterizedType, is TypeVariable<*> -> KTypeProjection.invariant(toKType())
+    is WildcardType -> {
+      val lowerBounds = lowerBounds
+      val upperBounds = upperBounds
+      if (lowerBounds.isEmpty() && upperBounds.isEmpty()) {
+        return KTypeProjection.STAR
+      }
+      return if (lowerBounds.isNotEmpty()) {
+        KTypeProjection.contravariant(lowerBounds[0].toKType())
+      } else {
+        KTypeProjection.invariant(upperBounds[0].toKType())
+      }
+    }
+    else -> {
+      TODO("Unsupported type: $this")
+    }
+  }
+}

--- a/moshi/src/main/java/com/squareup/moshi/MapJsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/MapJsonAdapter.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.moshi
 
-import com.squareup.moshi.internal.knownNotNull
 import java.lang.reflect.Type
 
 /**
@@ -25,12 +24,11 @@ import java.lang.reflect.Type
  */
 internal class MapJsonAdapter<K, V>(moshi: Moshi, keyType: Type, valueType: Type) : JsonAdapter<Map<K, V?>>() {
   private val keyAdapter: JsonAdapter<K> = moshi.adapter(keyType)
-  private val valueAdapter: JsonAdapter<V> = moshi.adapter(valueType)
+  private val valueAdapter: JsonAdapter<V?> = moshi.adapter(valueType)
 
-  override fun toJson(writer: JsonWriter, value: Map<K, V?>?) {
+  override fun toJson(writer: JsonWriter, value: Map<K, V?>) {
     writer.beginObject()
-    // Never null because we wrap in nullSafe()
-    for ((k, v) in knownNotNull(value)) {
+    for ((k, v) in value) {
       if (k == null) {
         throw JsonDataException("Map key is null at ${writer.path}")
       }

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.kt
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.kt
@@ -20,7 +20,6 @@ import com.squareup.moshi.internal.NO_ANNOTATIONS
 import com.squareup.moshi.internal.NullAwareJsonAdapter
 import com.squareup.moshi.internal.canonicalize
 import com.squareup.moshi.internal.isAnnotationPresent
-import com.squareup.moshi.toKType
 import com.squareup.moshi.internal.toStringWithAnnotations
 import com.squareup.moshi.internal.typesMatch
 import java.lang.reflect.Type

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.kt
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.kt
@@ -17,8 +17,7 @@ package com.squareup.moshi
 
 import com.squareup.moshi.Types.createJsonQualifierImplementation
 import com.squareup.moshi.internal.NO_ANNOTATIONS
-import com.squareup.moshi.internal.NonNullJsonAdapter
-import com.squareup.moshi.internal.NullSafeJsonAdapter
+import com.squareup.moshi.internal.NullAwareJsonAdapter
 import com.squareup.moshi.internal.canonicalize
 import com.squareup.moshi.internal.isAnnotationPresent
 import com.squareup.moshi.internal.toKType
@@ -71,7 +70,7 @@ public class Moshi internal constructor(builder: Builder) {
 
   @CheckReturnValue
   public fun <T> adapter(type: Type, annotations: Set<Annotation>): JsonAdapter<T> =
-    adapter(type.toKType(), annotations, fieldName = null)
+    adapter<T>(type.toKType(), annotations, fieldName = null)
 
   /**
    * @return a [JsonAdapter] for [T], creating it if necessary. Note that while nullability of [T]
@@ -133,7 +132,8 @@ public class Moshi internal constructor(builder: Builder) {
       for (i in factories.indices) {
         @Suppress("UNCHECKED_CAST") // Factories are required to return only matching JsonAdapters.
         val initialResult = factories[i].create(cleanedType, annotations, this) as JsonAdapter<T>? ?: continue
-        val result = if (initialResult is NullSafeJsonAdapter<*> || initialResult is NonNullJsonAdapter<*>) {
+        val result = if (initialResult is NullAwareJsonAdapter<*>) {
+          // If it's null-aware already, let it handle things internally
           initialResult
         } else if (type.isMarkedNullable) {
           @Suppress("UNCHECKED_CAST")

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.kt
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.kt
@@ -20,7 +20,7 @@ import com.squareup.moshi.internal.NO_ANNOTATIONS
 import com.squareup.moshi.internal.NullAwareJsonAdapter
 import com.squareup.moshi.internal.canonicalize
 import com.squareup.moshi.internal.isAnnotationPresent
-import com.squareup.moshi.internal.toKType
+import com.squareup.moshi.toKType
 import com.squareup.moshi.internal.toStringWithAnnotations
 import com.squareup.moshi.internal.typesMatch
 import java.lang.reflect.Type

--- a/moshi/src/main/java/com/squareup/moshi/RecordJsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/RecordJsonAdapter.kt
@@ -24,7 +24,7 @@ import java.lang.reflect.Type
 internal class RecordJsonAdapter<T> : JsonAdapter<T>() {
   override fun fromJson(reader: JsonReader) = throw AssertionError()
 
-  override fun toJson(writer: JsonWriter, value: T?) = throw AssertionError()
+  override fun toJson(writer: JsonWriter, value: T) = throw AssertionError()
 
   companion object Factory : JsonAdapter.Factory {
     override fun create(type: Type, annotations: Set<Annotation>, moshi: Moshi): JsonAdapter<*>? = null

--- a/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.kt
+++ b/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.kt
@@ -67,8 +67,8 @@ internal object StandardJsonAdapters : JsonAdapter.Factory {
   val BOOLEAN_JSON_ADAPTER: JsonAdapter<Boolean> = object : JsonAdapter<Boolean>() {
     override fun fromJson(reader: JsonReader) = reader.nextBoolean()
 
-    override fun toJson(writer: JsonWriter, value: Boolean?) {
-      writer.value(knownNotNull(value))
+    override fun toJson(writer: JsonWriter, value: Boolean) {
+      writer.value(value)
     }
 
     override fun toString() = "JsonAdapter(Boolean)"
@@ -79,7 +79,7 @@ internal object StandardJsonAdapters : JsonAdapter.Factory {
       return rangeCheckNextInt(reader, "a byte", Byte.MIN_VALUE.toInt(), 0xff).toByte()
     }
 
-    override fun toJson(writer: JsonWriter, value: Byte?) {
+    override fun toJson(writer: JsonWriter, value: Byte) {
       writer.value((knownNotNull(value).toInt() and 0xff).toLong())
     }
 
@@ -95,7 +95,7 @@ internal object StandardJsonAdapters : JsonAdapter.Factory {
       return value[0]
     }
 
-    override fun toJson(writer: JsonWriter, value: Char?) {
+    override fun toJson(writer: JsonWriter, value: Char) {
       writer.value(knownNotNull(value).toString())
     }
 
@@ -107,7 +107,7 @@ internal object StandardJsonAdapters : JsonAdapter.Factory {
       return reader.nextDouble()
     }
 
-    override fun toJson(writer: JsonWriter, value: Double?) {
+    override fun toJson(writer: JsonWriter, value: Double) {
       writer.value(knownNotNull(value).toDouble())
     }
 
@@ -126,11 +126,7 @@ internal object StandardJsonAdapters : JsonAdapter.Factory {
       return value
     }
 
-    override fun toJson(writer: JsonWriter, value: Float?) {
-      // Manual null pointer check for the float.class adapter.
-      if (value == null) {
-        throw NullPointerException()
-      }
+    override fun toJson(writer: JsonWriter, value: Float) {
       // Use the Number overload so we write out float precision instead of double precision.
       writer.value(value)
     }
@@ -143,8 +139,8 @@ internal object StandardJsonAdapters : JsonAdapter.Factory {
       return reader.nextInt()
     }
 
-    override fun toJson(writer: JsonWriter, value: Int?) {
-      writer.value(knownNotNull(value).toInt().toLong())
+    override fun toJson(writer: JsonWriter, value: Int) {
+      writer.value(value.toLong())
     }
 
     override fun toString() = "JsonAdapter(Integer)"
@@ -155,8 +151,8 @@ internal object StandardJsonAdapters : JsonAdapter.Factory {
       return reader.nextLong()
     }
 
-    override fun toJson(writer: JsonWriter, value: Long?) {
-      writer.value(knownNotNull(value).toLong())
+    override fun toJson(writer: JsonWriter, value: Long) {
+      writer.value(value)
     }
 
     override fun toString() = "JsonAdapter(Long)"
@@ -167,19 +163,19 @@ internal object StandardJsonAdapters : JsonAdapter.Factory {
       return rangeCheckNextInt(reader, "a short", Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
     }
 
-    override fun toJson(writer: JsonWriter, value: Short?) {
-      writer.value(knownNotNull(value).toInt().toLong())
+    override fun toJson(writer: JsonWriter, value: Short) {
+      writer.value(value.toInt().toLong())
     }
 
     override fun toString() = "JsonAdapter(Short)"
   }
 
   private val STRING_JSON_ADAPTER: JsonAdapter<String> = object : JsonAdapter<String>() {
-    override fun fromJson(reader: JsonReader): String? {
+    override fun fromJson(reader: JsonReader): String {
       return reader.nextString()
     }
 
-    override fun toJson(writer: JsonWriter, value: String?) {
+    override fun toJson(writer: JsonWriter, value: String) {
       writer.value(value)
     }
 
@@ -211,8 +207,8 @@ internal object StandardJsonAdapters : JsonAdapter.Factory {
       )
     }
 
-    override fun toJson(writer: JsonWriter, value: T?) {
-      writer.value(nameStrings[knownNotNull(value).ordinal])
+    override fun toJson(writer: JsonWriter, value: T) {
+      writer.value(nameStrings[value.ordinal])
     }
 
     override fun toString() = "JsonAdapter(${enumType.name})"
@@ -226,7 +222,7 @@ internal object StandardJsonAdapters : JsonAdapter.Factory {
    * This adapter needs a Moshi instance to look up the appropriate adapter for runtime types as
    * they are encountered.
    */
-  internal class ObjectJsonAdapter(private val moshi: Moshi) : JsonAdapter<Any>() {
+  internal class ObjectJsonAdapter(private val moshi: Moshi) : JsonAdapter<Any?>() {
     private val listJsonAdapter: JsonAdapter<List<*>> = moshi.adapter(List::class.java)
     private val mapAdapter: JsonAdapter<Map<*, *>> = moshi.adapter(Map::class.java)
     private val stringAdapter: JsonAdapter<String> = moshi.adapter(String::class.java)
@@ -254,7 +250,7 @@ internal object StandardJsonAdapters : JsonAdapter.Factory {
         writer.beginObject()
         writer.endObject()
       } else {
-        moshi.adapter<Any>(toJsonType(valueClass), NO_ANNOTATIONS).toJson(writer, value)
+        moshi.adapter<Any?>(toJsonType(valueClass), NO_ANNOTATIONS).toJson(writer, value)
       }
     }
 

--- a/moshi/src/main/java/com/squareup/moshi/Types.kt
+++ b/moshi/src/main/java/com/squareup/moshi/Types.kt
@@ -32,6 +32,7 @@ import java.util.Collections
 import java.util.Properties
 import javax.annotation.CheckReturnValue
 import java.lang.annotation.Annotation as JavaAnnotation
+import java.lang.reflect.Array as JavaArray
 
 /** Factory methods for types. */
 @CheckReturnValue
@@ -170,7 +171,7 @@ public object Types {
       }
       is GenericArrayType -> {
         val componentType = type.genericComponentType
-        java.lang.reflect.Array.newInstance(getRawType(componentType), 0).javaClass
+        JavaArray.newInstance(getRawType(componentType), 0).javaClass
       }
       is TypeVariable<*> -> {
         // We could use the variable's bounds, but that won't work if there are multiple. having a raw

--- a/moshi/src/main/java/com/squareup/moshi/internal/InteropKFactory.kt
+++ b/moshi/src/main/java/com/squareup/moshi/internal/InteropKFactory.kt
@@ -1,0 +1,27 @@
+package com.squareup.moshi.internal
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import kotlin.reflect.KType
+import kotlin.reflect.javaType
+
+internal class InteropKFactory(val delegate: JsonAdapter.Factory) : JsonAdapter.KFactory {
+  @OptIn(ExperimentalStdlibApi::class)
+  override fun create(type: KType, annotations: Set<Annotation>, moshi: Moshi): JsonAdapter<*>? =
+    delegate.create(type.javaType, annotations, moshi)
+
+  override fun toString(): String = "KFactory($delegate)"
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as InteropKFactory
+
+    if (delegate != other.delegate) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int = delegate.hashCode()
+}

--- a/moshi/src/main/java/com/squareup/moshi/internal/NonNullJsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/internal/NonNullJsonAdapter.kt
@@ -28,7 +28,7 @@ import com.squareup.moshi.JsonWriter
 public class NonNullJsonAdapter<T>(public val delegate: JsonAdapter<T>) : JsonAdapter<T?>() {
   override fun fromJson(reader: JsonReader): T {
     return if (reader.peek() == JsonReader.Token.NULL) {
-      throw JsonDataException("Unexpected null at " + reader.path)
+      throw JsonDataException("Non-null value was null at ${reader.path}")
     } else {
       knownNotNull(delegate.fromJson(reader))
     }
@@ -36,7 +36,7 @@ public class NonNullJsonAdapter<T>(public val delegate: JsonAdapter<T>) : JsonAd
 
   override fun toJson(writer: JsonWriter, value: T?) {
     if (value == null) {
-      throw JsonDataException("Unexpected null at " + writer.path)
+      throw JsonDataException("Non-null value was null at ${writer.path}")
     } else {
       delegate.toJson(writer, value)
     }

--- a/moshi/src/main/java/com/squareup/moshi/internal/NonNullJsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/internal/NonNullJsonAdapter.kt
@@ -20,7 +20,12 @@ import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 
-public class NonNullJsonAdapter<T>(public val delegate: JsonAdapter<T>) : JsonAdapter<T>() {
+/**
+ * Surprise! This is typed as `T?` to allow us to use it as a nullable type and give clearer error
+ * messages, but users of this class should always use it as an assumed non-nullable type and is
+ * cast as such in [JsonAdapter.nonNull].
+ */
+public class NonNullJsonAdapter<T>(public val delegate: JsonAdapter<T>) : JsonAdapter<T?>() {
   override fun fromJson(reader: JsonReader): T {
     return if (reader.peek() == JsonReader.Token.NULL) {
       throw JsonDataException("Unexpected null at " + reader.path)

--- a/moshi/src/main/java/com/squareup/moshi/internal/NonNullJsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/internal/NonNullJsonAdapter.kt
@@ -25,7 +25,7 @@ import com.squareup.moshi.JsonWriter
  * messages, but users of this class should always use it as an assumed non-nullable type and is
  * cast as such in [JsonAdapter.nonNull].
  */
-public class NonNullJsonAdapter<T>(public val delegate: JsonAdapter<T>) : JsonAdapter<T?>() {
+public class NonNullJsonAdapter<T>(public val delegate: JsonAdapter<T>) : NullAwareJsonAdapter<T?>() {
   override fun fromJson(reader: JsonReader): T {
     return if (reader.peek() == JsonReader.Token.NULL) {
       throw JsonDataException("Non-null value was null at ${reader.path}")

--- a/moshi/src/main/java/com/squareup/moshi/internal/NullAwareJsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/internal/NullAwareJsonAdapter.kt
@@ -1,0 +1,5 @@
+package com.squareup.moshi.internal
+
+import com.squareup.moshi.JsonAdapter
+
+public abstract class NullAwareJsonAdapter<T> : JsonAdapter<T?>()

--- a/moshi/src/main/java/com/squareup/moshi/internal/NullSafeJsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/internal/NullSafeJsonAdapter.kt
@@ -19,7 +19,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 
-public class NullSafeJsonAdapter<T>(public val delegate: JsonAdapter<T>) : JsonAdapter<T>() {
+public class NullSafeJsonAdapter<T>(public val delegate: JsonAdapter<T>) : JsonAdapter<T?>() {
   override fun fromJson(reader: JsonReader): T? {
     return if (reader.peek() == JsonReader.Token.NULL) {
       reader.nextNull()

--- a/moshi/src/main/java/com/squareup/moshi/internal/NullSafeJsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/internal/NullSafeJsonAdapter.kt
@@ -19,7 +19,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 
-public class NullSafeJsonAdapter<T>(public val delegate: JsonAdapter<T>) : JsonAdapter<T?>() {
+public class NullSafeJsonAdapter<T>(public val delegate: JsonAdapter<T>) : NullAwareJsonAdapter<T?>() {
   override fun fromJson(reader: JsonReader): T? {
     return if (reader.peek() == JsonReader.Token.NULL) {
       reader.nextNull()

--- a/moshi/src/main/java16/com/squareup/moshi/RecordJsonAdapter.kt
+++ b/moshi/src/main/java16/com/squareup/moshi/RecordJsonAdapter.kt
@@ -43,14 +43,14 @@ internal class RecordJsonAdapter<T>(
   data class ComponentBinding<T>(
     val componentName: String,
     val jsonName: String,
-    val adapter: JsonAdapter<T>,
+    val adapter: JsonAdapter<T?>,
     val accessor: MethodHandle
   )
 
   private val componentBindingsArray = componentBindings.values.toTypedArray()
   private val options = JsonReader.Options.of(*componentBindings.keys.toTypedArray())
 
-  override fun fromJson(reader: JsonReader): T? {
+  override fun fromJson(reader: JsonReader): T {
     val resultsArray = arrayOfNulls<Any>(componentBindingsArray.size)
 
     reader.beginObject()
@@ -85,12 +85,12 @@ internal class RecordJsonAdapter<T>(
     }
   }
 
-  override fun toJson(writer: JsonWriter, value: T?) {
+  override fun toJson(writer: JsonWriter, value: T) {
     writer.beginObject()
 
     for (binding in componentBindingsArray) {
       writer.name(binding.jsonName)
-      val componentValue = try {
+      val componentValue: Any? = try {
         binding.accessor.invoke(value)
       } catch (e: InvocationTargetException) {
         throw e.rethrowCause()
@@ -162,7 +162,7 @@ internal class RecordJsonAdapter<T>(
 
       val componentType = component.genericType.resolve(type, rawType)
       val qualifiers = component.jsonAnnotations
-      val adapter = moshi.adapter<Any>(componentType, qualifiers)
+      val adapter = moshi.adapter<Any?>(componentType, qualifiers)
 
       val accessor = try {
         lookup.unreflect(component.accessor)

--- a/moshi/src/test/java/com/squareup/moshi/AdapterMethodsTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/AdapterMethodsTest.java
@@ -515,8 +515,8 @@ public final class AdapterMethodsTest {
       assertThat(e.getCause())
           .hasMessageThat()
           .isEqualTo(
-              "No next JsonAdapter for interface "
-                  + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)");
+              "No next JsonAdapter for com.squareup.moshi.AdapterMethodsTest.Shape (with "
+                  + "no annotations)");
     }
   }
 
@@ -544,8 +544,8 @@ public final class AdapterMethodsTest {
       assertThat(e.getCause())
           .hasMessageThat()
           .isEqualTo(
-              "No next JsonAdapter for interface "
-                  + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)");
+              "No next JsonAdapter for com.squareup.moshi.AdapterMethodsTest.Shape (with "
+                  + "no annotations)");
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/JsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonAdapterTest.java
@@ -125,7 +125,7 @@ public final class JsonAdapterTest {
       toUpperCase.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Unexpected null at $[1]");
+      assertThat(expected).hasMessageThat().isEqualTo("Non-null value was null at $[1]");
       assertThat(reader.<Object>nextNull()).isNull();
     }
     assertThat(toUpperCase.fromJson(reader)).isEqualTo("C");
@@ -138,7 +138,7 @@ public final class JsonAdapterTest {
       toUpperCase.toJson(writer, null);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Unexpected null at $[1]");
+      assertThat(expected).hasMessageThat().isEqualTo("Non-null value was null at $[1]");
       writer.nullValue();
     }
     toUpperCase.toJson(writer, "c");

--- a/moshi/src/test/java/com/squareup/moshi/JsonQualifiersTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonQualifiersTest.java
@@ -365,8 +365,8 @@ public final class JsonQualifiersTest {
           .isEqualTo(
               "No @FromJson adapter for class java.lang.String annotated "
                   + "[@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]"
-                  + "\nfor class java.lang.String b"
-                  + "\nfor class com.squareup.moshi.JsonQualifiersTest$StringAndFooString");
+                  + "\nfor kotlin.String? b"
+                  + "\nfor com.squareup.moshi.JsonQualifiersTest.StringAndFooString");
       assertThat(expected).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(expected.getCause())
           .hasMessageThat()
@@ -377,8 +377,8 @@ public final class JsonQualifiersTest {
       assertThat(expected.getCause().getCause())
           .hasMessageThat()
           .isEqualTo(
-              "No next JsonAdapter for class "
-                  + "java.lang.String annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
+              "No next JsonAdapter for kotlin.String annotated "
+                  + "[@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
     }
   }
 
@@ -403,8 +403,8 @@ public final class JsonQualifiersTest {
           .isEqualTo(
               "No @ToJson adapter for class java.lang.String annotated "
                   + "[@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]"
-                  + "\nfor class java.lang.String b"
-                  + "\nfor class com.squareup.moshi.JsonQualifiersTest$StringAndFooString");
+                  + "\nfor kotlin.String? b"
+                  + "\nfor com.squareup.moshi.JsonQualifiersTest.StringAndFooString");
       assertThat(expected).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(expected.getCause())
           .hasMessageThat()
@@ -415,8 +415,8 @@ public final class JsonQualifiersTest {
       assertThat(expected.getCause().getCause())
           .hasMessageThat()
           .isEqualTo(
-              "No next JsonAdapter for class "
-                  + "java.lang.String annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
+              "No next JsonAdapter for kotlin.String annotated "
+                  + "[@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/KotlinExtensionsTest.kt
+++ b/moshi/src/test/java/com/squareup/moshi/KotlinExtensionsTest.kt
@@ -66,7 +66,7 @@ class KotlinExtensionsTest {
         return -1
       }
 
-      override fun toJson(writer: JsonWriter, value: Int?) {
+      override fun toJson(writer: JsonWriter, value: Int) {
         throw NotImplementedError()
       }
     }
@@ -86,7 +86,7 @@ class KotlinExtensionsTest {
         return listOf(-1)
       }
 
-      override fun toJson(writer: JsonWriter, value: List<Int>?) {
+      override fun toJson(writer: JsonWriter, value: List<Int>) {
         throw NotImplementedError()
       }
     }

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -66,13 +66,13 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a boolean but was NULL at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Non-null value was null at $");
     }
 
     try {
       adapter.toJson(null);
       fail();
-    } catch (NullPointerException expected) {
+    } catch (JsonDataException expected) {
     }
   }
 
@@ -126,13 +126,13 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected an int but was NULL at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Non-null value was null at $");
     }
 
     try {
       adapter.toJson(null);
       fail();
-    } catch (NullPointerException expected) {
+    } catch (JsonDataException expected) {
     }
   }
 
@@ -217,13 +217,13 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a string but was NULL at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Non-null value was null at $");
     }
 
     try {
       adapter.toJson(null);
       fail();
-    } catch (NullPointerException expected) {
+    } catch (JsonDataException expected) {
     }
   }
 
@@ -275,13 +275,13 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a double but was NULL at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Non-null value was null at $");
     }
 
     try {
       adapter.toJson(null);
       fail();
-    } catch (NullPointerException expected) {
+    } catch (JsonDataException expected) {
     }
 
     // Non-lenient adapter won't allow values outside of range.
@@ -349,13 +349,13 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a double but was NULL at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Non-null value was null at $");
     }
 
     try {
       adapter.toJson(null);
       fail();
-    } catch (NullPointerException expected) {
+    } catch (JsonDataException expected) {
     }
 
     // Non-lenient adapter won't allow values outside of range.
@@ -432,13 +432,13 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected an int but was NULL at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Non-null value was null at $");
     }
 
     try {
       adapter.toJson(null);
       fail();
-    } catch (NullPointerException expected) {
+    } catch (JsonDataException expected) {
     }
   }
 
@@ -489,13 +489,13 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a long but was NULL at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Non-null value was null at $");
     }
 
     try {
       adapter.toJson(null);
       fail();
-    } catch (NullPointerException expected) {
+    } catch (JsonDataException expected) {
     }
   }
 
@@ -542,13 +542,13 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected an int but was NULL at path $");
+      assertThat(expected).hasMessageThat().isEqualTo("Non-null value was null at $");
     }
 
     try {
       adapter.toJson(null);
       fail();
-    } catch (NullPointerException expected) {
+    } catch (JsonDataException expected) {
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -615,7 +615,7 @@ public final class MoshiTest {
       assertThat(expected).hasMessageThat().contains("Parameter specified as non-null is null");
     }
     try {
-      builder.add(null, null);
+      builder.add((Type) null, null);
       fail();
     } catch (NullPointerException expected) {
       assertThat(expected).hasMessageThat().contains("Parameter specified as non-null is null");
@@ -627,7 +627,7 @@ public final class MoshiTest {
       assertThat(expected).hasMessageThat().contains("Parameter specified as non-null is null");
     }
     try {
-      builder.add(null, null, null);
+      builder.add((Type) null, null, null);
       fail();
     } catch (NullPointerException expected) {
       assertThat(expected).hasMessageThat().contains("Parameter specified as non-null is null");

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -45,6 +45,7 @@ import java.util.UUID;
 import javax.annotation.Nullable;
 import javax.crypto.KeyGenerator;
 import okio.Buffer;
+import org.junit.Ignore;
 import org.junit.Test;
 
 @SuppressWarnings({"CheckReturnValue", "ResultOfMethodCallIgnored"})
@@ -582,6 +583,7 @@ public final class MoshiTest {
     assertThat(adapter.toJson(null)).isEqualTo("null");
   }
 
+  @Ignore("No longer supported. TODO delete?")
   @Test
   public void lowerBoundedWildcardsAreNotHandled() {
     Moshi moshi = new Moshi.Builder().build();
@@ -591,7 +593,7 @@ public final class MoshiTest {
     } catch (IllegalArgumentException e) {
       assertThat(e)
           .hasMessageThat()
-          .isEqualTo("No JsonAdapter for ? super java.lang.String (with no annotations)");
+          .isEqualTo("No JsonAdapter for in : kotlin.String (with no annotations)");
     }
   }
 
@@ -601,7 +603,7 @@ public final class MoshiTest {
     Class<? extends Annotation> annotation = Annotation.class;
     Moshi.Builder builder = new Moshi.Builder();
     try {
-      builder.add((null));
+      builder.add((JsonAdapter.Factory) null);
       fail();
     } catch (NullPointerException expected) {
       assertThat(expected).hasMessageThat().contains("Parameter specified as non-null is null");
@@ -875,8 +877,8 @@ public final class MoshiTest {
       assertThat(expected)
           .hasMessageThat()
           .isEqualTo(
-              "No JsonAdapter for java.util.List<java.lang.String> "
-                  + "annotated [@com.squareup.moshi.MoshiTest$Uppercase()]");
+              "No JsonAdapter for kotlin.collections.List<kotlin.String> annotated "
+                  + "[@com.squareup.moshi.MoshiTest$Uppercase()]");
     }
   }
 
@@ -892,8 +894,8 @@ public final class MoshiTest {
       assertThat(expected)
           .hasMessageThat()
           .isEqualTo(
-              "No JsonAdapter for class java.lang.String "
-                  + "annotated [@com.squareup.moshi.MoshiTest$Uppercase()]");
+              "No JsonAdapter for kotlin.String annotated "
+                  + "[@com.squareup.moshi.MoshiTest$Uppercase()]");
     }
   }
 
@@ -1097,10 +1099,10 @@ public final class MoshiTest {
           .isEqualTo(
               "Platform class java.util.UUID requires explicit "
                   + "JsonAdapter to be registered"
-                  + "\nfor class java.util.UUID uuid"
-                  + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType"
-                  + "\nfor java.util.Map<java.lang.String, "
-                  + "com.squareup.moshi.MoshiTest$HasPlatformType>");
+                  + "\nfor java.util.UUID? uuid"
+                  + "\nfor com.squareup.moshi.MoshiTest.HasPlatformType"
+                  + "\nfor kotlin.collections.Map<kotlin.String, "
+                  + "com.squareup.moshi.MoshiTest.HasPlatformType>");
       assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause())
           .hasMessageThat()
@@ -1121,9 +1123,9 @@ public final class MoshiTest {
           .isEqualTo(
               "Platform class java.util.UUID requires explicit "
                   + "JsonAdapter to be registered"
-                  + "\nfor class java.util.UUID uuid"
-                  + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType hasPlatformType"
-                  + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType$Wrapper");
+                  + "\nfor java.util.UUID? uuid"
+                  + "\nfor com.squareup.moshi.MoshiTest.HasPlatformType? hasPlatformType"
+                  + "\nfor com.squareup.moshi.MoshiTest.HasPlatformType.Wrapper");
       assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause())
           .hasMessageThat()
@@ -1144,10 +1146,10 @@ public final class MoshiTest {
           .isEqualTo(
               "Platform class java.util.UUID requires explicit "
                   + "JsonAdapter to be registered"
-                  + "\nfor class java.util.UUID uuid"
-                  + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType"
-                  + "\nfor java.util.List<com.squareup.moshi.MoshiTest$HasPlatformType> platformTypes"
-                  + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType$ListWrapper");
+                  + "\nfor java.util.UUID? uuid"
+                  + "\nfor com.squareup.moshi.MoshiTest.HasPlatformType"
+                  + "\nfor kotlin.collections.List<com.squareup.moshi.MoshiTest.HasPlatformType>? platformTypes"
+                  + "\nfor com.squareup.moshi.MoshiTest.HasPlatformType.ListWrapper");
       assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
       assertThat(e.getCause())
           .hasMessageThat()
@@ -1237,7 +1239,7 @@ public final class MoshiTest {
   public void newBuilder() throws Exception {
     Moshi moshi = new Moshi.Builder().add(Pizza.class, new PizzaAdapter()).build();
     Moshi.Builder newBuilder = moshi.newBuilder();
-    for (JsonAdapter.Factory factory : Moshi.BUILT_IN_FACTORIES) {
+    for (JsonAdapter.KFactory factory : Moshi.BUILT_IN_FACTORIES) {
       // Awkward but java sources don't know about the internal-ness of this
       assertThat(factory).isNotIn(newBuilder.getFactories$moshi());
     }


### PR DESCRIPTION
## Overview

This overhauls Moshi to use `KType` as its source of truth rather than `Type`. This puts us one step closer toward making all of Moshi's internals purely Kotlin while maintaining (backward) compatibility with Java.

## `KFactory`

The core of this is `JsonAdapter.KFactory`, which is analogous to the previous `JsonAdapter.Factory` but changed to accept a `KType` instead of a `Type`. We'll want to change internal standard adapters to implement this as well, but I'll leave those to later PRs to reduce churn in this one.

With it I've added a `fun JsonAdapter.Factory.asKFactory(): JsonAdapter.KFactory` to ease interop (implemented as `InteropKFactory`). This does _not_ add the reverse, but open to it.

This new factory also still uses `java.lang.Annotation` for now, also saving for a later PR to reduce churn.

## `JsonAdapter<T>`

Up to this point, `JsonAdapter` has always used nullable values for `fromJson` and `toJson`, regardless of the nullability on the generic. Now nullability travels from the generic type itself, allowing `JsonAdapter<T?>` and `JsonAdapter<T>` to indicate nullable and non-nullable respectively. We also leverage the new `T & Any` syntax in Kotlin 1.7 in `JsonAdapter.nonNull()`.

## `typeOf()` usage

`typeOf()` went stable in 1.6, but we still had to guard it with experimental annotations because we always had to immediately defer back to `KType.javaType` (which remains experimental). By moving to KType internally, we can mostly lift these experimental annotations. We can also potentially implement `KType.javaType` ourselves internally to completely remove them, since that API isn't a compiler intrinsic.

## Behavior change - `WildcardType`

Kotlin's `KType` cannot represent a Java `WildcardType`. Instead, these are _only_ available as `KTypeProjection`. Talked with @swankjesse and we're ok with dropping support for wildcard types as standalone types. Instead these will now get stripped when canonicalizing types.

## Behavior change - null-checks

Now that `nonNull()` actually checks null values, we get slightly different null error messages. They still indicate the path, but in some cases may be less informative than before (i.e. only saying the path was null, but not the type).

## Code gen

Code gen's been updated to rely on KType directly now since we can use `typeOf()` freely, simplifying things quite a bit. The new nullability enforcement in `JsonAdapter` also allows us to functionally remove `Util.unexpectedNull()`

Example generated adapter

```kotlin
// Code generated by moshi-kotlin-codegen. Do not edit.
@file:Suppress("DEPRECATION", "unused", "ClassName", "REDUNDANT_PROJECTION",
    "RedundantExplicitType", "LocalVariableName", "RedundantVisibilityModifier",
    "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "IMPLICIT_NOTHING_TYPE_ARGUMENT_IN_RETURN_POSITION")

package com.squareup.moshi.kotlin.codegen

import com.squareup.moshi.JsonAdapter
import com.squareup.moshi.JsonReader
import com.squareup.moshi.JsonWriter
import com.squareup.moshi.Moshi
import com.squareup.moshi.`internal`.DEFAULT_CONSTRUCTOR_MARKER
import com.squareup.moshi.`internal`.missingProperty
import java.lang.reflect.Constructor
import kotlin.Any
import kotlin.Array
import kotlin.Boolean
import kotlin.Float
import kotlin.Int
import kotlin.IntArray
import kotlin.String
import kotlin.Suppress
import kotlin.Unit
import kotlin.collections.List
import kotlin.collections.Map
import kotlin.collections.MutableList
import kotlin.collections.Set
import kotlin.collections.emptySet
import kotlin.jvm.Volatile
import kotlin.reflect.typeOf
import kotlin.text.buildString

public class SmokeTestTypeJsonAdapter(
  moshi: Moshi,
) : JsonAdapter<SmokeTestType>() {
  private val options: JsonReader.Options = JsonReader.Options.of("first_name", "last_name", "age",
      "nationalities", "weight", "tattoos", "race", "hasChildren", "favoriteFood", "favoriteDrink",
      "wildcardOut", "nullableWildcardOut", "wildcardIn", "any", "anyTwo", "anyOut",
      "nullableAnyOut", "favoriteThreeNumbers", "favoriteArrayValues",
      "favoriteNullableArrayValues", "nullableSetListMapArrayNullableIntWithDefault", "aliasedName",
      "genericAlias", "nestedArray")

  private val stringAdapter: JsonAdapter<String> = moshi.adapter(typeOf<String>(), emptySet(),
      "firstName")

  private val intAdapter: JsonAdapter<Int> = moshi.adapter(typeOf<Int>(), emptySet(), "age")

  private val listOfStringAdapter: JsonAdapter<List<String>> = moshi.adapter(typeOf<List<String>>(),
      emptySet(), "nationalities")

  private val floatAdapter: JsonAdapter<Float> = moshi.adapter(typeOf<Float>(), emptySet(),
      "weight")

  private val booleanAdapter: JsonAdapter<Boolean> = moshi.adapter(typeOf<Boolean>(), emptySet(),
      "tattoos")

  private val nullableStringAdapter: JsonAdapter<String?> = moshi.adapter(typeOf<String?>(),
      emptySet(), "race")

  private val mutableListOfStringAdapter: JsonAdapter<MutableList<out String>> =
      moshi.adapter(typeOf<MutableList<out String>>(), emptySet(), "wildcardOut")

  private val mutableListOfNullableStringAdapter: JsonAdapter<MutableList<out String?>> =
      moshi.adapter(typeOf<MutableList<out String?>>(), emptySet(), "nullableWildcardOut")

  private val arrayOfStringAnyAdapter: JsonAdapter<Array<in String>> =
      moshi.adapter(typeOf<Array<in String>>(), emptySet(), "wildcardIn")

  private val listOfNullableAnyAdapter: JsonAdapter<List<*>> = moshi.adapter(typeOf<List<*>>(),
      emptySet(), "any")

  private val listOfAnyAdapter: JsonAdapter<List<Any>> = moshi.adapter(typeOf<List<Any>>(),
      emptySet(), "anyTwo")

  private val mutableListOfAnyAdapter: JsonAdapter<MutableList<out Any>> =
      moshi.adapter(typeOf<MutableList<out Any>>(), emptySet(), "anyOut")

  private val mutableListOfNullableAnyAdapter: JsonAdapter<MutableList<*>> =
      moshi.adapter(typeOf<MutableList<*>>(), emptySet(), "nullableAnyOut")

  private val intArrayAdapter: JsonAdapter<IntArray> = moshi.adapter(typeOf<IntArray>(), emptySet(),
      "favoriteThreeNumbers")

  private val arrayOfStringAdapter: JsonAdapter<Array<String>> =
      moshi.adapter(typeOf<Array<String>>(), emptySet(), "favoriteArrayValues")

  private val arrayOfNullableStringAdapter: JsonAdapter<Array<String?>> =
      moshi.adapter(typeOf<Array<String?>>(), emptySet(), "favoriteNullableArrayValues")

  private val nullableSetOfListOfMapOfStringArrayOfNullableIntArrayAdapter:
      JsonAdapter<Set<List<Map<String, Array<IntArray?>>>>?> =
      moshi.adapter(typeOf<Set<List<Map<String, Array<IntArray?>>>>?>(), emptySet(),
      "nullableSetListMapArrayNullableIntWithDefault")

  private val nullableArrayOfMapOfStringAnyAdapter: JsonAdapter<Array<Map<String, Any>>?> =
      moshi.adapter(typeOf<Array<Map<String, Any>>?>(), emptySet(), "nestedArray")

  @Volatile
  private var constructorRef: Constructor<SmokeTestType>? = null

  public override fun toString(): String = buildString(35) {
      append("GeneratedJsonAdapter(").append("SmokeTestType").append(')') }

  public override fun fromJson(reader: JsonReader): SmokeTestType {
    var firstName: String? = null
    var lastName: String? = null
    var age: Int? = null
    var nationalities: List<String>? = null
    var weight: Float? = null
    var tattoos: Boolean? = false
    var race: String? = null
    var hasChildren: Boolean? = false
    var favoriteFood: String? = null
    var favoriteDrink: String? = null
    var wildcardOut: MutableList<out String>? = null
    var nullableWildcardOut: MutableList<out String?>? = null
    var wildcardIn: Array<in String>? = null
    var any: List<*>? = null
    var anyTwo: List<Any>? = null
    var anyOut: MutableList<out Any>? = null
    var nullableAnyOut: MutableList<*>? = null
    var favoriteThreeNumbers: IntArray? = null
    var favoriteArrayValues: Array<String>? = null
    var favoriteNullableArrayValues: Array<String?>? = null
    var nullableSetListMapArrayNullableIntWithDefault: Set<List<Map<String, Array<IntArray?>>>>? =
        null
    var aliasedName: String? = null
    var genericAlias: List<String>? = null
    var nestedArray: Array<Map<String, Any>>? = null
    var mask0 = -1
    reader.beginObject()
    while (reader.hasNext()) {
      when (reader.selectName(options)) {
        0 -> firstName = stringAdapter.fromJson(reader)
        1 -> lastName = stringAdapter.fromJson(reader)
        2 -> age = intAdapter.fromJson(reader)
        3 -> {
          nationalities = listOfStringAdapter.fromJson(reader)
          // $mask = $mask and (1 shl 3).inv()
          mask0 = mask0 and 0xfffffff7.toInt()
        }
        4 -> weight = floatAdapter.fromJson(reader)
        5 -> {
          tattoos = booleanAdapter.fromJson(reader)
          // $mask = $mask and (1 shl 5).inv()
          mask0 = mask0 and 0xffffffdf.toInt()
        }
        6 -> race = nullableStringAdapter.fromJson(reader)
        7 -> {
          hasChildren = booleanAdapter.fromJson(reader)
          // $mask = $mask and (1 shl 7).inv()
          mask0 = mask0 and 0xffffff7f.toInt()
        }
        8 -> {
          favoriteFood = nullableStringAdapter.fromJson(reader)
          // $mask = $mask and (1 shl 8).inv()
          mask0 = mask0 and 0xfffffeff.toInt()
        }
        9 -> {
          favoriteDrink = nullableStringAdapter.fromJson(reader)
          // $mask = $mask and (1 shl 9).inv()
          mask0 = mask0 and 0xfffffdff.toInt()
        }
        10 -> {
          wildcardOut = mutableListOfStringAdapter.fromJson(reader)
          // $mask = $mask and (1 shl 10).inv()
          mask0 = mask0 and 0xfffffbff.toInt()
        }
        11 -> {
          nullableWildcardOut = mutableListOfNullableStringAdapter.fromJson(reader)
          // $mask = $mask and (1 shl 11).inv()
          mask0 = mask0 and 0xfffff7ff.toInt()
        }
        12 -> wildcardIn = arrayOfStringAnyAdapter.fromJson(reader)
        13 -> any = listOfNullableAnyAdapter.fromJson(reader)
        14 -> anyTwo = listOfAnyAdapter.fromJson(reader)
        15 -> anyOut = mutableListOfAnyAdapter.fromJson(reader)
        16 -> nullableAnyOut = mutableListOfNullableAnyAdapter.fromJson(reader)
        17 -> favoriteThreeNumbers = intArrayAdapter.fromJson(reader)
        18 -> favoriteArrayValues = arrayOfStringAdapter.fromJson(reader)
        19 -> favoriteNullableArrayValues = arrayOfNullableStringAdapter.fromJson(reader)
        20 -> {
          nullableSetListMapArrayNullableIntWithDefault =
              nullableSetOfListOfMapOfStringArrayOfNullableIntArrayAdapter.fromJson(reader)
          // $mask = $mask and (1 shl 20).inv()
          mask0 = mask0 and 0xffefffff.toInt()
        }
        21 -> {
          aliasedName = stringAdapter.fromJson(reader)
          // $mask = $mask and (1 shl 21).inv()
          mask0 = mask0 and 0xffdfffff.toInt()
        }
        22 -> {
          genericAlias = listOfStringAdapter.fromJson(reader)
          // $mask = $mask and (1 shl 22).inv()
          mask0 = mask0 and 0xffbfffff.toInt()
        }
        23 -> {
          nestedArray = nullableArrayOfMapOfStringAnyAdapter.fromJson(reader)
          // $mask = $mask and (1 shl 23).inv()
          mask0 = mask0 and 0xff7fffff.toInt()
        }
        -1 -> {
          // Unknown name, skip it.
          reader.skipName()
          reader.skipValue()
        }
      }
    }
    reader.endObject()
    if (mask0 == 0xff0ff057.toInt()) {
      // All parameters with defaults are set, invoke the constructor directly
      return  SmokeTestType(
          firstName = firstName ?: throw missingProperty("firstName", "first_name", reader),
          lastName = lastName ?: throw missingProperty("lastName", "last_name", reader),
          age = age ?: throw missingProperty("age", "age", reader),
          nationalities = nationalities as List<String>,
          weight = weight ?: throw missingProperty("weight", "weight", reader),
          tattoos = tattoos as Boolean,
          race = race,
          hasChildren = hasChildren as Boolean,
          favoriteFood = favoriteFood,
          favoriteDrink = favoriteDrink,
          wildcardOut = wildcardOut as MutableList<out String>,
          nullableWildcardOut = nullableWildcardOut as MutableList<out String?>,
          wildcardIn = wildcardIn ?: throw missingProperty("wildcardIn", "wildcardIn", reader),
          any = any ?: throw missingProperty("any", "any", reader),
          anyTwo = anyTwo ?: throw missingProperty("anyTwo", "anyTwo", reader),
          anyOut = anyOut ?: throw missingProperty("anyOut", "anyOut", reader),
          nullableAnyOut = nullableAnyOut ?: throw missingProperty("nullableAnyOut",
              "nullableAnyOut", reader),
          favoriteThreeNumbers = favoriteThreeNumbers ?:
              throw missingProperty("favoriteThreeNumbers", "favoriteThreeNumbers", reader),
          favoriteArrayValues = favoriteArrayValues ?: throw missingProperty("favoriteArrayValues",
              "favoriteArrayValues", reader),
          favoriteNullableArrayValues = favoriteNullableArrayValues ?:
              throw missingProperty("favoriteNullableArrayValues", "favoriteNullableArrayValues",
              reader),
          nullableSetListMapArrayNullableIntWithDefault =
              nullableSetListMapArrayNullableIntWithDefault,
          aliasedName = aliasedName as TypeAliasName,
          genericAlias = genericAlias as GenericTypeAlias,
          nestedArray = nestedArray
      )
    } else {
      // Reflectively invoke the synthetic defaults constructor
      @Suppress("UNCHECKED_CAST")
      val localConstructor: Constructor<SmokeTestType> = this.constructorRef ?:
          SmokeTestType::class.java.getDeclaredConstructor(String::class.java, String::class.java,
          Int::class.javaPrimitiveType, List::class.java, Float::class.javaPrimitiveType,
          Boolean::class.javaPrimitiveType, String::class.java, Boolean::class.javaPrimitiveType,
          String::class.java, String::class.java, MutableList::class.java, MutableList::class.java,
          Array<in String>::class.java, List::class.java, List::class.java, MutableList::class.java,
          MutableList::class.java, IntArray::class.java, Array<String>::class.java,
          Array<String?>::class.java, Set::class.java, String::class.java, List::class.java,
          java.lang.reflect.Array.newInstance(Map::class.java, 0).javaClass,
          Int::class.javaPrimitiveType, DEFAULT_CONSTRUCTOR_MARKER).also { this.constructorRef = it
          }
      return localConstructor.newInstance(
          firstName ?: throw missingProperty("firstName", "first_name", reader),
          lastName ?: throw missingProperty("lastName", "last_name", reader),
          age ?: throw missingProperty("age", "age", reader),
          nationalities,
          weight ?: throw missingProperty("weight", "weight", reader),
          tattoos,
          race,
          hasChildren,
          favoriteFood,
          favoriteDrink,
          wildcardOut,
          nullableWildcardOut,
          wildcardIn ?: throw missingProperty("wildcardIn", "wildcardIn", reader),
          any ?: throw missingProperty("any", "any", reader),
          anyTwo ?: throw missingProperty("anyTwo", "anyTwo", reader),
          anyOut ?: throw missingProperty("anyOut", "anyOut", reader),
          nullableAnyOut ?: throw missingProperty("nullableAnyOut", "nullableAnyOut", reader),
          favoriteThreeNumbers ?: throw missingProperty("favoriteThreeNumbers",
              "favoriteThreeNumbers", reader),
          favoriteArrayValues ?: throw missingProperty("favoriteArrayValues", "favoriteArrayValues",
              reader),
          favoriteNullableArrayValues ?: throw missingProperty("favoriteNullableArrayValues",
              "favoriteNullableArrayValues", reader),
          nullableSetListMapArrayNullableIntWithDefault,
          aliasedName,
          genericAlias,
          nestedArray,
          mask0,
          /* DefaultConstructorMarker */ null
      )
    }
  }

  public override fun toJson(writer: JsonWriter, `value`: SmokeTestType): Unit {
    writer.beginObject()
    writer.name("first_name")
    stringAdapter.toJson(writer, `value`.firstName)
    writer.name("last_name")
    stringAdapter.toJson(writer, `value`.lastName)
    writer.name("age")
    intAdapter.toJson(writer, `value`.age)
    writer.name("nationalities")
    listOfStringAdapter.toJson(writer, `value`.nationalities)
    writer.name("weight")
    floatAdapter.toJson(writer, `value`.weight)
    writer.name("tattoos")
    booleanAdapter.toJson(writer, `value`.tattoos)
    writer.name("race")
    nullableStringAdapter.toJson(writer, `value`.race)
    writer.name("hasChildren")
    booleanAdapter.toJson(writer, `value`.hasChildren)
    writer.name("favoriteFood")
    nullableStringAdapter.toJson(writer, `value`.favoriteFood)
    writer.name("favoriteDrink")
    nullableStringAdapter.toJson(writer, `value`.favoriteDrink)
    writer.name("wildcardOut")
    mutableListOfStringAdapter.toJson(writer, `value`.wildcardOut)
    writer.name("nullableWildcardOut")
    mutableListOfNullableStringAdapter.toJson(writer, `value`.nullableWildcardOut)
    writer.name("wildcardIn")
    arrayOfStringAnyAdapter.toJson(writer, `value`.wildcardIn)
    writer.name("any")
    listOfNullableAnyAdapter.toJson(writer, `value`.any)
    writer.name("anyTwo")
    listOfAnyAdapter.toJson(writer, `value`.anyTwo)
    writer.name("anyOut")
    mutableListOfAnyAdapter.toJson(writer, `value`.anyOut)
    writer.name("nullableAnyOut")
    mutableListOfNullableAnyAdapter.toJson(writer, `value`.nullableAnyOut)
    writer.name("favoriteThreeNumbers")
    intArrayAdapter.toJson(writer, `value`.favoriteThreeNumbers)
    writer.name("favoriteArrayValues")
    arrayOfStringAdapter.toJson(writer, `value`.favoriteArrayValues)
    writer.name("favoriteNullableArrayValues")
    arrayOfNullableStringAdapter.toJson(writer, `value`.favoriteNullableArrayValues)
    writer.name("nullableSetListMapArrayNullableIntWithDefault")
    nullableSetOfListOfMapOfStringArrayOfNullableIntArrayAdapter.toJson(writer,
        `value`.nullableSetListMapArrayNullableIntWithDefault)
    writer.name("aliasedName")
    stringAdapter.toJson(writer, `value`.aliasedName)
    writer.name("genericAlias")
    listOfStringAdapter.toJson(writer, `value`.genericAlias)
    writer.name("nestedArray")
    nullableArrayOfMapOfStringAnyAdapter.toJson(writer, `value`.nestedArray)
    writer.endObject()
  }
}

```