### PR TITLE
Publish 1.14.0-SNAPSHOT from the 1.14 branch.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Test
         run: ./gradlew build check --stacktrace -PkotlinTestMode=${{ matrix.kotlin-test-mode }}
 
-      - name: Publish (default branch only)
-        if: github.repository == 'square/moshi' && github.ref == 'refs/heads/master' && matrix.kotlin-test-mode == 'reflect'
+      - name: Publish (release branch only)
+        if: github.repository == 'square/moshi' && github.ref == 'refs/heads/moshi_1.14.x' && matrix.kotlin-test-mode == 'reflect'
         run: ./gradlew publish
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: '${{ secrets.SONATYPE_NEXUS_USERNAME }}'

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 \
 kapt.include.compile.classpath=false
 
 GROUP=com.squareup.moshi
-VERSION_NAME=1.13.0
+VERSION_NAME=1.14.0-SNAPSHOT
 POM_DESCRIPTION=A modern JSON API for Android and Java
 POM_URL=https://github.com/square/moshi/
 POM_SCM_URL=https://github.com/square/moshi/


### PR DESCRIPTION
After `main` is updated to use  `2.0.0-SNAPSHOT` -> https://github.com/square/moshi/pull/1552

then `1.14.0-SNAPSHOT` can be published from the `moshi_1.14.x` branch