### PR TITLE
publish `2.0.0-SNAPSHOT` from `main`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 
 allprojects {
   group = "com.squareup.moshi"
-  version = "1.14.0-SNAPSHOT"
+  version = "2.0.0-SNAPSHOT"
 
   repositories {
     mavenCentral()


### PR DESCRIPTION
Right now the builds on `main` are publishing `1.14.0-SNAPSHOT` but it contains stuff that is not intended to go into `1.14` and is only intended for `2.x`

With this change, `main` will produce `2.0.0-SNAPSHOT` instead of `1.14.0-SNAPSHOT`