### PR TITLE
Remove truth library

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,4 +39,3 @@ assertj = "org.assertj:assertj-core:3.11.1"
 junit = "junit:junit:4.13.2"
 kotlinCompileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version.ref = "kotlinCompileTesting" }
 kotlinCompileTesting-ksp = { module = "com.github.tschuchortdev:kotlin-compile-testing-ksp", version.ref ="kotlinCompileTesting" }
-truth = "com.google.truth:truth:1.1.3"

--- a/moshi-adapters/build.gradle.kts
+++ b/moshi-adapters/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
   api(project(":moshi"))
 
   testImplementation(libs.junit)
-  testImplementation(libs.truth)
 }
 
 tasks.withType<Jar>().configureEach {

--- a/moshi-adapters/src/test/java/com/squareup/moshi/adapters/EnumJsonAdapterTest.java
+++ b/moshi-adapters/src/test/java/com/squareup/moshi/adapters/EnumJsonAdapterTest.java
@@ -15,7 +15,8 @@
  */
 package com.squareup.moshi.adapters;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import com.squareup.moshi.Json;
@@ -29,15 +30,15 @@ public final class EnumJsonAdapterTest {
   @Test
   public void toAndFromJson() throws Exception {
     EnumJsonAdapter<Roshambo> adapter = EnumJsonAdapter.create(Roshambo.class);
-    assertThat(adapter.fromJson("\"ROCK\"")).isEqualTo(Roshambo.ROCK);
-    assertThat(adapter.toJson(Roshambo.PAPER)).isEqualTo("\"PAPER\"");
+    assertEquals(adapter.fromJson("\"ROCK\""), Roshambo.ROCK);
+    assertEquals(adapter.toJson(Roshambo.PAPER), "\"PAPER\"");
   }
 
   @Test
   public void withJsonName() throws Exception {
     EnumJsonAdapter<Roshambo> adapter = EnumJsonAdapter.create(Roshambo.class);
-    assertThat(adapter.fromJson("\"scr\"")).isEqualTo(Roshambo.SCISSORS);
-    assertThat(adapter.toJson(Roshambo.SCISSORS)).isEqualTo("\"scr\"");
+    assertEquals(adapter.fromJson("\"scr\""), Roshambo.SCISSORS);
+    assertEquals(adapter.toJson(Roshambo.SCISSORS), "\"scr\"");
   }
 
   @Test
@@ -48,11 +49,10 @@ public final class EnumJsonAdapterTest {
       adapter.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected one of [ROCK, PAPER, scr] but was SPOCK at path $");
+      assertEquals(
+          "Expected one of [ROCK, PAPER, scr] but was SPOCK at path $", expected.getMessage());
     }
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -60,8 +60,8 @@ public final class EnumJsonAdapterTest {
     EnumJsonAdapter<Roshambo> adapter =
         EnumJsonAdapter.create(Roshambo.class).withUnknownFallback(Roshambo.ROCK);
     JsonReader reader = JsonReader.of(new Buffer().writeUtf8("\"SPOCK\""));
-    assertThat(adapter.fromJson(reader)).isEqualTo(Roshambo.ROCK);
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(adapter.fromJson(reader), Roshambo.ROCK);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -69,8 +69,8 @@ public final class EnumJsonAdapterTest {
     EnumJsonAdapter<Roshambo> adapter =
         EnumJsonAdapter.create(Roshambo.class).withUnknownFallback(null);
     JsonReader reader = JsonReader.of(new Buffer().writeUtf8("\"SPOCK\""));
-    assertThat(adapter.fromJson(reader)).isNull();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertNull(adapter.fromJson(reader));
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   enum Roshambo {

--- a/moshi-adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
+++ b/moshi-adapters/src/test/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactoryTest.java
@@ -15,7 +15,9 @@
  */
 package com.squareup.moshi.adapters;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.squareup.moshi.JsonAdapter;
@@ -43,10 +45,11 @@ public final class PolymorphicJsonAdapterFactoryTest {
             .build();
     JsonAdapter<Message> adapter = moshi.adapter(Message.class);
 
-    assertThat(adapter.fromJson("{\"type\":\"success\",\"value\":\"Okay!\"}"))
-        .isEqualTo(new Success("Okay!"));
-    assertThat(adapter.fromJson("{\"type\":\"error\",\"error_logs\":{\"order\":66}}"))
-        .isEqualTo(new Error(Collections.<String, Object>singletonMap("order", 66d)));
+    assertEquals(
+        adapter.fromJson("{\"type\":\"success\",\"value\":\"Okay!\"}"), new Success("Okay!"));
+    assertEquals(
+        adapter.fromJson("{\"type\":\"error\",\"error_logs\":{\"order\":66}}"),
+        new Error(Collections.<String, Object>singletonMap("order", 66d)));
   }
 
   @Test
@@ -60,10 +63,11 @@ public final class PolymorphicJsonAdapterFactoryTest {
             .build();
     JsonAdapter<Message> adapter = moshi.adapter(Message.class);
 
-    assertThat(adapter.toJson(new Success("Okay!")))
-        .isEqualTo("{\"type\":\"success\",\"value\":\"Okay!\"}");
-    assertThat(adapter.toJson(new Error(Collections.<String, Object>singletonMap("order", 66))))
-        .isEqualTo("{\"type\":\"error\",\"error_logs\":{\"order\":66}}");
+    assertEquals(
+        adapter.toJson(new Success("Okay!")), "{\"type\":\"success\",\"value\":\"Okay!\"}");
+    assertEquals(
+        adapter.toJson(new Error(Collections.singletonMap("order", 66))),
+        "{\"type\":\"error\",\"error_logs\":{\"order\":66}}");
   }
 
   @Test
@@ -83,13 +87,12 @@ public final class PolymorphicJsonAdapterFactoryTest {
       adapter.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Expected one of [success, error] for key 'type' but found"
-                  + " 'data'. Register a subtype for this label.");
+      assertEquals(
+          "Expected one of [success, error] for key 'type' but found"
+              + " 'data'. Register a subtype for this label.",
+          expected.getMessage());
     }
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.BEGIN_OBJECT);
+    assertEquals(reader.peek(), JsonReader.Token.BEGIN_OBJECT);
   }
 
   @Test
@@ -106,7 +109,8 @@ public final class PolymorphicJsonAdapterFactoryTest {
     JsonAdapter<Message> adapter = moshi.adapter(Message.class);
 
     Message message = adapter.fromJson("{\"type\":\"data\",\"value\":\"Okay!\"}");
-    assertThat(message).isSameInstanceAs(fallbackError);
+    assertEquals(message.getClass(), fallbackError.getClass());
+    assertEquals(message.getClass().getName(), fallbackError.getClass().getName());
   }
 
   @Test
@@ -122,7 +126,7 @@ public final class PolymorphicJsonAdapterFactoryTest {
     JsonAdapter<Message> adapter = moshi.adapter(Message.class);
 
     Message message = adapter.fromJson("{\"type\":\"data\",\"value\":\"Okay!\"}");
-    assertThat(message).isNull();
+    assertNull(message);
   }
 
   @Test
@@ -138,10 +142,10 @@ public final class PolymorphicJsonAdapterFactoryTest {
                           @Override
                           public Object fromJson(JsonReader reader) throws IOException {
                             reader.beginObject();
-                            assertThat(reader.nextName()).isEqualTo("type");
-                            assertThat(reader.nextString()).isEqualTo("data");
-                            assertThat(reader.nextName()).isEqualTo("value");
-                            assertThat(reader.nextString()).isEqualTo("Okay!");
+                            assertEquals(reader.nextName(), "type");
+                            assertEquals(reader.nextString(), "data");
+                            assertEquals(reader.nextName(), "value");
+                            assertEquals(reader.nextString(), "Okay!");
                             reader.endObject();
                             return new EmptyMessage();
                           }
@@ -158,8 +162,8 @@ public final class PolymorphicJsonAdapterFactoryTest {
         JsonReader.of(new Buffer().writeUtf8("{\"type\":\"data\",\"value\":\"Okay!\"}"));
 
     Message message = adapter.fromJson(reader);
-    assertThat(message).isInstanceOf(EmptyMessage.class);
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertTrue(message instanceof EmptyMessage);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -176,15 +180,14 @@ public final class PolymorphicJsonAdapterFactoryTest {
     try {
       adapter.toJson(new EmptyMessage());
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Expected one of [class"
-                  + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$Success, class"
-                  + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$Error] but found"
-                  + " EmptyMessage, a class"
-                  + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$EmptyMessage. Register"
-                  + " this subtype.");
+      assertEquals(
+          "Expected one of [class"
+              + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$Success, class"
+              + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$Error] but found"
+              + " EmptyMessage, a class"
+              + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$EmptyMessage. Register"
+              + " this subtype.",
+          expected.getMessage());
     }
   }
 
@@ -204,15 +207,14 @@ public final class PolymorphicJsonAdapterFactoryTest {
     try {
       adapter.toJson(new EmptyMessage());
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Expected one of [class"
-                  + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$Success, class"
-                  + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$Error] but found"
-                  + " EmptyMessage, a class"
-                  + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$EmptyMessage. Register"
-                  + " this subtype.");
+      assertEquals(
+          "Expected one of [class"
+              + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$Success, class"
+              + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$Error] but found"
+              + " EmptyMessage, a class"
+              + " com.squareup.moshi.adapters.PolymorphicJsonAdapterFactoryTest$EmptyMessage. Register"
+              + " this subtype.",
+          expected.getMessage());
     }
   }
 
@@ -241,7 +243,7 @@ public final class PolymorphicJsonAdapterFactoryTest {
     JsonAdapter<Message> adapter = moshi.adapter(Message.class);
 
     String json = adapter.toJson(new EmptyMessage());
-    assertThat(json).isEqualTo("{\"type\":\"injected by fallbackJsonAdapter\"}");
+    assertEquals(json, "{\"type\":\"injected by fallbackJsonAdapter\"}");
   }
 
   @Test
@@ -259,9 +261,7 @@ public final class PolymorphicJsonAdapterFactoryTest {
       adapter.fromJson("{\"type\":{},\"value\":\"Okay!\"}");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected a string but was BEGIN_OBJECT at path $.type");
+      assertEquals("Expected a string but was BEGIN_OBJECT at path $.type", expected.getMessage());
     }
   }
 
@@ -281,12 +281,10 @@ public final class PolymorphicJsonAdapterFactoryTest {
       adapter.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected BEGIN_OBJECT but was STRING at path $");
+      assertEquals("Expected BEGIN_OBJECT but was STRING at path $", expected.getMessage());
     }
-    assertThat(reader.nextString()).isEqualTo("Failure");
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.nextString(), "Failure");
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -302,14 +300,14 @@ public final class PolymorphicJsonAdapterFactoryTest {
 
     JsonAdapter<Message> adapter = moshi.adapter(Message.class);
 
-    assertThat(adapter.fromJson("{\"type\":\"success\",\"value\":\"Okay!\"}"))
-        .isEqualTo(new Success("Okay!"));
-    assertThat(adapter.fromJson("{\"type\":\"data\",\"value\":\"Data!\"}"))
-        .isEqualTo(new Success("Data!"));
-    assertThat(adapter.fromJson("{\"type\":\"error\",\"error_logs\":{\"order\":66}}"))
-        .isEqualTo(new Error(Collections.<String, Object>singletonMap("order", 66d)));
-    assertThat(adapter.toJson(new Success("Data!")))
-        .isEqualTo("{\"type\":\"success\",\"value\":\"Data!\"}");
+    assertEquals(
+        adapter.fromJson("{\"type\":\"success\",\"value\":\"Okay!\"}"), new Success("Okay!"));
+    assertEquals(adapter.fromJson("{\"type\":\"data\",\"value\":\"Data!\"}"), new Success("Data!"));
+    assertEquals(
+        adapter.fromJson("{\"type\":\"error\",\"error_logs\":{\"order\":66}}"),
+        new Error(Collections.<String, Object>singletonMap("order", 66d)));
+    assertEquals(
+        adapter.toJson(new Success("Data!")), "{\"type\":\"success\",\"value\":\"Data!\"}");
   }
 
   @Test
@@ -320,7 +318,7 @@ public final class PolymorphicJsonAdapterFactoryTest {
       factory.withSubtype(Error.class, "data");
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Labels must be unique.");
+      assertEquals("Labels must be unique.", expected.getMessage());
     }
   }
 
@@ -336,8 +334,8 @@ public final class PolymorphicJsonAdapterFactoryTest {
     JsonAdapter<Message> adapter = moshi.adapter(Message.class);
 
     JsonReader reader = JsonReader.of(new Buffer().writeUtf8("null"));
-    assertThat(adapter.fromJson(reader)).isNull();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertNull(adapter.fromJson(reader));
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   /**
@@ -354,12 +352,13 @@ public final class PolymorphicJsonAdapterFactoryTest {
             .build();
     JsonAdapter<Message> adapter = moshi.adapter(Message.class);
 
-    assertThat(adapter.toJson(new MessageWithUnportableTypes(9007199254740993L)))
-        .isEqualTo("{\"type\":\"unportable\",\"long_value\":9007199254740993}");
+    assertEquals(
+        adapter.toJson(new MessageWithUnportableTypes(9007199254740993L)),
+        "{\"type\":\"unportable\",\"long_value\":9007199254740993}");
     MessageWithUnportableTypes decoded =
         (MessageWithUnportableTypes)
             adapter.fromJson("{\"type\":\"unportable\",\"long_value\":9007199254740993}");
-    assertThat(decoded.long_value).isEqualTo(9007199254740993L);
+    assertEquals(decoded.long_value, 9007199254740993L);
   }
 
   @Test
@@ -374,7 +373,7 @@ public final class PolymorphicJsonAdapterFactoryTest {
 
     MessageWithType decoded =
         (MessageWithType) adapter.fromJson("{\"value\":\"Okay!\",\"type\":\"success\"}");
-    assertThat(decoded.value).isEqualTo("Okay!");
+    assertEquals(decoded.value, "Okay!");
   }
 
   interface Message {}

--- a/moshi-adapters/src/test/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapterTest.java
+++ b/moshi-adapters/src/test/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapterTest.java
@@ -15,7 +15,8 @@
  */
 package com.squareup.moshi.adapters;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import com.squareup.moshi.JsonAdapter;
 import java.util.Calendar;
@@ -30,46 +31,51 @@ public final class Rfc3339DateJsonAdapterTest {
 
   @Test
   public void fromJsonWithTwoDigitMillis() throws Exception {
-    assertThat(adapter.fromJson("\"1985-04-12T23:20:50.52Z\""))
-        .isEqualTo(newDate(1985, 4, 12, 23, 20, 50, 520, 0));
+    assertEquals(
+        adapter.fromJson("\"1985-04-12T23:20:50.52Z\""), newDate(1985, 4, 12, 23, 20, 50, 520, 0));
   }
 
   @Test
   public void fromJson() throws Exception {
-    assertThat(adapter.fromJson("\"1970-01-01T00:00:00.000Z\""))
-        .isEqualTo(newDate(1970, 1, 1, 0, 0, 0, 0, 0));
-    assertThat(adapter.fromJson("\"1985-04-12T23:20:50.520Z\""))
-        .isEqualTo(newDate(1985, 4, 12, 23, 20, 50, 520, 0));
-    assertThat(adapter.fromJson("\"1996-12-19T16:39:57-08:00\""))
-        .isEqualTo(newDate(1996, 12, 19, 16, 39, 57, 0, -8 * 60));
-    assertThat(adapter.fromJson("\"1990-12-31T23:59:60Z\""))
-        .isEqualTo(newDate(1990, 12, 31, 23, 59, 59, 0, 0));
-    assertThat(adapter.fromJson("\"1990-12-31T15:59:60-08:00\""))
-        .isEqualTo(newDate(1990, 12, 31, 15, 59, 59, 0, -8 * 60));
-    assertThat(adapter.fromJson("\"1937-01-01T12:00:27.870+00:20\""))
-        .isEqualTo(newDate(1937, 1, 1, 12, 0, 27, 870, 20));
+    assertEquals(
+        adapter.fromJson("\"1970-01-01T00:00:00.000Z\""), newDate(1970, 1, 1, 0, 0, 0, 0, 0));
+    assertEquals(
+        adapter.fromJson("\"1985-04-12T23:20:50.520Z\""), newDate(1985, 4, 12, 23, 20, 50, 520, 0));
+    assertEquals(
+        adapter.fromJson("\"1996-12-19T16:39:57-08:00\""),
+        newDate(1996, 12, 19, 16, 39, 57, 0, -8 * 60));
+    assertEquals(
+        adapter.fromJson("\"1990-12-31T23:59:60Z\""), newDate(1990, 12, 31, 23, 59, 59, 0, 0));
+    assertEquals(
+        adapter.fromJson("\"1990-12-31T15:59:60-08:00\""),
+        newDate(1990, 12, 31, 15, 59, 59, 0, -8 * 60));
+    assertEquals(
+        adapter.fromJson("\"1937-01-01T12:00:27.870+00:20\""),
+        newDate(1937, 1, 1, 12, 0, 27, 870, 20));
   }
 
   @Test
   public void toJson() throws Exception {
-    assertThat(adapter.toJson(newDate(1970, 1, 1, 0, 0, 0, 0, 0)))
-        .isEqualTo("\"1970-01-01T00:00:00.000Z\"");
-    assertThat(adapter.toJson(newDate(1985, 4, 12, 23, 20, 50, 520, 0)))
-        .isEqualTo("\"1985-04-12T23:20:50.520Z\"");
-    assertThat(adapter.toJson(newDate(1996, 12, 19, 16, 39, 57, 0, -8 * 60)))
-        .isEqualTo("\"1996-12-20T00:39:57.000Z\"");
-    assertThat(adapter.toJson(newDate(1990, 12, 31, 23, 59, 59, 0, 0)))
-        .isEqualTo("\"1990-12-31T23:59:59.000Z\"");
-    assertThat(adapter.toJson(newDate(1990, 12, 31, 15, 59, 59, 0, -8 * 60)))
-        .isEqualTo("\"1990-12-31T23:59:59.000Z\"");
-    assertThat(adapter.toJson(newDate(1937, 1, 1, 12, 0, 27, 870, 20)))
-        .isEqualTo("\"1937-01-01T11:40:27.870Z\"");
+    assertEquals(
+        adapter.toJson(newDate(1970, 1, 1, 0, 0, 0, 0, 0)), "\"1970-01-01T00:00:00.000Z\"");
+    assertEquals(
+        adapter.toJson(newDate(1985, 4, 12, 23, 20, 50, 520, 0)), "\"1985-04-12T23:20:50.520Z\"");
+    assertEquals(
+        adapter.toJson(newDate(1996, 12, 19, 16, 39, 57, 0, -8 * 60)),
+        "\"1996-12-20T00:39:57.000Z\"");
+    assertEquals(
+        adapter.toJson(newDate(1990, 12, 31, 23, 59, 59, 0, 0)), "\"1990-12-31T23:59:59.000Z\"");
+    assertEquals(
+        adapter.toJson(newDate(1990, 12, 31, 15, 59, 59, 0, -8 * 60)),
+        "\"1990-12-31T23:59:59.000Z\"");
+    assertEquals(
+        adapter.toJson(newDate(1937, 1, 1, 12, 0, 27, 870, 20)), "\"1937-01-01T11:40:27.870Z\"");
   }
 
   @Test
   public void nullSafety() throws Exception {
-    assertThat(adapter.toJson(null)).isEqualTo("null");
-    assertThat(adapter.fromJson("null")).isNull();
+    assertEquals(adapter.toJson(null), "null");
+    assertNull(adapter.fromJson("null"));
   }
 
   private Date newDate(

--- a/moshi-kotlin-codegen/build.gradle.kts
+++ b/moshi-kotlin-codegen/build.gradle.kts
@@ -75,7 +75,6 @@ dependencies {
   testImplementation(libs.kotlinpoet.metadata)
   testImplementation(libs.kotlinpoet.ksp)
   testImplementation(libs.junit)
-  testImplementation(libs.truth)
   testImplementation(libs.kotlinCompileTesting)
 }
 

--- a/moshi-kotlin-codegen/src/test/java/com/squareup/moshi/kotlin/codegen/apt/JsonClassCodegenProcessorTest.kt
+++ b/moshi-kotlin-codegen/src/test/java/com/squareup/moshi/kotlin/codegen/apt/JsonClassCodegenProcessorTest.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.moshi.kotlin.codegen.apt
 
-import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.kotlin.codegen.api.Options.OPTION_GENERATED
@@ -23,6 +22,8 @@ import com.squareup.moshi.kotlin.codegen.api.Options.OPTION_GENERATE_PROGUARD_RU
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import com.tschuchort.compiletesting.SourceFile.Companion.kotlin
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
@@ -60,8 +61,8 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains("constructor is not internal or public")
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(result.messages.contains("constructor is not internal or public"))
   }
 
   @Test
@@ -77,8 +78,8 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains("property a is not visible")
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(result.messages.contains("property a is not visible"))
   }
 
   @Test
@@ -97,8 +98,8 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains("property a is not visible")
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(result.messages.contains("property a is not visible"))
   }
 
   @Test
@@ -114,9 +115,11 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "error: @JsonClass can't be applied to Interface: must be a Kotlin class"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "error: @JsonClass can't be applied to Interface: must be a Kotlin class"
+      )
     )
   }
 
@@ -133,7 +136,7 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK)
   }
 
   @Test
@@ -149,9 +152,11 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "error: @JsonClass can't be applied to AbstractClass: must not be abstract"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "error: @JsonClass can't be applied to AbstractClass: must not be abstract"
+      )
     )
   }
 
@@ -168,9 +173,11 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "error: @JsonClass can't be applied to SealedClass: must not be sealed"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "error: @JsonClass can't be applied to SealedClass: must not be sealed"
+      )
     )
   }
 
@@ -189,9 +196,11 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "error: @JsonClass can't be applied to Outer.InnerClass: must not be an inner class"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "error: @JsonClass can't be applied to Outer.InnerClass: must not be an inner class"
+      )
     )
   }
 
@@ -210,9 +219,11 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "error: @JsonClass with 'generateAdapter = \"true\"' can't be applied to KotlinEnum: code gen for enums is not supported or necessary"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "error: @JsonClass with 'generateAdapter = \"true\"' can't be applied to KotlinEnum: code gen for enums is not supported or necessary"
+      )
     )
   }
 
@@ -233,9 +244,11 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "error: @JsonClass can't be applied to LocalClass: must not be local"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "error: @JsonClass can't be applied to LocalClass: must not be local"
+      )
     )
   }
 
@@ -252,9 +265,11 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "error: @JsonClass can't be applied to PrivateClass: must be internal or public"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "error: @JsonClass can't be applied to PrivateClass: must be internal or public"
+      )
     )
   }
 
@@ -273,9 +288,11 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "error: @JsonClass can't be applied to ObjectDeclaration: must be a Kotlin class"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "error: @JsonClass can't be applied to ObjectDeclaration: must be a Kotlin class"
+      )
     )
   }
 
@@ -294,9 +311,11 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "error: @JsonClass can't be applied to getExpression\$annotations(): must be a Kotlin class"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "error: @JsonClass can't be applied to getExpression\$annotations(): must be a Kotlin class"
+      )
     )
   }
 
@@ -313,9 +332,11 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "error: No default value for transient/ignored property a"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "error: No default value for transient/ignored property a"
+      )
     )
   }
 
@@ -333,9 +354,11 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "error: No default value for transient/ignored property a"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "error: No default value for transient/ignored property a"
+      )
     )
   }
 
@@ -352,9 +375,11 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "error: No property for required constructor parameter a"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "error: No property for required constructor parameter a"
+      )
     )
   }
 
@@ -373,8 +398,10 @@ class JsonClassCodegenProcessorTest {
     ).apply {
       kaptArgs[OPTION_GENERATED] = "javax.annotation.GeneratedBlerg"
     }.compile()
-    assertThat(result.messages).contains(
-      "Invalid option value for $OPTION_GENERATED"
+    assertTrue(
+      result.messages.contains(
+        "Invalid option value for $OPTION_GENERATED"
+      )
     )
   }
   @Test
@@ -392,7 +419,7 @@ class JsonClassCodegenProcessorTest {
     ).apply {
       kaptArgs[OPTION_GENERATE_PROGUARD_RULES] = "false"
     }.compile()
-    assertThat(result.generatedFiles.filter { it.endsWith(".pro") }).isEmpty()
+    assertEquals(0, result.generatedFiles.filter { it.endsWith(".pro") }.size)
   }
 
   @Test
@@ -411,9 +438,9 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains("property a is not visible")
-    assertThat(result.messages).contains("property c is not visible")
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(result.messages.contains("property a is not visible"))
+    assertTrue(result.messages.contains("property c is not visible"))
   }
 
   @Test
@@ -430,7 +457,7 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.messages).contains("supertype java.util.Date is not a Kotlin type")
+    assertTrue(result.messages.contains("supertype java.util.Date is not a Kotlin type"))
   }
 
   @Test
@@ -447,9 +474,11 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages)
-      .contains("supertype com.squareup.moshi.kotlin.codegen.JavaSuperclass is not a Kotlin type")
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages
+        .contains("supertype com.squareup.moshi.kotlin.codegen.JavaSuperclass is not a Kotlin type")
+    )
   }
 
   @Test
@@ -476,7 +505,7 @@ class JsonClassCodegenProcessorTest {
       )
     )
     // We instantiate directly so doesn't need to be FIELD
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK)
   }
 
   @Test
@@ -503,8 +532,8 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains("JsonQualifier @UpperCase must have RUNTIME retention")
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(result.messages.contains("JsonQualifier @UpperCase must have RUNTIME retention"))
   }
 
   @Test
@@ -523,15 +552,14 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK)
 
     // We're checking here that we only generate one `stringAdapter` that's used for both the
     // regular string properties as well as the the aliased ones.
     val adapterClass = result.classLoader.loadClass("PersonJsonAdapter").kotlin
-    assertThat(adapterClass.declaredMemberProperties.map { it.returnType }).containsExactly(
-      JsonReader.Options::class.createType(),
-      JsonAdapter::class.parameterizedBy(String::class)
-    )
+    val types = adapterClass.declaredMemberProperties.map { it.returnType }
+    assertEquals(types[0], JsonReader.Options::class.createType())
+    assertEquals(types[1], JsonAdapter::class.parameterizedBy(String::class))
   }
 
   @Test
@@ -651,64 +679,75 @@ class JsonClassCodegenProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK)
 
     result.generatedFiles.filter { it.extension == "pro" }.forEach { generatedFile ->
       when (generatedFile.nameWithoutExtension) {
-        "moshi-testPackage.Aliases" -> assertThat(generatedFile.readText()).contains(
-          """
+        "moshi-testPackage.Aliases" -> assertTrue(
+          generatedFile.readText().contains(
+            """
           -if class testPackage.Aliases
           -keepnames class testPackage.Aliases
           -if class testPackage.Aliases
           -keep class testPackage.AliasesJsonAdapter {
               public <init>(com.squareup.moshi.Moshi);
           }
-          """.trimIndent()
+            """.trimIndent()
+          )
         )
-        "moshi-testPackage.Simple" -> assertThat(generatedFile.readText()).contains(
-          """
+        "moshi-testPackage.Simple" -> assertTrue(
+          generatedFile.readText().contains(
+            """
           -if class testPackage.Simple
           -keepnames class testPackage.Simple
           -if class testPackage.Simple
           -keep class testPackage.SimpleJsonAdapter {
               public <init>(com.squareup.moshi.Moshi);
           }
-          """.trimIndent()
+            """.trimIndent()
+          )
         )
-        "moshi-testPackage.Generic" -> assertThat(generatedFile.readText()).contains(
-          """
+        "moshi-testPackage.Generic" -> assertTrue(
+          generatedFile.readText().contains(
+            """
           -if class testPackage.Generic
           -keepnames class testPackage.Generic
           -if class testPackage.Generic
           -keep class testPackage.GenericJsonAdapter {
               public <init>(com.squareup.moshi.Moshi,java.lang.reflect.Type[]);
           }
-          """.trimIndent()
+            """.trimIndent()
+          )
         )
         "moshi-testPackage.UsingQualifiers" -> {
-          assertThat(generatedFile.readText()).contains(
-            """
+          assertTrue(
+            generatedFile.readText().contains(
+              """
             -if class testPackage.UsingQualifiers
             -keepnames class testPackage.UsingQualifiers
             -if class testPackage.UsingQualifiers
             -keep class testPackage.UsingQualifiersJsonAdapter {
                 public <init>(com.squareup.moshi.Moshi);
             }
-            """.trimIndent()
+              """.trimIndent()
+            )
           )
         }
-        "moshi-testPackage.MixedTypes" -> assertThat(generatedFile.readText()).contains(
-          """
+        "moshi-testPackage.MixedTypes" -> assertTrue(
+          generatedFile.readText().contains(
+            """
           -if class testPackage.MixedTypes
           -keepnames class testPackage.MixedTypes
           -if class testPackage.MixedTypes
           -keep class testPackage.MixedTypesJsonAdapter {
               public <init>(com.squareup.moshi.Moshi);
           }
-          """.trimIndent()
+            """.trimIndent()
+          )
         )
-        "moshi-testPackage.DefaultParams" -> assertThat(generatedFile.readText()).contains(
-          """
+        "moshi-testPackage.DefaultParams" -> assertTrue(
+          generatedFile.readText().contains(
+            """
           -if class testPackage.DefaultParams
           -keepnames class testPackage.DefaultParams
           -if class testPackage.DefaultParams
@@ -721,11 +760,13 @@ class JsonClassCodegenProcessorTest {
           -keepclassmembers class testPackage.DefaultParams {
               public synthetic <init>(java.lang.String,int,kotlin.jvm.internal.DefaultConstructorMarker);
           }
-          """.trimIndent()
+            """.trimIndent()
+          )
         )
         "moshi-testPackage.Complex" -> {
-          assertThat(generatedFile.readText()).contains(
-            """
+          assertTrue(
+            generatedFile.readText().contains(
+              """
             -if class testPackage.Complex
             -keepnames class testPackage.Complex
             -if class testPackage.Complex
@@ -738,11 +779,13 @@ class JsonClassCodegenProcessorTest {
             -keepclassmembers class testPackage.Complex {
                 public synthetic <init>(java.lang.String,java.util.List,java.lang.Object,int,kotlin.jvm.internal.DefaultConstructorMarker);
             }
-            """.trimIndent()
+              """.trimIndent()
+            )
           )
         }
-        "moshi-testPackage.MultipleMasks" -> assertThat(generatedFile.readText()).contains(
-          """
+        "moshi-testPackage.MultipleMasks" -> assertTrue(
+          generatedFile.readText().contains(
+            """
           -if class testPackage.MultipleMasks
           -keepnames class testPackage.MultipleMasks
           -if class testPackage.MultipleMasks
@@ -755,18 +798,21 @@ class JsonClassCodegenProcessorTest {
           -keepclassmembers class testPackage.MultipleMasks {
               public synthetic <init>(long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,int,int,int,kotlin.jvm.internal.DefaultConstructorMarker);
           }
-          """.trimIndent()
+            """.trimIndent()
+          )
         )
         "moshi-testPackage.NestedType.NestedSimple" -> {
-          assertThat(generatedFile.readText()).contains(
-            """
+          assertTrue(
+            generatedFile.readText().contains(
+              """
             -if class testPackage.NestedType${'$'}NestedSimple
             -keepnames class testPackage.NestedType${'$'}NestedSimple
             -if class testPackage.NestedType${'$'}NestedSimple
             -keep class testPackage.NestedType_NestedSimpleJsonAdapter {
                 public <init>(com.squareup.moshi.Moshi);
             }
-            """.trimIndent()
+              """.trimIndent()
+            )
           )
         }
         else -> error("Unexpected proguard file! ${generatedFile.name}")

--- a/moshi-kotlin-codegen/src/test/java/com/squareup/moshi/kotlin/codegen/ksp/JsonClassSymbolProcessorTest.kt
+++ b/moshi-kotlin-codegen/src/test/java/com/squareup/moshi/kotlin/codegen/ksp/JsonClassSymbolProcessorTest.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.moshi.kotlin.codegen.ksp
 
-import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.kotlin.codegen.api.Options.OPTION_GENERATED
 import com.squareup.moshi.kotlin.codegen.api.Options.OPTION_GENERATE_PROGUARD_RULES
 import com.tschuchort.compiletesting.KotlinCompilation
@@ -26,6 +25,8 @@ import com.tschuchort.compiletesting.kspArgs
 import com.tschuchort.compiletesting.kspIncremental
 import com.tschuchort.compiletesting.kspSourcesDir
 import com.tschuchort.compiletesting.symbolProcessorProviders
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
@@ -56,8 +57,8 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains("constructor is not internal or public")
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(result.messages.contains("constructor is not internal or public"))
   }
 
   @Test
@@ -74,8 +75,8 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains("property a is not visible")
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(result.messages.contains("property a is not visible"))
   }
 
   @Test
@@ -95,8 +96,8 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains("property a is not visible")
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(result.messages.contains("property a is not visible"))
   }
 
   @Test
@@ -113,9 +114,11 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "@JsonClass can't be applied to test.Interface: must be a Kotlin class"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "@JsonClass can't be applied to test.Interface: must be a Kotlin class"
+      )
     )
   }
 
@@ -133,7 +136,7 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK)
   }
 
   @Test
@@ -150,9 +153,11 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "@JsonClass can't be applied to test.AbstractClass: must not be abstract"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "@JsonClass can't be applied to test.AbstractClass: must not be abstract"
+      )
     )
   }
 
@@ -170,9 +175,11 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "@JsonClass can't be applied to test.SealedClass: must not be sealed"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "@JsonClass can't be applied to test.SealedClass: must not be sealed"
+      )
     )
   }
 
@@ -192,9 +199,11 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "@JsonClass can't be applied to test.Outer.InnerClass: must not be an inner class"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "@JsonClass can't be applied to test.Outer.InnerClass: must not be an inner class"
+      )
     )
   }
 
@@ -214,9 +223,11 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "@JsonClass with 'generateAdapter = \"true\"' can't be applied to test.KotlinEnum: code gen for enums is not supported or necessary"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "@JsonClass with 'generateAdapter = \"true\"' can't be applied to test.KotlinEnum: code gen for enums is not supported or necessary"
+      )
     )
   }
 
@@ -238,9 +249,11 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "@JsonClass can't be applied to LocalClass: must not be local"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "@JsonClass can't be applied to LocalClass: must not be local"
+      )
     )
   }
 
@@ -258,9 +271,11 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "@JsonClass can't be applied to test.PrivateClass: must be internal or public"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "@JsonClass can't be applied to test.PrivateClass: must be internal or public"
+      )
     )
   }
 
@@ -280,9 +295,11 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "@JsonClass can't be applied to test.ObjectDeclaration: must be a Kotlin class"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "@JsonClass can't be applied to test.ObjectDeclaration: must be a Kotlin class"
+      )
     )
   }
 
@@ -302,9 +319,11 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "@JsonClass can't be applied to test.expression: must be a Kotlin class"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "@JsonClass can't be applied to test.expression: must be a Kotlin class"
+      )
     )
   }
 
@@ -322,9 +341,11 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "No default value for transient/ignored property a"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "No default value for transient/ignored property a"
+      )
     )
   }
 
@@ -343,9 +364,11 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "No default value for transient/ignored property a"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "No default value for transient/ignored property a"
+      )
     )
   }
 
@@ -363,9 +386,11 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains(
-      "No property for required constructor parameter a"
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages.contains(
+        "No property for required constructor parameter a"
+      )
     )
   }
 
@@ -385,8 +410,10 @@ class JsonClassSymbolProcessorTest {
     ).apply {
       kspArgs[OPTION_GENERATED] = "javax.annotation.GeneratedBlerg"
     }.compile()
-    assertThat(result.messages).contains(
-      "Invalid option value for $OPTION_GENERATED"
+    assertTrue(
+      result.messages.contains(
+        "Invalid option value for $OPTION_GENERATED"
+      )
     )
   }
 
@@ -407,8 +434,8 @@ class JsonClassSymbolProcessorTest {
       kspArgs[OPTION_GENERATE_PROGUARD_RULES] = "false"
     }
     val result = compilation.compile()
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
-    assertThat(compilation.kspSourcesDir.walkTopDown().filter { it.extension == "pro" }.toList()).isEmpty()
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK)
+    assertEquals(0, compilation.kspSourcesDir.walkTopDown().filter { it.extension == "pro" }.toList().size)
   }
 
   @Test
@@ -428,9 +455,9 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains("property a is not visible")
-    assertThat(result.messages).contains("property c is not visible")
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(result.messages.contains("property a is not visible"))
+    assertTrue(result.messages.contains("property c is not visible"))
   }
 
   @Test
@@ -448,7 +475,7 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.messages).contains("supertype java.util.Date is not a Kotlin type")
+    assertTrue(result.messages.contains("supertype java.util.Date is not a Kotlin type"))
   }
 
   @Test
@@ -475,9 +502,11 @@ class JsonClassSymbolProcessorTest {
         """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages)
-      .contains("supertype com.squareup.moshi.kotlin.codegen.JavaSuperclass is not a Kotlin type")
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(
+      result.messages
+        .contains("supertype com.squareup.moshi.kotlin.codegen.JavaSuperclass is not a Kotlin type")
+    )
   }
 
   @Test
@@ -505,7 +534,7 @@ class JsonClassSymbolProcessorTest {
       )
     )
     // We instantiate directly, no FIELD site target necessary
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK)
   }
 
   @Test
@@ -533,8 +562,8 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
-    assertThat(result.messages).contains("JsonQualifier @UpperCase must have RUNTIME retention")
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertTrue(result.messages.contains("JsonQualifier @UpperCase must have RUNTIME retention"))
   }
 
   @Test
@@ -554,13 +583,13 @@ class JsonClassSymbolProcessorTest {
           """
       )
     )
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK)
 
     // We're checking here that we only generate one `stringAdapter` that's used for both the
     // regular string properties as well as the the aliased ones.
     // TODO loading compiled classes from results not supported in KSP yet
 //    val adapterClass = result.classLoader.loadClass("PersonJsonAdapter").kotlin
-//    assertThat(adapterClass.declaredMemberProperties.map { it.returnType }).containsExactly(
+//    assertEquals(adapterClass.declaredMemberProperties.map { it.returnType }).containsExactly(
 //      JsonReader.Options::class.createType(),
 //      JsonAdapter::class.parameterizedBy(String::class)
 //    )
@@ -684,64 +713,75 @@ class JsonClassSymbolProcessorTest {
       )
     )
     val result = compilation.compile()
-    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK)
 
     compilation.kspSourcesDir.walkTopDown().filter { it.extension == "pro" }.forEach { generatedFile ->
       when (generatedFile.nameWithoutExtension) {
-        "moshi-testPackage.Aliases" -> assertThat(generatedFile.readText()).contains(
-          """
+        "moshi-testPackage.Aliases" -> assertTrue(
+          generatedFile.readText().contains(
+            """
           -if class testPackage.Aliases
           -keepnames class testPackage.Aliases
           -if class testPackage.Aliases
           -keep class testPackage.AliasesJsonAdapter {
               public <init>(com.squareup.moshi.Moshi);
           }
-          """.trimIndent()
+            """.trimIndent()
+          )
         )
-        "moshi-testPackage.Simple" -> assertThat(generatedFile.readText()).contains(
-          """
+        "moshi-testPackage.Simple" -> assertTrue(
+          generatedFile.readText().contains(
+            """
           -if class testPackage.Simple
           -keepnames class testPackage.Simple
           -if class testPackage.Simple
           -keep class testPackage.SimpleJsonAdapter {
               public <init>(com.squareup.moshi.Moshi);
           }
-          """.trimIndent()
+            """.trimIndent()
+          )
         )
-        "moshi-testPackage.Generic" -> assertThat(generatedFile.readText()).contains(
-          """
+        "moshi-testPackage.Generic" -> assertTrue(
+          generatedFile.readText().contains(
+            """
           -if class testPackage.Generic
           -keepnames class testPackage.Generic
           -if class testPackage.Generic
           -keep class testPackage.GenericJsonAdapter {
               public <init>(com.squareup.moshi.Moshi,java.lang.reflect.Type[]);
           }
-          """.trimIndent()
+            """.trimIndent()
+          )
         )
         "moshi-testPackage.UsingQualifiers" -> {
-          assertThat(generatedFile.readText()).contains(
-            """
+          assertTrue(
+            generatedFile.readText().contains(
+              """
             -if class testPackage.UsingQualifiers
             -keepnames class testPackage.UsingQualifiers
             -if class testPackage.UsingQualifiers
             -keep class testPackage.UsingQualifiersJsonAdapter {
                 public <init>(com.squareup.moshi.Moshi);
             }
-            """.trimIndent()
+              """.trimIndent()
+            )
           )
         }
-        "moshi-testPackage.MixedTypes" -> assertThat(generatedFile.readText()).contains(
-          """
+        "moshi-testPackage.MixedTypes" -> assertTrue(
+          generatedFile.readText().contains(
+            """
           -if class testPackage.MixedTypes
           -keepnames class testPackage.MixedTypes
           -if class testPackage.MixedTypes
           -keep class testPackage.MixedTypesJsonAdapter {
               public <init>(com.squareup.moshi.Moshi);
           }
-          """.trimIndent()
+            """.trimIndent()
+          )
         )
-        "moshi-testPackage.DefaultParams" -> assertThat(generatedFile.readText()).contains(
-          """
+        "moshi-testPackage.DefaultParams" -> assertTrue(
+          generatedFile.readText().contains(
+            """
           -if class testPackage.DefaultParams
           -keepnames class testPackage.DefaultParams
           -if class testPackage.DefaultParams
@@ -754,11 +794,13 @@ class JsonClassSymbolProcessorTest {
           -keepclassmembers class testPackage.DefaultParams {
               public synthetic <init>(java.lang.String,int,kotlin.jvm.internal.DefaultConstructorMarker);
           }
-          """.trimIndent()
+            """.trimIndent()
+          )
         )
         "moshi-testPackage.Complex" -> {
-          assertThat(generatedFile.readText()).contains(
-            """
+          assertTrue(
+            generatedFile.readText().contains(
+              """
             -if class testPackage.Complex
             -keepnames class testPackage.Complex
             -if class testPackage.Complex
@@ -771,11 +813,13 @@ class JsonClassSymbolProcessorTest {
             -keepclassmembers class testPackage.Complex {
                 public synthetic <init>(java.lang.String,java.util.List,java.lang.Object,int,kotlin.jvm.internal.DefaultConstructorMarker);
             }
-            """.trimIndent()
+              """.trimIndent()
+            )
           )
         }
-        "moshi-testPackage.MultipleMasks" -> assertThat(generatedFile.readText()).contains(
-          """
+        "moshi-testPackage.MultipleMasks" -> assertTrue(
+          generatedFile.readText().contains(
+            """
           -if class testPackage.MultipleMasks
           -keepnames class testPackage.MultipleMasks
           -if class testPackage.MultipleMasks
@@ -788,18 +832,21 @@ class JsonClassSymbolProcessorTest {
           -keepclassmembers class testPackage.MultipleMasks {
               public synthetic <init>(long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,int,int,int,kotlin.jvm.internal.DefaultConstructorMarker);
           }
-          """.trimIndent()
+            """.trimIndent()
+          )
         )
         "moshi-testPackage.NestedType.NestedSimple" -> {
-          assertThat(generatedFile.readText()).contains(
-            """
+          assertTrue(
+            generatedFile.readText().contains(
+              """
             -if class testPackage.NestedType${'$'}NestedSimple
             -keepnames class testPackage.NestedType${'$'}NestedSimple
             -if class testPackage.NestedType${'$'}NestedSimple
             -keep class testPackage.NestedType_NestedSimpleJsonAdapter {
                 public <init>(com.squareup.moshi.Moshi);
             }
-            """.trimIndent()
+              """.trimIndent()
+            )
           )
         }
         else -> error("Unexpected proguard file! ${generatedFile.name}")

--- a/moshi-kotlin-tests/build.gradle.kts
+++ b/moshi-kotlin-tests/build.gradle.kts
@@ -65,5 +65,4 @@ dependencies {
   testImplementation(kotlin("reflect"))
   testImplementation(libs.junit)
   testImplementation(libs.assertj)
-  testImplementation(libs.truth)
 }

--- a/moshi-kotlin-tests/codegen-only/build.gradle.kts
+++ b/moshi-kotlin-tests/codegen-only/build.gradle.kts
@@ -67,5 +67,4 @@ dependencies {
   testImplementation(kotlin("reflect"))
   testImplementation(libs.junit)
   testImplementation(libs.assertj)
-  testImplementation(libs.truth)
 }

--- a/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/ComplexGenericsInheritanceTest.kt
+++ b/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/ComplexGenericsInheritanceTest.kt
@@ -17,10 +17,10 @@
 
 package com.squareup.moshi.kotlin.codegen
 
-import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import org.intellij.lang.annotations.Language
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class ComplexGenericsInheritanceTest {
@@ -39,8 +39,8 @@ class ComplexGenericsInheritanceTest {
     val testInstance = PersonResponse().apply {
       data = Person("foo")
     }
-    assertThat(instance).isEqualTo(testInstance)
-    assertThat(adapter.toJson(instance)).isEqualTo(json)
+    assertEquals(instance, testInstance)
+    assertEquals(adapter.toJson(instance), json)
   }
 
   @Test
@@ -55,8 +55,8 @@ class ComplexGenericsInheritanceTest {
     val testInstance = NestedPersonResponse().apply {
       data = Person("foo")
     }
-    assertThat(instance).isEqualTo(testInstance)
-    assertThat(adapter.toJson(instance)).isEqualTo(json)
+    assertEquals(instance, testInstance)
+    assertEquals(adapter.toJson(instance), json)
   }
 
   @Test
@@ -71,8 +71,8 @@ class ComplexGenericsInheritanceTest {
     val testInstance = UntypedNestedPersonResponse<Person>().apply {
       data = Person("foo")
     }
-    assertThat(instance).isEqualTo(testInstance)
-    assertThat(adapter.toJson(instance)).isEqualTo(json)
+    assertEquals(instance, testInstance)
+    assertEquals(adapter.toJson(instance), json)
   }
 
   @Test
@@ -97,8 +97,8 @@ class ComplexGenericsInheritanceTest {
       layer2 = "layer2"
       layer1 = "layer1"
     }
-    assertThat(instance).isEqualTo(testInstance)
-    assertThat(adapter.toJson(testInstance)).isEqualTo(json)
+    assertEquals(instance, testInstance)
+    assertEquals(adapter.toJson(testInstance), json)
   }
 }
 

--- a/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/MixingReflectAndCodeGen.kt
+++ b/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/MixingReflectAndCodeGen.kt
@@ -15,10 +15,10 @@
  */
 package com.squareup.moshi.kotlin.codegen
 
-import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class MixingReflectAndCodeGen {
@@ -30,13 +30,12 @@ class MixingReflectAndCodeGen {
     val generatedAdapter = moshi.adapter<UsesGeneratedAdapter>()
     val reflectionAdapter = moshi.adapter<UsesReflectionAdapter>()
 
-    assertThat(generatedAdapter.toString())
-      .isEqualTo("GeneratedJsonAdapter(MixingReflectAndCodeGen.UsesGeneratedAdapter).nullSafe()")
-    assertThat(reflectionAdapter.toString())
-      .isEqualTo(
-        "KotlinJsonAdapter(com.squareup.moshi.kotlin.codegen.MixingReflectAndCodeGen" +
-          ".UsesReflectionAdapter).nullSafe()"
-      )
+    assertEquals("GeneratedJsonAdapter(MixingReflectAndCodeGen.UsesGeneratedAdapter).nullSafe()", generatedAdapter.toString())
+    assertEquals(
+      "KotlinJsonAdapter(com.squareup.moshi.kotlin.codegen.MixingReflectAndCodeGen" +
+        ".UsesReflectionAdapter).nullSafe()",
+      reflectionAdapter.toString()
+    )
   }
 
   @JsonClass(generateAdapter = true)

--- a/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/MoshiKspTest.kt
+++ b/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/MoshiKspTest.kt
@@ -15,9 +15,9 @@
  */
 package com.squareup.moshi.kotlin.codegen
 
-import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 // Regression tests specific to Moshi-KSP
@@ -32,9 +32,9 @@ class MoshiKspTest {
     val json = """{"a":"aValue","b":"bValue"}"""
     val expected = SimpleImpl("aValue", "bValue")
     val instance = adapter.fromJson(json)!!
-    assertThat(instance).isEqualTo(expected)
+    assertEquals(instance, expected)
     val encoded = adapter.toJson(instance)
-    assertThat(encoded).isEqualTo(json)
+    assertEquals(encoded, json)
   }
 
   interface SimpleInterface {

--- a/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.moshi.kotlin
 
-import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
@@ -25,6 +24,8 @@ import com.squareup.moshi.ToJson
 import com.squareup.moshi.Types
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import org.intellij.lang.annotations.Language
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.fail
 import org.junit.Test
 import kotlin.annotation.AnnotationRetention.RUNTIME
@@ -46,7 +47,7 @@ class DualKotlinTest {
       jsonAdapter.fromJson("""{"a":4}""")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessageThat().isEqualTo("Required value 'b' missing at $")
+      assertEquals("Required value 'b' missing at $", expected.message)
     }
   }
 
@@ -61,7 +62,7 @@ class DualKotlinTest {
       jsonAdapter.fromJson("""{"a":4}""")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessageThat().isEqualTo("Required value 'b' (JSON name 'bPrime') missing at \$")
+      assertEquals("Required value 'b' (JSON name 'bPrime') missing at \$", expected.message)
     }
   }
 
@@ -76,7 +77,7 @@ class DualKotlinTest {
       jsonAdapter.fromJson("{\"a\":null}")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessageThat().isEqualTo("Non-null value 'a' was null at \$.a")
+      assertEquals("Non-null value 'a' was null at \$.a", expected.message)
     }
   }
 
@@ -97,7 +98,7 @@ class DualKotlinTest {
       jsonAdapter.fromJson("{\"a\":\"hello\"}")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessageThat().isEqualTo("Non-null value 'a' was null at \$.a")
+      assertEquals("Non-null value 'a' was null at \$.a", expected.message)
     }
   }
 
@@ -114,7 +115,7 @@ class DualKotlinTest {
       jsonAdapter.fromJson("{\"aPrime\":null}")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessageThat().isEqualTo("Non-null value 'a' (JSON name 'aPrime') was null at \$.aPrime")
+      assertEquals("Non-null value 'a' (JSON name 'aPrime') was null at \$.aPrime", expected.message)
     }
   }
 
@@ -135,7 +136,7 @@ class DualKotlinTest {
       jsonAdapter.fromJson("{\"aPrime\":\"hello\"}")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessageThat().isEqualTo("Non-null value 'a' (JSON name 'aPrime') was null at \$.aPrime")
+      assertEquals("Non-null value 'a' (JSON name 'aPrime') was null at \$.aPrime", expected.message)
     }
   }
 
@@ -152,7 +153,7 @@ class DualKotlinTest {
       jsonAdapter.fromJson("{\"a\":null}")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessageThat().isEqualTo("Non-null value 'a' was null at \$.a")
+      assertEquals("Non-null value 'a' was null at \$.a", expected.message)
     }
   }
 
@@ -173,7 +174,7 @@ class DualKotlinTest {
       jsonAdapter.fromJson("{\"a\":\"hello\"}")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessageThat().isEqualTo("Non-null value 'a' was null at \$.a")
+      assertEquals("Non-null value 'a' was null at \$.a", expected.message)
     }
   }
 
@@ -205,24 +206,27 @@ class DualKotlinTest {
 
     val hasNonNullConstructorParameterAdapter =
       localMoshi.adapter<HasNonNullConstructorParameter>()
-    assertThat(
+    assertEquals(
       //language=JSON
       hasNonNullConstructorParameterAdapter
-        .fromJson("{\"a\":null}")
-    ).isEqualTo(HasNonNullConstructorParameter("fallback"))
+        .fromJson("{\"a\":null}"),
+      HasNonNullConstructorParameter("fallback")
+    )
 
     val hasNullableConstructorParameterAdapter =
       localMoshi.adapter<HasNullableConstructorParameter>()
-    assertThat(
+    assertEquals(
       //language=JSON
       hasNullableConstructorParameterAdapter
-        .fromJson("{\"a\":null}")
-    ).isEqualTo(HasNullableConstructorParameter("fallback"))
+        .fromJson("{\"a\":null}"),
+      HasNullableConstructorParameter("fallback")
+    )
     //language=JSON
-    assertThat(
+    assertEquals(
       hasNullableConstructorParameterAdapter
-        .toJson(HasNullableConstructorParameter(null))
-    ).isEqualTo("{\"a\":\"fallback\"}")
+        .toJson(HasNullableConstructorParameter(null)),
+      "{\"a\":\"fallback\"}"
+    )
   }
 
   @JsonClass(generateAdapter = true)
@@ -233,13 +237,13 @@ class DualKotlinTest {
 
     val encoded = HasNullableTypeWithGeneratedAdapter(null)
     //language=JSON
-    assertThat(adapter.toJson(encoded)).isEqualTo("""{}""")
+    assertEquals(adapter.toJson(encoded), """{}""")
     //language=JSON
-    assertThat(adapter.serializeNulls().toJson(encoded)).isEqualTo("""{"a":null}""")
+    assertEquals(adapter.serializeNulls().toJson(encoded), """{"a":null}""")
 
     //language=JSON
     val decoded = adapter.fromJson("""{"a":null}""")!!
-    assertThat(decoded.a).isEqualTo(null)
+    assertEquals(decoded.a, null)
   }
 
   @Test fun valueClass() {
@@ -249,19 +253,19 @@ class DualKotlinTest {
 
     val expectedJson =
       """{"i":5}"""
-    assertThat(adapter.toJson(inline)).isEqualTo(expectedJson)
+    assertEquals(adapter.toJson(inline), expectedJson)
 
     val testJson =
       """{"i":6}"""
     val result = adapter.fromJson(testJson)!!
-    assertThat(result.i).isEqualTo(6)
+    assertEquals(result.i, 6)
 
     // TODO doesn't work yet. https://github.com/square/moshi/issues/1170
     //  need to invoke the constructor_impl$default static method, invoke constructor with result
 //    val testEmptyJson =
 //      """{}"""
 //    val result2 = adapter.fromJson(testEmptyJson)!!
-//    assertThat(result2.i).isEqualTo(0)
+//    assertEquals(result2.i, 0)
   }
 
   @JsonClass(generateAdapter = true)
@@ -275,13 +279,13 @@ class DualKotlinTest {
     @Language("JSON")
     val expectedJson =
       """{"inline":{"i":23}}"""
-    assertThat(adapter.toJson(consumer)).isEqualTo(expectedJson)
+    assertEquals(adapter.toJson(consumer), expectedJson)
 
     @Language("JSON")
     val testJson =
       """{"inline":{"i":42}}"""
     val result = adapter.fromJson(testJson)!!
-    assertThat(result.inline.i).isEqualTo(42)
+    assertEquals(result.inline.i, 42)
   }
 
   // Regression test for https://github.com/square/moshi/issues/955
@@ -292,10 +296,10 @@ class DualKotlinTest {
     val testJson =
       """{"text":"text"}"""
 
-    assertThat(adapter.toJson(TextAssetMetaData("text"))).isEqualTo(testJson)
+    assertEquals(adapter.toJson(TextAssetMetaData("text")), testJson)
 
     val result = adapter.fromJson(testJson)!!
-    assertThat(result.text).isEqualTo("text")
+    assertEquals(result.text, "text")
   }
 
   @JsonClass(generateAdapter = true)
@@ -324,13 +328,13 @@ class DualKotlinTest {
       }
     }
 
-    assertThat(adapter.toJson(data))
+    assertEquals(
+      adapter.toJson(data),
       //language=JSON
-      .isEqualTo(
-        """
+      """
         {"text":"root","r":{"number":0,"r":{"text":"grand child 1"},"t":{"number":1}},"t":{"text":"child 1"}}
-        """.trimIndent()
-      )
+      """.trimIndent()
+    )
   }
 
   @JsonClass(generateAdapter = true)
@@ -359,10 +363,10 @@ class DualKotlinTest {
     val testJson =
       """{"test":"text"}"""
 
-    assertThat(adapter.toJson(InternalAbstractProperty("text"))).isEqualTo(testJson)
+    assertEquals(adapter.toJson(InternalAbstractProperty("text")), testJson)
 
     val result = adapter.fromJson(testJson)!!
-    assertThat(result.test).isEqualTo("text")
+    assertEquals(result.test, "text")
   }
 
   abstract class InternalAbstractPropertyBase {
@@ -384,13 +388,13 @@ class DualKotlinTest {
     val adapter = moshi.adapter<MultipleConstructorsB>()
 
     //language=JSON
-    assertThat(adapter.toJson(MultipleConstructorsB(6))).isEqualTo("""{"f":{"f":6},"b":6}""")
+    assertEquals(adapter.toJson(MultipleConstructorsB(6)), """{"f":{"f":6},"b":6}""")
 
     @Language("JSON")
     val testJson =
       """{"b":6}"""
     val result = adapter.fromJson(testJson)!!
-    assertThat(result.b).isEqualTo(6)
+    assertEquals(result.b, 6)
   }
 
   @JsonClass(generateAdapter = true)
@@ -408,10 +412,10 @@ class DualKotlinTest {
     val testJson =
       """{"prop":7}"""
 
-    assertThat(adapter.toJson(MultipleNonPropertyParameters(7))).isEqualTo(testJson)
+    assertEquals(adapter.toJson(MultipleNonPropertyParameters(7)), testJson)
 
     val result = adapter.fromJson(testJson)!!
-    assertThat(result.prop).isEqualTo(7)
+    assertEquals(result.prop, 7)
   }
 
   @JsonClass(generateAdapter = true)
@@ -435,11 +439,10 @@ class DualKotlinTest {
     val testJson =
       """{"prop":7}"""
 
-    assertThat(adapter.toJson(OnlyMultipleNonPropertyParameters().apply { prop = 7 }))
-      .isEqualTo(testJson)
+    assertEquals(adapter.toJson(OnlyMultipleNonPropertyParameters().apply { prop = 7 }), testJson)
 
     val result = adapter.fromJson(testJson)!!
-    assertThat(result.prop).isEqualTo(7)
+    assertEquals(result.prop, 7)
   }
 
   @JsonClass(generateAdapter = true)
@@ -474,10 +477,10 @@ class DualKotlinTest {
       wildcardOut = GenericClass(6),
       complex = GenericClass(listOf(GenericClass(6)))
     )
-    assertThat(adapter.toJson(testValue)).isEqualTo(testJson)
+    assertEquals(adapter.toJson(testValue), testJson)
 
     val result = adapter.fromJson(testJson)!!
-    assertThat(result).isEqualTo(testValue)
+    assertEquals(result, testValue)
   }
 
   @JsonClass(generateAdapter = true)
@@ -508,11 +511,10 @@ class DualKotlinTest {
       float = 3.2f,
       double = 3.2
     )
-    assertThat(adapter.toJson(instance))
-      .isEqualTo(testJson)
+    assertEquals(adapter.toJson(instance), testJson)
 
     val result = adapter.fromJson(testJson)!!
-    assertThat(result).isEqualTo(instance)
+    assertEquals(result, instance)
   }
 
   @JsonClass(generateAdapter = true)
@@ -544,11 +546,10 @@ class DualKotlinTest {
     val testJson =
       """{"nullableList":null}"""
 
-    assertThat(adapter.serializeNulls().toJson(NullableList(null)))
-      .isEqualTo(testJson)
+    assertEquals(adapter.serializeNulls().toJson(NullableList(null)), testJson)
 
     val result = adapter.fromJson(testJson)!!
-    assertThat(result.nullableList).isNull()
+    assertNull(result.nullableList)
   }
 
   @JsonClass(generateAdapter = true)
@@ -562,11 +563,10 @@ class DualKotlinTest {
       """{"aShouldBeNonNull":3,"nullableAShouldBeNullable":null,"redundantNullableAShouldBeNullable":null,"manuallyNullableAShouldBeNullable":null,"convolutedMultiNullableShouldBeNullable":null,"deepNestedNullableShouldBeNullable":null}"""
 
     val instance = TypeAliasNullability(3, null, null, null, null, null)
-    assertThat(adapter.serializeNulls().toJson(instance))
-      .isEqualTo(testJson)
+    assertEquals(adapter.serializeNulls().toJson(instance), testJson)
 
     val result = adapter.fromJson(testJson)!!
-    assertThat(result).isEqualTo(instance)
+    assertEquals(result, instance)
   }
 
   @Suppress("REDUNDANT_NULLABLE")
@@ -589,11 +589,10 @@ class DualKotlinTest {
       """{"input":3}"""
 
     val instance = OutDeclaration(3)
-    assertThat(adapter.serializeNulls().toJson(instance))
-      .isEqualTo(testJson)
+    assertEquals(adapter.serializeNulls().toJson(instance), testJson)
 
     val result = adapter.fromJson(testJson)!!
-    assertThat(result).isEqualTo(instance)
+    assertEquals(result, instance)
   }
 
   @JsonClass(generateAdapter = true)
@@ -607,11 +606,10 @@ class DualKotlinTest {
       """{"value":"VALUE"}"""
 
     val instance = IntersectionTypes(IntersectionTypesEnum.VALUE)
-    assertThat(adapter.serializeNulls().toJson(instance))
-      .isEqualTo(testJson)
+    assertEquals(adapter.serializeNulls().toJson(instance), testJson)
 
     val result = adapter.fromJson(testJson)!!
-    assertThat(result).isEqualTo(instance)
+    assertEquals(result, instance)
   }
 
   interface IntersectionTypeInterface<E : Enum<E>>
@@ -630,11 +628,11 @@ class DualKotlinTest {
     val jsonAdapter = moshi.adapter<TransientConstructorParameter>()
 
     val encoded = TransientConstructorParameter(3, 5)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
-    assertThat(decoded.a).isEqualTo(-1)
-    assertThat(decoded.b).isEqualTo(6)
+    assertEquals(decoded.a, -1)
+    assertEquals(decoded.b, 6)
   }
 
   class TransientConstructorParameter(@Transient var a: Int = -1, var b: Int = -1)
@@ -644,12 +642,12 @@ class DualKotlinTest {
     val jsonAdapter = moshi.adapter(MultipleTransientConstructorParameters::class.java)
 
     val encoded = MultipleTransientConstructorParameters(3, 5, 7)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
-    assertThat(decoded.a).isEqualTo(-1)
-    assertThat(decoded.b).isEqualTo(6)
-    assertThat(decoded.c).isEqualTo(-1)
+    assertEquals(decoded.a, -1)
+    assertEquals(decoded.b, 6)
+    assertEquals(decoded.c, -1)
   }
 
   class MultipleTransientConstructorParameters(@Transient var a: Int = -1, var b: Int = -1, @Transient var c: Int = -1)
@@ -662,12 +660,12 @@ class DualKotlinTest {
     encoded.a = 3
     encoded.setB(4)
     encoded.c = 5
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"c":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"c":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"b":5,"c":6}""")!!
-    assertThat(decoded.a).isEqualTo(-1)
-    assertThat(decoded.getB()).isEqualTo(-1)
-    assertThat(decoded.c).isEqualTo(6)
+    assertEquals(decoded.a, -1)
+    assertEquals(decoded.getB(), -1)
+    assertEquals(decoded.c, 6)
   }
 
   class TransientProperty {
@@ -687,11 +685,11 @@ class DualKotlinTest {
     val jsonAdapter = moshi.adapter<IgnoredConstructorParameter>()
 
     val encoded = IgnoredConstructorParameter(3, 5)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
-    assertThat(decoded.a).isEqualTo(-1)
-    assertThat(decoded.b).isEqualTo(6)
+    assertEquals(decoded.a, -1)
+    assertEquals(decoded.b, 6)
   }
 
   class IgnoredConstructorParameter(@Json(ignore = true) var a: Int = -1, var b: Int = -1)
@@ -701,12 +699,12 @@ class DualKotlinTest {
     val jsonAdapter = moshi.adapter(MultipleIgnoredConstructorParameters::class.java)
 
     val encoded = MultipleIgnoredConstructorParameters(3, 5, 7)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
-    assertThat(decoded.a).isEqualTo(-1)
-    assertThat(decoded.b).isEqualTo(6)
-    assertThat(decoded.c).isEqualTo(-1)
+    assertEquals(decoded.a, -1)
+    assertEquals(decoded.b, 6)
+    assertEquals(decoded.c, -1)
   }
 
   class MultipleIgnoredConstructorParameters(
@@ -723,12 +721,12 @@ class DualKotlinTest {
     encoded.a = 3
     encoded.setB(4)
     encoded.c = 5
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"c":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"c":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"b":5,"c":6}""")!!
-    assertThat(decoded.a).isEqualTo(-1)
-    assertThat(decoded.getB()).isEqualTo(-1)
-    assertThat(decoded.c).isEqualTo(6)
+    assertEquals(decoded.a, -1)
+    assertEquals(decoded.getB(), -1)
+    assertEquals(decoded.c, 6)
   }
 
   class IgnoredProperty {
@@ -749,8 +747,8 @@ class DualKotlinTest {
 
     val value = PropertyWithDollarSign("apple", "banana")
     val json = """{"${'$'}a":"apple","${'$'}b":"banana"}"""
-    assertThat(jsonAdapter.toJson(value)).isEqualTo(json)
-    assertThat(jsonAdapter.fromJson(json)).isEqualTo(value)
+    assertEquals(jsonAdapter.toJson(value), json)
+    assertEquals(jsonAdapter.fromJson(json), value)
   }
 
   @JsonClass(generateAdapter = true)

--- a/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.moshi.kotlin.reflect
 
-import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
@@ -27,6 +26,11 @@ import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.ToJson
 import org.assertj.core.api.Assertions
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 import java.io.ByteArrayOutputStream
@@ -43,11 +47,11 @@ class KotlinJsonAdapterTest {
     val jsonAdapter = moshi.adapter<ConstructorParameters>()
 
     val encoded = ConstructorParameters(3, 5)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"a":3,"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
-    assertThat(decoded.a).isEqualTo(4)
-    assertThat(decoded.b).isEqualTo(6)
+    assertEquals(decoded.a, 4)
+    assertEquals(decoded.b, 6)
   }
 
   class ConstructorParameters(var a: Int, var b: Int)
@@ -59,11 +63,11 @@ class KotlinJsonAdapterTest {
     val encoded = Properties()
     encoded.a = 3
     encoded.b = 5
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"a":3,"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":3,"b":5}""")!!
-    assertThat(decoded.a).isEqualTo(3)
-    assertThat(decoded.b).isEqualTo(5)
+    assertEquals(decoded.a, 3)
+    assertEquals(decoded.b, 5)
   }
 
   class Properties {
@@ -77,11 +81,11 @@ class KotlinJsonAdapterTest {
 
     val encoded = ConstructorParametersAndProperties(3)
     encoded.b = 5
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"a":3,"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
-    assertThat(decoded.a).isEqualTo(4)
-    assertThat(decoded.b).isEqualTo(6)
+    assertEquals(decoded.a, 4)
+    assertEquals(decoded.b, 6)
   }
 
   class ConstructorParametersAndProperties(var a: Int) {
@@ -93,11 +97,11 @@ class KotlinJsonAdapterTest {
     val jsonAdapter = moshi.adapter<ImmutableConstructorParameters>()
 
     val encoded = ImmutableConstructorParameters(3, 5)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"a":3,"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
-    assertThat(decoded.a).isEqualTo(4)
-    assertThat(decoded.b).isEqualTo(6)
+    assertEquals(decoded.a, 4)
+    assertEquals(decoded.b, 6)
   }
 
   class ImmutableConstructorParameters(val a: Int, val b: Int)
@@ -107,11 +111,11 @@ class KotlinJsonAdapterTest {
     val jsonAdapter = moshi.adapter<ImmutableProperties>()
 
     val encoded = ImmutableProperties(3, 5)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"a":3,"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":3,"b":5}""")!!
-    assertThat(decoded.a).isEqualTo(3)
-    assertThat(decoded.b).isEqualTo(5)
+    assertEquals(decoded.a, 3)
+    assertEquals(decoded.b, 5)
   }
 
   class ImmutableProperties(a: Int, b: Int) {
@@ -124,11 +128,11 @@ class KotlinJsonAdapterTest {
     val jsonAdapter = moshi.adapter<ConstructorDefaultValues>()
 
     val encoded = ConstructorDefaultValues(3, 5)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"a":3,"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"b":6}""")!!
-    assertThat(decoded.a).isEqualTo(-1)
-    assertThat(decoded.b).isEqualTo(6)
+    assertEquals(decoded.a, -1)
+    assertEquals(decoded.b, 6)
   }
 
   class ConstructorDefaultValues(var a: Int = -1, var b: Int = -2)
@@ -141,7 +145,7 @@ class KotlinJsonAdapterTest {
       jsonAdapter.fromJson("""{"a":4,"a":4}""")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessageThat().isEqualTo("Multiple values for 'a' at $.a")
+      assertEquals("Multiple values for 'a' at $.a", expected.message)
     }
   }
 
@@ -155,7 +159,7 @@ class KotlinJsonAdapterTest {
       jsonAdapter.fromJson("""{"a":4,"a":4}""")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessageThat().isEqualTo("Multiple values for 'a' at $.a")
+      assertEquals("Multiple values for 'a' at $.a", expected.message)
     }
   }
 
@@ -169,12 +173,12 @@ class KotlinJsonAdapterTest {
     val jsonAdapter = moshi.adapter<ExplicitNull>()
 
     val encoded = ExplicitNull(null, 5)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
-    assertThat(jsonAdapter.serializeNulls().toJson(encoded)).isEqualTo("""{"a":null,"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"b":5}""")
+    assertEquals(jsonAdapter.serializeNulls().toJson(encoded), """{"a":null,"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":null,"b":6}""")!!
-    assertThat(decoded.a).isEqualTo(null)
-    assertThat(decoded.b).isEqualTo(6)
+    assertEquals(decoded.a, null)
+    assertEquals(decoded.b, 6)
   }
 
   class ExplicitNull(var a: Int?, var b: Int?)
@@ -184,12 +188,12 @@ class KotlinJsonAdapterTest {
     val jsonAdapter = moshi.adapter<AbsentNull>()
 
     val encoded = AbsentNull(null, 5)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
-    assertThat(jsonAdapter.serializeNulls().toJson(encoded)).isEqualTo("""{"a":null,"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"b":5}""")
+    assertEquals(jsonAdapter.serializeNulls().toJson(encoded), """{"a":null,"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"b":6}""")!!
-    assertThat(decoded.a).isNull()
-    assertThat(decoded.b).isEqualTo(6)
+    assertNull(decoded.a)
+    assertEquals(decoded.b, 6)
   }
 
   class AbsentNull(var a: Int?, var b: Int?)
@@ -202,7 +206,7 @@ class KotlinJsonAdapterTest {
       jsonAdapter.fromJson("""{"a":4,"b":null,"b":6}""")
       fail()
     } catch (expected: JsonDataException) {
-      assertThat(expected).hasMessageThat().isEqualTo("Multiple values for 'b' at $.b")
+      assertEquals("Multiple values for 'b' at $.b", expected.message)
     }
   }
 
@@ -216,11 +220,11 @@ class KotlinJsonAdapterTest {
     val jsonAdapter = moshi.adapter<ConstructorParameterWithQualifier>()
 
     val encoded = ConstructorParameterWithQualifier("Android", "Banana")
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":"ANDROID","b":"Banana"}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"a":"ANDROID","b":"Banana"}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":"Android","b":"Banana"}""")!!
-    assertThat(decoded.a).isEqualTo("android")
-    assertThat(decoded.b).isEqualTo("Banana")
+    assertEquals(decoded.a, "android")
+    assertEquals(decoded.b, "Banana")
   }
 
   class ConstructorParameterWithQualifier(@Uppercase var a: String, var b: String)
@@ -235,11 +239,11 @@ class KotlinJsonAdapterTest {
     val encoded = PropertyWithQualifier()
     encoded.a = "Android"
     encoded.b = "Banana"
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":"ANDROID","b":"Banana"}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"a":"ANDROID","b":"Banana"}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":"Android","b":"Banana"}""")!!
-    assertThat(decoded.a).isEqualTo("android")
-    assertThat(decoded.b).isEqualTo("Banana")
+    assertEquals(decoded.a, "android")
+    assertEquals(decoded.b, "Banana")
   }
 
   class PropertyWithQualifier {
@@ -252,11 +256,11 @@ class KotlinJsonAdapterTest {
     val jsonAdapter = moshi.adapter<ConstructorParameterWithJsonName>()
 
     val encoded = ConstructorParameterWithJsonName(3, 5)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"key a":3,"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"key a":3,"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"key a":4,"b":6}""")!!
-    assertThat(decoded.a).isEqualTo(4)
-    assertThat(decoded.b).isEqualTo(6)
+    assertEquals(decoded.a, 4)
+    assertEquals(decoded.b, 6)
   }
 
   class ConstructorParameterWithJsonName(@Json(name = "key a") var a: Int, var b: Int)
@@ -268,11 +272,11 @@ class KotlinJsonAdapterTest {
     val encoded = PropertyWithJsonName()
     encoded.a = 3
     encoded.b = 5
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"key a":3,"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"key a":3,"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"key a":4,"b":6}""")!!
-    assertThat(decoded.a).isEqualTo(4)
-    assertThat(decoded.b).isEqualTo(6)
+    assertEquals(decoded.a, 4)
+    assertEquals(decoded.b, 6)
   }
 
   class PropertyWithJsonName {
@@ -286,10 +290,11 @@ class KotlinJsonAdapterTest {
       moshi.adapter<RequiredTransientConstructorParameter>()
       fail()
     } catch (expected: IllegalArgumentException) {
-      assertThat(expected).hasMessageThat().isEqualTo(
+      assertEquals(
         "No default value for transient constructor parameter #0 " +
           "a of fun `<init>`(kotlin.Int): " +
-          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest.RequiredTransientConstructorParameter"
+          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest.RequiredTransientConstructorParameter",
+        expected.message
       )
     }
   }
@@ -302,10 +307,11 @@ class KotlinJsonAdapterTest {
       moshi.adapter<RequiredIgnoredConstructorParameter>()
       fail()
     } catch (expected: IllegalArgumentException) {
-      assertThat(expected).hasMessageThat().isEqualTo(
+      assertEquals(
         "No default value for ignored constructor parameter #0 " +
           "a of fun `<init>`(kotlin.Int): " +
-          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest.RequiredIgnoredConstructorParameter"
+          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest.RequiredIgnoredConstructorParameter",
+        expected.message
       )
     }
   }
@@ -318,9 +324,10 @@ class KotlinJsonAdapterTest {
       moshi.adapter<ConstructorParameterWithSameNameAsPropertyButDifferentType>()
       fail()
     } catch (expected: IllegalArgumentException) {
-      assertThat(expected).hasMessageThat().isEqualTo(
+      assertEquals(
         "'a' has a constructor parameter of type " +
-          "kotlin.Int but a property of type kotlin.String."
+          "kotlin.Int but a property of type kotlin.String.",
+        expected.message
       )
     }
   }
@@ -334,11 +341,11 @@ class KotlinJsonAdapterTest {
     val jsonAdapter = moshi.adapter<SubtypeConstructorParameters>()
 
     val encoded = SubtypeConstructorParameters(3, 5)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"a":3,"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
-    assertThat(decoded.a).isEqualTo(4)
-    assertThat(decoded.b).isEqualTo(6)
+    assertEquals(decoded.a, 4)
+    assertEquals(decoded.b, 6)
   }
 
   open class SupertypeConstructorParameters(var a: Int)
@@ -352,11 +359,11 @@ class KotlinJsonAdapterTest {
     val encoded = SubtypeProperties()
     encoded.a = 3
     encoded.b = 5
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5,"a":3}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"b":5,"a":3}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
-    assertThat(decoded.a).isEqualTo(4)
-    assertThat(decoded.b).isEqualTo(6)
+    assertEquals(decoded.a, 4)
+    assertEquals(decoded.b, 6)
   }
 
   open class SupertypeProperties {
@@ -372,11 +379,11 @@ class KotlinJsonAdapterTest {
     val jsonAdapter = moshi.adapter<ExtendsPlatformClassWithPrivateField>()
 
     val encoded = ExtendsPlatformClassWithPrivateField(3)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"a":3}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"id":"B"}""")!!
-    assertThat(decoded.a).isEqualTo(4)
-    assertThat(decoded.id).isEqualTo("C")
+    assertEquals(decoded.a, 4)
+    assertEquals(decoded.id, "C")
   }
 
   internal class ExtendsPlatformClassWithPrivateField(var a: Int) : SimpleTimeZone(0, "C")
@@ -386,12 +393,12 @@ class KotlinJsonAdapterTest {
     val jsonAdapter = moshi.adapter<ExtendsPlatformClassWithProtectedField>()
 
     val encoded = ExtendsPlatformClassWithProtectedField(3)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"buf":[0,0],"count":0}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"a":3,"buf":[0,0],"count":0}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"buf":[0,0],"size":0}""")!!
-    assertThat(decoded.a).isEqualTo(4)
-    assertThat(decoded.buf()).isEqualTo(ByteArray(2) { 0 })
-    assertThat(decoded.count()).isEqualTo(0)
+    assertEquals(4, decoded.a)
+    assertArrayEquals(ByteArray(2) { 0 }, decoded.buf())
+    assertEquals(0, decoded.count())
   }
 
   internal class ExtendsPlatformClassWithProtectedField(var a: Int) : ByteArrayOutputStream(2) {
@@ -405,8 +412,9 @@ class KotlinJsonAdapterTest {
       moshi.adapter<Triple<*, *, *>>()
       fail()
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessageThat().isEqualTo(
-        "Platform class kotlin.Triple in kotlin.Triple<?, ?, ?> requires explicit JsonAdapter to be registered"
+      assertEquals(
+        "Platform class kotlin.Triple in kotlin.Triple<?, ?, ?> requires explicit JsonAdapter to be registered",
+        e.message
       )
     }
   }
@@ -416,11 +424,11 @@ class KotlinJsonAdapterTest {
     val jsonAdapter = moshi.adapter<PrivateConstructorParameters>()
 
     val encoded = PrivateConstructorParameters(3, 5)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"a":3,"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
-    assertThat(decoded.a()).isEqualTo(4)
-    assertThat(decoded.b()).isEqualTo(6)
+    assertEquals(decoded.a(), 4)
+    assertEquals(decoded.b(), 6)
   }
 
   class PrivateConstructorParameters(private var a: Int, private var b: Int) {
@@ -433,11 +441,11 @@ class KotlinJsonAdapterTest {
     val jsonAdapter = moshi.adapter<PrivateConstructor>()
 
     val encoded = PrivateConstructor.newInstance(3, 5)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"a":3,"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
-    assertThat(decoded.a()).isEqualTo(4)
-    assertThat(decoded.b()).isEqualTo(6)
+    assertEquals(decoded.a(), 4)
+    assertEquals(decoded.b(), 6)
   }
 
   class PrivateConstructor private constructor(var a: Int, var b: Int) {
@@ -455,11 +463,11 @@ class KotlinJsonAdapterTest {
     val encoded = PrivateProperties()
     encoded.a(3)
     encoded.b(5)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"a":3,"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
-    assertThat(decoded.a()).isEqualTo(4)
-    assertThat(decoded.b()).isEqualTo(6)
+    assertEquals(decoded.a(), 4)
+    assertEquals(decoded.b(), 6)
   }
 
   class PrivateProperties {
@@ -485,11 +493,11 @@ class KotlinJsonAdapterTest {
 
     val encoded = UnsettableProperty()
     encoded.b = 5
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
-    assertThat(decoded.a).isEqualTo(-1)
-    assertThat(decoded.b).isEqualTo(6)
+    assertEquals(decoded.a, -1)
+    assertEquals(decoded.b, 6)
   }
 
   class UnsettableProperty {
@@ -502,12 +510,12 @@ class KotlinJsonAdapterTest {
     val jsonAdapter = moshi.adapter<GetterOnly>()
 
     val encoded = GetterOnly(3, 5)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"a":3,"b":5}""")
 
     val decoded = jsonAdapter.fromJson("""{"a":4,"b":6}""")!!
-    assertThat(decoded.a).isEqualTo(4)
-    assertThat(decoded.b).isEqualTo(6)
-    assertThat(decoded.total).isEqualTo(10)
+    assertEquals(decoded.a, 4)
+    assertEquals(decoded.b, 6)
+    assertEquals(decoded.total, 10)
   }
 
   class GetterOnly(var a: Int, var b: Int) {
@@ -520,19 +528,19 @@ class KotlinJsonAdapterTest {
     val jsonAdapter = moshi.adapter<GetterAndSetter>()
 
     val encoded = GetterAndSetter(3, 5)
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"a":3,"b":5,"total":8}""")
+    assertEquals(jsonAdapter.toJson(encoded), """{"a":3,"b":5,"total":8}""")
 
     // Whether b is 6 or 7 is an implementation detail. Currently we call constructors then setters.
     val decoded1 = jsonAdapter.fromJson("""{"a":4,"b":6,"total":11}""")!!
-    assertThat(decoded1.a).isEqualTo(4)
-    assertThat(decoded1.b).isEqualTo(7)
-    assertThat(decoded1.total).isEqualTo(11)
+    assertEquals(decoded1.a, 4)
+    assertEquals(decoded1.b, 7)
+    assertEquals(decoded1.total, 11)
 
     // Whether b is 6 or 7 is an implementation detail. Currently we call constructors then setters.
     val decoded2 = jsonAdapter.fromJson("""{"a":4,"total":11,"b":6}""")!!
-    assertThat(decoded2.a).isEqualTo(4)
-    assertThat(decoded2.b).isEqualTo(7)
-    assertThat(decoded2.total).isEqualTo(11)
+    assertEquals(decoded2.a, 4)
+    assertEquals(decoded2.b, 7)
+    assertEquals(decoded2.total, 11)
   }
 
   class GetterAndSetter(var a: Int, var b: Int) {
@@ -549,9 +557,10 @@ class KotlinJsonAdapterTest {
       moshi.adapter<NonPropertyConstructorParameter>()
       fail()
     } catch (expected: IllegalArgumentException) {
-      assertThat(expected).hasMessageThat().isEqualTo(
+      assertEquals(
         "No property for required constructor parameter #0 a of fun `<init>`(" +
-          "kotlin.Int, kotlin.Int): ${NonPropertyConstructorParameter::class.qualifiedName}"
+          "kotlin.Int, kotlin.Int): ${NonPropertyConstructorParameter::class.qualifiedName}",
+        expected.message
       )
     }
   }
@@ -562,7 +571,7 @@ class KotlinJsonAdapterTest {
     val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
     val adapter = moshi.adapter<UsingEnum>()
 
-    assertThat(adapter.fromJson("""{"e": "A"}""")).isEqualTo(UsingEnum(KotlinEnum.A))
+    assertEquals(adapter.fromJson("""{"e": "A"}"""), UsingEnum(KotlinEnum.A))
   }
 
   data class UsingEnum(val e: KotlinEnum)
@@ -577,9 +586,10 @@ class KotlinJsonAdapterTest {
       moshi.adapter<Interface>()
       fail()
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessageThat().isEqualTo(
+      assertEquals(
         "No JsonAdapter for interface " +
-          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$Interface (with no annotations)"
+          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$Interface (with no annotations)",
+        e.message
       )
     }
   }
@@ -592,9 +602,10 @@ class KotlinJsonAdapterTest {
       moshi.adapter<AbstractClass>()
       fail()
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessageThat().isEqualTo(
+      assertEquals(
         "Cannot serialize abstract class " +
-          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$AbstractClass"
+          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$AbstractClass",
+        e.message
       )
     }
   }
@@ -607,9 +618,10 @@ class KotlinJsonAdapterTest {
       moshi.adapter<InnerClass>()
       fail()
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessageThat().isEqualTo(
+      assertEquals(
         "Cannot serialize inner class " +
-          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$InnerClass"
+          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$InnerClass",
+        e.message
       )
     }
   }
@@ -623,9 +635,10 @@ class KotlinJsonAdapterTest {
       moshi.adapter<LocalClass>()
       fail()
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessageThat().isEqualTo(
+      assertEquals(
         "Cannot serialize local class or object expression " +
-          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$localClassesNotSupported\$LocalClass"
+          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$localClassesNotSupported\$LocalClass",
+        e.message
       )
     }
   }
@@ -636,9 +649,10 @@ class KotlinJsonAdapterTest {
       moshi.adapter<ObjectDeclaration>()
       fail()
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessageThat().isEqualTo(
+      assertEquals(
         "Cannot serialize object declaration " +
-          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$ObjectDeclaration"
+          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$ObjectDeclaration",
+        e.message
       )
     }
   }
@@ -663,10 +677,11 @@ class KotlinJsonAdapterTest {
       } else {
         "anonymous class"
       }
-      assertThat(e).hasMessageThat().isEqualTo(
+      assertEquals(
         "Cannot serialize $type " +
           "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest\$anonymousClassesNotSupported" +
-          "\$expression$1"
+          "\$expression$1",
+        e.message
       )
     }
   }
@@ -698,11 +713,11 @@ class KotlinJsonAdapterTest {
         |"""
       ).trimMargin().replace("\n", "")
 
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo(json)
+    assertEquals(jsonAdapter.toJson(encoded), json)
 
     val decoded = jsonAdapter.fromJson(json)!!
-    assertThat(decoded.v01).isEqualTo(101)
-    assertThat(decoded.v32).isEqualTo(132)
+    assertEquals(decoded.v01, 101)
+    assertEquals(decoded.v32, 132)
   }
 
   class ManyProperties32(
@@ -767,12 +782,12 @@ class KotlinJsonAdapterTest {
         |"""
       ).trimMargin().replace("\n", "")
 
-    assertThat(jsonAdapter.toJson(encoded)).isEqualTo(json)
+    assertEquals(jsonAdapter.toJson(encoded), json)
 
     val decoded = jsonAdapter.fromJson(json)!!
-    assertThat(decoded.v01).isEqualTo(101)
-    assertThat(decoded.v32).isEqualTo(132)
-    assertThat(decoded.v33).isEqualTo(133)
+    assertEquals(decoded.v01, 101)
+    assertEquals(decoded.v32, 132)
+    assertEquals(decoded.v33, 133)
   }
 
   class ManyProperties33(
@@ -816,8 +831,8 @@ class KotlinJsonAdapterTest {
   @Test fun genericTypes() {
     val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
     val stringBoxAdapter = moshi.adapter<Box<String>>()
-    assertThat(stringBoxAdapter.fromJson("""{"data":"hello"}""")).isEqualTo(Box("hello"))
-    assertThat(stringBoxAdapter.toJson(Box("hello"))).isEqualTo("""{"data":"hello"}""")
+    assertEquals(stringBoxAdapter.fromJson("""{"data":"hello"}"""), Box("hello"))
+    assertEquals(stringBoxAdapter.toJson(Box("hello")), """{"data":"hello"}""")
   }
 
   data class NestedGenerics<R, C, out V>(val value: Map<R, Map<C, List<V>>>)
@@ -843,8 +858,8 @@ class KotlinJsonAdapterTest {
       |}
       """.trimMargin()
     val value = NestedGenerics(mapOf("hello" to mapOf(1 to listOf(Box(" "), Box("world!")))))
-    assertThat(adapter.fromJson(json)).isEqualTo(value)
-    assertThat(adapter.toJson(value)).isEqualTo(json)
+    assertEquals(adapter.fromJson(json), value)
+    assertEquals(adapter.toJson(value), json)
   }
 
   @Retention(RUNTIME)
@@ -890,9 +905,8 @@ class KotlinJsonAdapterTest {
       .add(KotlinJsonAdapterFactory())
       .build()
     val adapter = moshi.adapter<HasNullableBoolean>().serializeNulls()
-    assertThat(adapter.fromJson("""{"boolean":"not a boolean"}"""))
-      .isEqualTo(HasNullableBoolean(null))
-    assertThat(adapter.toJson(HasNullableBoolean(null))).isEqualTo("""{"boolean":null}""")
+    assertEquals(adapter.fromJson("""{"boolean":"not a boolean"}"""), HasNullableBoolean(null))
+    assertEquals(adapter.toJson(HasNullableBoolean(null)), """{"boolean":null}""")
   }
 
   @Test fun adaptersAreNullSafe() {
@@ -902,8 +916,8 @@ class KotlinJsonAdapterTest {
 
     // TODO in CR: We had to mark this as nullable, vs before the jsonadapter factory would always run
     val adapter = moshi.adapter<HasNullableBoolean?>()
-    assertThat(adapter.fromJson("null")).isNull()
-    assertThat(adapter.toJson(null)).isEqualTo("null")
+    assertNull(adapter.fromJson("null"))
+    assertEquals(adapter.toJson(null), "null")
   }
 
   @Test fun kotlinClassesWithoutAdapterAreRefused() {
@@ -912,7 +926,7 @@ class KotlinJsonAdapterTest {
       moshi.adapter<PlainKotlinClass>()
       fail("Should not pass here")
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessageThat().contains("Reflective serialization of Kotlin classes")
+      assertTrue(e.message!!.contains("Reflective serialization of Kotlin classes"))
     }
   }
 
@@ -1065,7 +1079,7 @@ class KotlinJsonAdapterTest {
       moshi.adapter<SealedClass>()
       fail()
     } catch (e: IllegalArgumentException) {
-      assertThat(e).hasMessageThat().contains("Cannot reflectively serialize sealed class")
+      assertTrue(e.message!!.contains("Cannot reflectively serialize sealed class"))
     }
   }
 
@@ -1075,13 +1089,13 @@ class KotlinJsonAdapterTest {
     // Ensure the map was created with the expected wildcards of a Kotlin map.
     val fieldType = type.getDeclaredField("map").genericType
     val fieldTypeArguments = (fieldType as ParameterizedType).actualTypeArguments
-    assertThat(fieldTypeArguments[0]).isNotInstanceOf(WildcardType::class.java)
-    assertThat(fieldTypeArguments[1]).isInstanceOf(WildcardType::class.java)
+    assertFalse(fieldTypeArguments[0] is WildcardType)
+    assertTrue(fieldTypeArguments[1] is WildcardType)
 
     val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
     val adapter = moshi.adapter(type)
 
     Assertions.assertThat(adapter.fromJson(json)).isEqualToComparingFieldByFieldRecursively(value)
-    assertThat(adapter.toJson(value)).isEqualTo(json)
+    assertEquals(adapter.toJson(value), json)
   }
 }

--- a/moshi-kotlin/build.gradle.kts
+++ b/moshi-kotlin/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
 
   testImplementation(kotlin("test"))
   testImplementation(libs.junit)
-  testImplementation(libs.truth)
 }
 
 tasks.withType<Jar>().configureEach {

--- a/moshi-kotlin/src/test/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/moshi-kotlin/src/test/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -15,10 +15,10 @@
  */
 package com.squareup.moshi.kotlin.reflect
 
-import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import org.junit.Test
+import kotlin.test.assertTrue
 
 class KotlinJsonAdapterTest {
   @JsonClass(generateAdapter = true)
@@ -30,8 +30,9 @@ class KotlinJsonAdapterTest {
       .add(KotlinJsonAdapterFactory())
       .build()
     val adapter = moshi.adapter(Data::class.java)
-    assertThat(adapter.toString()).isEqualTo(
-      "KotlinJsonAdapter(com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest.Data).nullSafe()"
+
+    assertTrue(
+      adapter.toString().contentEquals("KotlinJsonAdapter(com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest.Data).nullSafe()")
     )
   }
 }

--- a/moshi/build.gradle.kts
+++ b/moshi/build.gradle.kts
@@ -80,7 +80,6 @@ dependencies {
 
   testCompileOnly(libs.jsr305)
   testImplementation(libs.junit)
-  testImplementation(libs.truth)
 }
 
 tasks.withType<Jar>().configureEach {

--- a/moshi/records-tests/build.gradle.kts
+++ b/moshi/records-tests/build.gradle.kts
@@ -17,5 +17,4 @@ dependencies {
   testImplementation(project(":moshi"))
   testCompileOnly(libs.jsr305)
   testImplementation(libs.junit)
-  testImplementation(libs.truth)
 }

--- a/moshi/records-tests/src/test/java/com/squareup/moshi/records/RecordsTest.java
+++ b/moshi/records-tests/src/test/java/com/squareup/moshi/records/RecordsTest.java
@@ -15,8 +15,9 @@
  */
 package com.squareup.moshi.records;
 
-import static com.google.common.truth.Truth.assertThat;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.squareup.moshi.FromJson;
@@ -73,7 +74,7 @@ public final class RecordsTest {
             new Map[] {Map.of("Hello", "value")});
     var json = adapter.toJson(instance);
     var deserialized = adapter.fromJson(json);
-    assertThat(deserialized).isEqualTo(instance);
+    assertEquals(deserialized, instance);
   }
 
   public record SmokeTestType(
@@ -147,7 +148,7 @@ public final class RecordsTest {
         moshi.<GenericRecord<String>>adapter(
             Types.newParameterizedTypeWithOwner(
                 RecordsTest.class, GenericRecord.class, String.class));
-    assertThat(adapter.fromJson("{\"value\":\"Okay!\"}")).isEqualTo(new GenericRecord<>("Okay!"));
+    assertEquals(adapter.fromJson("{\"value\":\"Okay!\"}"), new GenericRecord<>("Okay!"));
   }
 
   public record GenericRecord<T>(T value) {}
@@ -158,7 +159,7 @@ public final class RecordsTest {
         moshi.<GenericBoundedRecord<Integer>>adapter(
             Types.newParameterizedTypeWithOwner(
                 RecordsTest.class, GenericBoundedRecord.class, Integer.class));
-    assertThat(adapter.fromJson("{\"value\":4}")).isEqualTo(new GenericBoundedRecord<>(4));
+    assertEquals(adapter.fromJson("{\"value\":4}"), new GenericBoundedRecord<>(4));
   }
 
   @Test
@@ -168,8 +169,8 @@ public final class RecordsTest {
             new IndirectGenerics<>(1L, List.of(2L, 3L, 4L), Map.of("five", 5L)));
     var jsonAdapter = moshi.adapter(HasIndirectGenerics.class);
     var json = "{\"value\":{\"single\":1,\"list\":[2,3,4],\"map\":{\"five\":5}}}";
-    assertThat(jsonAdapter.toJson(value)).isEqualTo(json);
-    assertThat(jsonAdapter.fromJson(json)).isEqualTo(value);
+    assertEquals(jsonAdapter.toJson(value), json);
+    assertEquals(jsonAdapter.fromJson(json), value);
   }
 
   public record IndirectGenerics<T>(T single, List<T> list, Map<String, T> map) {}
@@ -179,8 +180,7 @@ public final class RecordsTest {
   @Test
   public void qualifiedValues() throws IOException {
     var adapter = moshi.newBuilder().add(new ColorAdapter()).build().adapter(QualifiedValues.class);
-    assertThat(adapter.fromJson("{\"value\":\"#ff0000\"}"))
-        .isEqualTo(new QualifiedValues(16711680));
+    assertEquals(adapter.fromJson("{\"value\":\"#ff0000\"}"), new QualifiedValues(16711680));
   }
 
   public record QualifiedValues(@HexColor int value) {}
@@ -208,7 +208,7 @@ public final class RecordsTest {
   @Test
   public void jsonName() throws IOException {
     var adapter = moshi.adapter(JsonName.class);
-    assertThat(adapter.fromJson("{\"actualValue\":3}")).isEqualTo(new JsonName(3));
+    assertEquals(adapter.fromJson("{\"actualValue\":3}"), new JsonName(3));
   }
 
   public record JsonName(@Json(name = "actualValue") int value) {}
@@ -238,13 +238,13 @@ public final class RecordsTest {
       adapter.fromJson(json);
       fail();
     } catch (IOException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("boom!");
+      assertTrue(expected.getMessage().contains("boom!"));
     }
     try {
       adapter.toJson(new Buffer(), new BooleanRecord(true));
       fail();
     } catch (IOException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("boom!");
+      assertTrue(expected.getMessage().contains("boom!"));
     }
   }
 
@@ -257,7 +257,7 @@ public final class RecordsTest {
       adapter.fromJson("{\"s\":\"\"}");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Required value 'i' missing at $");
+      assertTrue(expected.getMessage().contains("Required value 'i' missing at $"));
     }
   }
 
@@ -268,7 +268,7 @@ public final class RecordsTest {
       adapter.fromJson("{\"s\":\"\",\"i\":null}");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected an int but was NULL at path $.i");
+      assertTrue(expected.getMessage().contains("Expected an int but was NULL at path $.i"));
     }
   }
 
@@ -277,8 +277,8 @@ public final class RecordsTest {
     var adapter = moshi.adapter(AbsentValues.class);
     String json = "{\"i\":5}";
     AbsentValues value = new AbsentValues(null, 5);
-    assertThat(adapter.fromJson(json)).isEqualTo(value);
-    assertThat(adapter.toJson(value)).isEqualTo(json);
+    assertEquals(adapter.fromJson(json), value);
+    assertEquals(adapter.toJson(value), json);
   }
 
   @Test
@@ -286,8 +286,8 @@ public final class RecordsTest {
     var adapter = moshi.adapter(AbsentValues.class);
     String json = "{\"i\":5,\"s\":null}";
     AbsentValues value = new AbsentValues(null, 5);
-    assertThat(adapter.fromJson(json)).isEqualTo(value);
-    assertThat(adapter.toJson(value)).isEqualTo("{\"i\":5}");
+    assertEquals(adapter.fromJson(json), value);
+    assertEquals(adapter.toJson(value), "{\"i\":5}");
   }
 
   public record AbsentValues(String s, int i) {}

--- a/moshi/src/test/java/com/squareup/moshi/AdapterMethodsTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/AdapterMethodsTest.java
@@ -15,8 +15,10 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.squareup.moshi.MoshiTest.Uppercase;
@@ -41,8 +43,8 @@ public final class AdapterMethodsTest {
   public void toAndFromJsonViaListOfIntegers() throws Exception {
     Moshi moshi = new Moshi.Builder().add(new PointAsListOfIntegersJsonAdapter()).build();
     JsonAdapter<Point> pointAdapter = moshi.adapter(Point.class);
-    assertThat(pointAdapter.toJson(new Point(5, 8))).isEqualTo("[5,8]");
-    assertThat(pointAdapter.fromJson("[5,8]")).isEqualTo(new Point(5, 8));
+    assertEquals(pointAdapter.toJson(new Point(5, 8)), "[5,8]");
+    assertEquals(pointAdapter.fromJson("[5,8]"), new Point(5, 8));
   }
 
   static class PointAsListOfIntegersJsonAdapter {
@@ -62,8 +64,8 @@ public final class AdapterMethodsTest {
   public void toAndFromJsonWithWriterAndReader() throws Exception {
     Moshi moshi = new Moshi.Builder().add(new PointWriterAndReaderJsonAdapter()).build();
     JsonAdapter<Point> pointAdapter = moshi.adapter(Point.class);
-    assertThat(pointAdapter.toJson(new Point(5, 8))).isEqualTo("[5,8]");
-    assertThat(pointAdapter.fromJson("[5,8]")).isEqualTo(new Point(5, 8));
+    assertEquals(pointAdapter.toJson(new Point(5, 8)), "[5,8]");
+    assertEquals(pointAdapter.fromJson("[5,8]"), new Point(5, 8));
   }
 
   static class PointWriterAndReaderJsonAdapter {
@@ -126,8 +128,8 @@ public final class AdapterMethodsTest {
     Moshi moshi = new Moshi.Builder().add(new PointJsonAdapterWithDelegate()).build();
     JsonAdapter<Point> adapter = moshi.adapter(Point.class);
     Point point = new Point(5, 8);
-    assertThat(adapter.toJson(point)).isEqualTo("[{\"x\":5,\"y\":8}]");
-    assertThat(adapter.fromJson("[{\"x\":5,\"y\":8}]")).isEqualTo(point);
+    assertEquals(adapter.toJson(point), "[{\"x\":5,\"y\":8}]");
+    assertEquals(adapter.fromJson("[{\"x\":5,\"y\":8}]"), point);
   }
 
   @Test
@@ -139,8 +141,8 @@ public final class AdapterMethodsTest {
             .build();
     JsonAdapter<Point> adapter = moshi.adapter(Point.class, WithParens.class);
     Point point = new Point(5, 8);
-    assertThat(adapter.toJson(point)).isEqualTo("[\"(5 8)\"]");
-    assertThat(adapter.fromJson("[\"(5 8)\"]")).isEqualTo(point);
+    assertEquals(adapter.toJson(point), "[\"(5 8)\"]");
+    assertEquals(adapter.fromJson("[\"(5 8)\"]"), point);
   }
 
   @Test
@@ -161,8 +163,8 @@ public final class AdapterMethodsTest {
                 })
             .build();
     JsonAdapter<String> adapter = moshi.adapter(String.class);
-    assertThat(adapter.toJson("pizza")).isEqualTo("\"|pizza|\"");
-    assertThat(adapter.fromJson("\"|pizza|\"")).isEqualTo("pizza");
+    assertEquals(adapter.toJson("pizza"), "\"|pizza|\"");
+    assertEquals(adapter.fromJson("\"|pizza|\""), "pizza");
   }
 
   @Test
@@ -186,16 +188,16 @@ public final class AdapterMethodsTest {
             .add(new UppercaseAdapterFactory())
             .build();
     JsonAdapter<String> adapter = moshi.adapter(String.class, Uppercase.class);
-    assertThat(adapter.toJson("pizza")).isEqualTo("\"|PIZZA|\"");
-    assertThat(adapter.fromJson("\"|pizza|\"")).isEqualTo("PIZZA");
+    assertEquals(adapter.toJson("pizza"), "\"|PIZZA|\"");
+    assertEquals(adapter.fromJson("\"|pizza|\""), "PIZZA");
   }
 
   @Test
   public void toJsonOnly() throws Exception {
     Moshi moshi = new Moshi.Builder().add(new PointAsListOfIntegersToAdapter()).build();
     JsonAdapter<Point> pointAdapter = moshi.adapter(Point.class);
-    assertThat(pointAdapter.toJson(new Point(5, 8))).isEqualTo("[5,8]");
-    assertThat(pointAdapter.fromJson("{\"x\":5,\"y\":8}")).isEqualTo(new Point(5, 8));
+    assertEquals(pointAdapter.toJson(new Point(5, 8)), "[5,8]");
+    assertEquals(pointAdapter.fromJson("{\"x\":5,\"y\":8}"), new Point(5, 8));
   }
 
   static class PointAsListOfIntegersToAdapter {
@@ -209,8 +211,8 @@ public final class AdapterMethodsTest {
   public void fromJsonOnly() throws Exception {
     Moshi moshi = new Moshi.Builder().add(new PointAsListOfIntegersFromAdapter()).build();
     JsonAdapter<Point> pointAdapter = moshi.adapter(Point.class);
-    assertThat(pointAdapter.toJson(new Point(5, 8))).isEqualTo("{\"x\":5,\"y\":8}");
-    assertThat(pointAdapter.fromJson("[5,8]")).isEqualTo(new Point(5, 8));
+    assertEquals(pointAdapter.toJson(new Point(5, 8)), "{\"x\":5,\"y\":8}");
+    assertEquals(pointAdapter.fromJson("[5,8]"), new Point(5, 8));
   }
 
   static class PointAsListOfIntegersFromAdapter {
@@ -225,8 +227,8 @@ public final class AdapterMethodsTest {
   public void multipleLayersOfAdapters() throws Exception {
     Moshi moshi = new Moshi.Builder().add(new MultipleLayersJsonAdapter()).build();
     JsonAdapter<Point> pointAdapter = moshi.adapter(Point.class).lenient();
-    assertThat(pointAdapter.toJson(new Point(5, 8))).isEqualTo("\"5 8\"");
-    assertThat(pointAdapter.fromJson("\"5 8\"")).isEqualTo(new Point(5, 8));
+    assertEquals(pointAdapter.toJson(new Point(5, 8)), "\"5 8\"");
+    assertEquals(pointAdapter.fromJson("\"5 8\""), new Point(5, 8));
   }
 
   static class MultipleLayersJsonAdapter {
@@ -262,15 +264,15 @@ public final class AdapterMethodsTest {
   }
 
   @Test
-  public void conflictingToAdapters() throws Exception {
+  public void conflictingToAdapters() {
     Moshi.Builder builder = new Moshi.Builder();
     try {
       builder.add(new ConflictingsToJsonAdapter());
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected.getMessage()).contains("Conflicting @ToJson methods:");
-      assertThat(expected.getMessage()).contains("pointToJson1");
-      assertThat(expected.getMessage()).contains("pointToJson2");
+      assertTrue(expected.getMessage().contains("Conflicting @ToJson methods:"));
+      assertTrue(expected.getMessage().contains("pointToJson1"));
+      assertTrue(expected.getMessage().contains("pointToJson2"));
     }
   }
 
@@ -293,9 +295,9 @@ public final class AdapterMethodsTest {
       builder.add(new ConflictingsFromJsonAdapter());
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected.getMessage()).contains("Conflicting @FromJson methods:");
-      assertThat(expected.getMessage()).contains("pointFromJson1");
-      assertThat(expected.getMessage()).contains("pointFromJson2");
+      assertTrue(expected.getMessage().contains("Conflicting @FromJson methods:"));
+      assertTrue(expected.getMessage().contains("pointFromJson1"));
+      assertTrue(expected.getMessage().contains("pointFromJson2"));
     }
   }
 
@@ -318,11 +320,10 @@ public final class AdapterMethodsTest {
       builder.add(new EmptyJsonAdapter()).build();
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Expected at least one @ToJson or @FromJson method on "
-                  + "com.squareup.moshi.AdapterMethodsTest$EmptyJsonAdapter");
+      assertEquals(
+          "Expected at least one @ToJson or @FromJson method on "
+              + "com.squareup.moshi.AdapterMethodsTest$EmptyJsonAdapter",
+          expected.getMessage());
     }
   }
 
@@ -335,17 +336,16 @@ public final class AdapterMethodsTest {
       builder.add(new UnexpectedSignatureToJsonAdapter()).build();
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Unexpected signature for void "
-                  + "com.squareup.moshi.AdapterMethodsTest$UnexpectedSignatureToJsonAdapter.pointToJson"
-                  + "(com.squareup.moshi.AdapterMethodsTest$Point).\n"
-                  + "@ToJson method signatures may have one of the following structures:\n"
-                  + "    <any access modifier> void toJson(JsonWriter writer, T value) throws <any>;\n"
-                  + "    <any access modifier> void toJson(JsonWriter writer, T value,"
-                  + " JsonAdapter<any> delegate, <any more delegates>) throws <any>;\n"
-                  + "    <any access modifier> R toJson(T value) throws <any>;\n");
+      assertEquals(
+          "Unexpected signature for void "
+              + "com.squareup.moshi.AdapterMethodsTest$UnexpectedSignatureToJsonAdapter.pointToJson"
+              + "(com.squareup.moshi.AdapterMethodsTest$Point).\n"
+              + "@ToJson method signatures may have one of the following structures:\n"
+              + "    <any access modifier> void toJson(JsonWriter writer, T value) throws <any>;\n"
+              + "    <any access modifier> void toJson(JsonWriter writer, T value,"
+              + " JsonAdapter<any> delegate, <any more delegates>) throws <any>;\n"
+              + "    <any access modifier> R toJson(T value) throws <any>;\n",
+          expected.getMessage());
     }
   }
 
@@ -361,17 +361,17 @@ public final class AdapterMethodsTest {
       builder.add(new UnexpectedSignatureFromJsonAdapter()).build();
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Unexpected signature for void "
-                  + "com.squareup.moshi.AdapterMethodsTest$UnexpectedSignatureFromJsonAdapter.pointFromJson"
-                  + "(java.lang.String).\n"
-                  + "@FromJson method signatures may have one of the following structures:\n"
-                  + "    <any access modifier> R fromJson(JsonReader jsonReader) throws <any>;\n"
-                  + "    <any access modifier> R fromJson(JsonReader jsonReader,"
-                  + " JsonAdapter<any> delegate, <any more delegates>) throws <any>;\n"
-                  + "    <any access modifier> R fromJson(T value) throws <any>;\n");
+
+      assertEquals(
+          "Unexpected signature for void "
+              + "com.squareup.moshi.AdapterMethodsTest$UnexpectedSignatureFromJsonAdapter.pointFromJson"
+              + "(java.lang.String).\n"
+              + "@FromJson method signatures may have one of the following structures:\n"
+              + "    <any access modifier> R fromJson(JsonReader jsonReader) throws <any>;\n"
+              + "    <any access modifier> R fromJson(JsonReader jsonReader,"
+              + " JsonAdapter<any> delegate, <any more delegates>) throws <any>;\n"
+              + "    <any access modifier> R fromJson(T value) throws <any>;\n",
+          expected.getMessage());
     }
   }
 
@@ -389,8 +389,8 @@ public final class AdapterMethodsTest {
     Moshi moshi =
         new Moshi.Builder().add(new NotNullablePointAsListOfIntegersJsonAdapter()).build();
     JsonAdapter<Point> pointAdapter = moshi.adapter(Point.class).lenient();
-    assertThat(pointAdapter.toJson(null)).isEqualTo("null");
-    assertThat(pointAdapter.fromJson("null")).isNull();
+    assertEquals(pointAdapter.toJson(null), "null");
+    assertNull(pointAdapter.fromJson("null"));
   }
 
   static class NotNullablePointAsListOfIntegersJsonAdapter {
@@ -409,8 +409,8 @@ public final class AdapterMethodsTest {
   public void toAndFromNullNullable() throws Exception {
     Moshi moshi = new Moshi.Builder().add(new NullablePointAsListOfIntegersJsonAdapter()).build();
     JsonAdapter<Point> pointAdapter = moshi.adapter(Point.class).lenient();
-    assertThat(pointAdapter.toJson(null)).isEqualTo("[0,0]");
-    assertThat(pointAdapter.fromJson("null")).isEqualTo(new Point(0, 0));
+    assertEquals(pointAdapter.toJson(null), "[0,0]");
+    assertEquals(pointAdapter.fromJson("null"), new Point(0, 0));
   }
 
   static class NullablePointAsListOfIntegersJsonAdapter {
@@ -434,8 +434,8 @@ public final class AdapterMethodsTest {
   public void toAndFromNullJsonWithWriterAndReader() throws Exception {
     Moshi moshi = new Moshi.Builder().add(new NullableIntToJsonAdapter()).build();
     JsonAdapter<Point> pointAdapter = moshi.adapter(Point.class);
-    assertThat(pointAdapter.fromJson("{\"x\":null,\"y\":3}")).isEqualTo(new Point(-1, 3));
-    assertThat(pointAdapter.toJson(new Point(-1, 3))).isEqualTo("{\"y\":3}");
+    assertEquals(pointAdapter.fromJson("{\"x\":null,\"y\":3}"), new Point(-1, 3));
+    assertEquals(pointAdapter.toJson(new Point(-1, 3)), "{\"y\":3}");
   }
 
   static class NullableIntToJsonAdapter {
@@ -466,14 +466,13 @@ public final class AdapterMethodsTest {
       arrayOfPointAdapter.toJson(new Point[] {null, null, new Point(0, 0)});
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected.getMessage()).isEqualTo("java.lang.Exception: pointToJson fail! at $[2]");
+      assertEquals(expected.getMessage(), "java.lang.Exception: pointToJson fail! at $[2]");
     }
     try {
       arrayOfPointAdapter.fromJson("[null,null,[0,0]]");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected.getMessage())
-          .isEqualTo("java.lang.Exception: pointFromJson fail! at $[2]");
+      assertEquals("java.lang.Exception: pointFromJson fail! at $[2]", expected.getMessage());
     }
   }
 
@@ -506,17 +505,17 @@ public final class AdapterMethodsTest {
       toJsonMoshi.adapter(Shape.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e)
-          .hasMessageThat()
-          .isEqualTo(
-              "No @FromJson adapter for interface "
-                  + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)");
-      assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
-      assertThat(e.getCause())
-          .hasMessageThat()
-          .isEqualTo(
-              "No next JsonAdapter for interface "
-                  + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)");
+      assertEquals(
+          "No @FromJson adapter for interface "
+              + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)",
+          e.getMessage());
+
+      assertTrue(e.getCause() instanceof IllegalArgumentException);
+
+      assertEquals(
+          "No next JsonAdapter for interface "
+              + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)",
+          e.getCause().getMessage());
     }
   }
 
@@ -535,17 +534,18 @@ public final class AdapterMethodsTest {
       fromJsonMoshi.adapter(Shape.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e)
-          .hasMessageThat()
-          .isEqualTo(
-              "No @ToJson adapter for interface "
-                  + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)");
-      assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
-      assertThat(e.getCause())
-          .hasMessageThat()
-          .isEqualTo(
-              "No next JsonAdapter for interface "
-                  + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)");
+
+      assertEquals(
+          "No @ToJson adapter for interface "
+              + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)",
+          e.getMessage());
+
+      assertTrue(e.getCause() instanceof IllegalArgumentException);
+
+      assertEquals(
+          "No next JsonAdapter for interface "
+              + "com.squareup.moshi.AdapterMethodsTest$Shape (with no annotations)",
+          e.getCause().getMessage());
     }
   }
 
@@ -561,8 +561,8 @@ public final class AdapterMethodsTest {
     ParameterizedType listOfStringType = brokenParameterizedType(0, List.class, String.class);
 
     JsonAdapter<List<String>> jsonAdapter = moshi.adapter(listOfStringType);
-    assertThat(jsonAdapter.toJson(Arrays.asList("a", "b", "c"))).isEqualTo("\"a|b|c\"");
-    assertThat(jsonAdapter.fromJson("\"a|b|c\"")).isEqualTo(Arrays.asList("a", "b", "c"));
+    assertEquals(jsonAdapter.toJson(Arrays.asList("a", "b", "c")), "\"a|b|c\"");
+    assertEquals(jsonAdapter.fromJson("\"a|b|c\""), Arrays.asList("a", "b", "c"));
   }
 
   static class ListOfStringJsonAdapter {
@@ -594,8 +594,11 @@ public final class AdapterMethodsTest {
     Type b = brokenParameterizedType(1, List.class, String.class);
     Type c = brokenParameterizedType(2, List.class, String.class);
 
-    assertThat(moshi.adapter(b)).isSameInstanceAs(moshi.adapter(a));
-    assertThat(moshi.adapter(c)).isSameInstanceAs(moshi.adapter(a));
+    assertEquals(moshi.adapter(b).getClass(), moshi.adapter(a).getClass());
+    assertEquals(moshi.adapter(b), moshi.adapter(a));
+
+    assertEquals(moshi.adapter(c).getClass(), moshi.adapter(a).getClass());
+    assertEquals(moshi.adapter(c), moshi.adapter(a));
   }
 
   @Test
@@ -607,8 +610,8 @@ public final class AdapterMethodsTest {
             .build();
     JsonAdapter<Line> lineAdapter = moshi.adapter(Line.class);
     Line line = new Line(new Point(5, 8), new Point(3, 2));
-    assertThat(lineAdapter.toJson(line)).isEqualTo("[[5,8],[3,2]]");
-    assertThat(lineAdapter.fromJson("[[5,8],[3,2]]")).isEqualTo(line);
+    assertEquals(lineAdapter.toJson(line), "[[5,8],[3,2]]");
+    assertEquals(lineAdapter.fromJson("[[5,8],[3,2]]"), line);
   }
 
   static class JsonAdapterWithWriterAndReaderTakingJsonAdapterParameter {
@@ -640,8 +643,8 @@ public final class AdapterMethodsTest {
             .build();
     JsonAdapter<Line> lineAdapter = moshi.adapter(Line.class);
     Line line = new Line(new Point(5, 8), new Point(3, 2));
-    assertThat(lineAdapter.toJson(line)).isEqualTo("[\"(5 8)\",\"(3 2)\"]");
-    assertThat(lineAdapter.fromJson("[\"(5 8)\",\"(3 2)\"]")).isEqualTo(line);
+    assertEquals(lineAdapter.toJson(line), "[\"(5 8)\",\"(3 2)\"]");
+    assertEquals(lineAdapter.fromJson("[\"(5 8)\",\"(3 2)\"]"), line);
   }
 
   static class PointWithParensJsonAdapter {
@@ -690,8 +693,8 @@ public final class AdapterMethodsTest {
             .build();
     JsonAdapter<Line> lineAdapter = moshi.adapter(Line.class);
     Line line = new Line(new Point(5, 8), new Point(3, 2));
-    assertThat(lineAdapter.toJson(line)).isEqualTo("[[5,8],\"(3 2)\"]");
-    assertThat(lineAdapter.fromJson("[[5,8],\"(3 2)\"]")).isEqualTo(line);
+    assertEquals(lineAdapter.toJson(line), "[[5,8],\"(3 2)\"]");
+    assertEquals(lineAdapter.fromJson("[[5,8],\"(3 2)\"]"), line);
   }
 
   static class JsonAdapterWithWriterAndReaderTakingMultipleJsonAdapterParameters {
@@ -730,7 +733,7 @@ public final class AdapterMethodsTest {
       new Moshi.Builder().add(new ToJsonAdapterTakingJsonAdapterParameter());
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().startsWith("Unexpected signature");
+      assertTrue(expected.getMessage().startsWith("Unexpected signature"));
     }
   }
 
@@ -747,7 +750,7 @@ public final class AdapterMethodsTest {
       new Moshi.Builder().add(new FromJsonAdapterTakingJsonAdapterParameter());
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().startsWith("Unexpected signature");
+      assertTrue(expected.getMessage().startsWith("Unexpected signature"));
     }
   }
 
@@ -766,8 +769,8 @@ public final class AdapterMethodsTest {
             Types.newParameterizedTypeWithOwner(AdapterMethodsTest.class, Box.class, Point.class));
     Box<Point> box = new Box<>(new Point(5, 8));
     String json = "[{\"x\":5,\"y\":8}]";
-    assertThat(boxAdapter.toJson(box)).isEqualTo(json);
-    assertThat(boxAdapter.fromJson(json)).isEqualTo(box);
+    assertEquals(boxAdapter.toJson(box), json);
+    assertEquals(boxAdapter.fromJson(json), box);
   }
 
   static class EnclosedParameterizedTypeJsonAdapter {
@@ -809,8 +812,8 @@ public final class AdapterMethodsTest {
         new MapOfByteArrays(Collections.singletonMap("a", new byte[] {0, -1}));
     String json = "{\"map\":{\"a\":\"00ff\"}}";
 
-    assertThat(jsonAdapter.toJson(mapOfByteArrays)).isEqualTo(json);
-    assertThat(jsonAdapter.fromJson(json)).isEqualTo(mapOfByteArrays);
+    assertEquals(jsonAdapter.toJson(mapOfByteArrays), json);
+    assertEquals(jsonAdapter.fromJson(json), mapOfByteArrays);
   }
 
   static class ByteArrayJsonAdapter {

--- a/moshi/src/test/java/com/squareup/moshi/CircularAdaptersTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/CircularAdaptersTest.java
@@ -15,8 +15,8 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.Assert.assertEquals;
 
 import com.squareup.moshi.internal.Util;
 import java.io.IOException;
@@ -56,19 +56,19 @@ public final class CircularAdaptersTest {
         new Team(
             "Alice",
             new Project("King", new Team("Charlie", new Project("Delivery", (Team[]) null))));
-    assertThat(teamAdapter.toJson(team))
-        .isEqualTo(
-            "{\"lead\":\"Alice\",\"projects\":[{\"name\":"
-                + "\"King\",\"teams\":[{\"lead\":\"Charlie\",\"projects\":[{\"name\":\"Delivery\"}]}]}]}");
+    assertEquals(
+        teamAdapter.toJson(team),
+        "{\"lead\":\"Alice\",\"projects\":[{\"name\":"
+            + "\"King\",\"teams\":[{\"lead\":\"Charlie\",\"projects\":[{\"name\":\"Delivery\"}]}]}]}");
 
     Team fromJson =
         teamAdapter.fromJson(
             "{\"lead\":\"Alice\",\"projects\":[{\"name\":"
                 + "\"King\",\"teams\":[{\"lead\":\"Charlie\",\"projects\":[{\"name\":\"Delivery\"}]}]}]}");
-    assertThat(fromJson.lead).isEqualTo("Alice");
-    assertThat(fromJson.projects[0].name).isEqualTo("King");
-    assertThat(fromJson.projects[0].teams[0].lead).isEqualTo("Charlie");
-    assertThat(fromJson.projects[0].teams[0].projects[0].name).isEqualTo("Delivery");
+    assertEquals(fromJson.lead, "Alice");
+    assertEquals(fromJson.projects[0].name, "King");
+    assertEquals(fromJson.projects[0].teams[0].lead, "Charlie");
+    assertEquals(fromJson.projects[0].teams[0].projects[0].name, "Delivery");
   }
 
   @Retention(RUNTIME)
@@ -146,13 +146,13 @@ public final class CircularAdaptersTest {
             "C",
             new Node("A", null, new Node("B", null, null)),
             new Node("D", null, new Node("E", null, null)));
-    assertThat(nodeAdapter.toJson(tree))
-        .isEqualTo(
-            "{"
-                + "\"left\":{\"name\":\"L A\",\"right\":{\"name\":\"R B\"}},"
-                + "\"name\":\"C\","
-                + "\"right\":{\"name\":\"R D\",\"right\":{\"name\":\"R E\"}}"
-                + "}");
+    assertEquals(
+        nodeAdapter.toJson(tree),
+        "{"
+            + "\"left\":{\"name\":\"L A\",\"right\":{\"name\":\"R B\"}},"
+            + "\"name\":\"C\","
+            + "\"right\":{\"name\":\"R D\",\"right\":{\"name\":\"R E\"}}"
+            + "}");
 
     Node fromJson =
         nodeAdapter.fromJson(
@@ -161,10 +161,10 @@ public final class CircularAdaptersTest {
                 + "\"name\":\"C\","
                 + "\"right\":{\"name\":\"R D\",\"right\":{\"name\":\"R E\"}}"
                 + "}");
-    assertThat(fromJson.name).isEqualTo("C");
-    assertThat(fromJson.left.name).isEqualTo("A");
-    assertThat(fromJson.left.right.name).isEqualTo("B");
-    assertThat(fromJson.right.name).isEqualTo("D");
-    assertThat(fromJson.right.right.name).isEqualTo("E");
+    assertEquals(fromJson.name, "C");
+    assertEquals(fromJson.left.name, "A");
+    assertEquals(fromJson.left.right.name, "B");
+    assertEquals(fromJson.right.name, "D");
+    assertEquals(fromJson.right.right.name, "E");
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/ClassJsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/ClassJsonAdapterTest.java
@@ -15,9 +15,12 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.moshi.TestUtil.newReader;
 import static com.squareup.moshi.internal.Util.NO_ANNOTATIONS;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
@@ -43,11 +46,11 @@ public final class ClassJsonAdapterTest {
     value.diameter = 13;
     value.extraCheese = true;
     String toJson = toJson(BasicPizza.class, value);
-    assertThat(toJson).isEqualTo("{\"diameter\":13,\"extraCheese\":true}");
+    assertEquals(toJson, "{\"diameter\":13,\"extraCheese\":true}");
 
     BasicPizza fromJson = fromJson(BasicPizza.class, "{\"diameter\":13,\"extraCheese\":true}");
-    assertThat(fromJson.diameter).isEqualTo(13);
-    assertThat(fromJson.extraCheese).isTrue();
+    assertEquals(fromJson.diameter, 13);
+    assertTrue(fromJson.extraCheese);
   }
 
   static class PrivateFieldsPizza {
@@ -59,11 +62,11 @@ public final class ClassJsonAdapterTest {
     PrivateFieldsPizza value = new PrivateFieldsPizza();
     value.secretIngredient = "vodka";
     String toJson = toJson(PrivateFieldsPizza.class, value);
-    assertThat(toJson).isEqualTo("{\"secretIngredient\":\"vodka\"}");
+    assertEquals(toJson, "{\"secretIngredient\":\"vodka\"}");
 
     PrivateFieldsPizza fromJson =
         fromJson(PrivateFieldsPizza.class, "{\"secretIngredient\":\"vodka\"}");
-    assertThat(fromJson.secretIngredient).isEqualTo("vodka");
+    assertEquals(fromJson.secretIngredient, "vodka");
   }
 
   static class BasePizza {
@@ -80,11 +83,11 @@ public final class ClassJsonAdapterTest {
     value.diameter = 13;
     value.chocolate = true;
     String toJson = toJson(DessertPizza.class, value);
-    assertThat(toJson).isEqualTo("{\"chocolate\":true,\"diameter\":13}");
+    assertEquals(toJson, "{\"chocolate\":true,\"diameter\":13}");
 
     DessertPizza fromJson = fromJson(DessertPizza.class, "{\"diameter\":13,\"chocolate\":true}");
-    assertThat(fromJson.diameter).isEqualTo(13);
-    assertThat(fromJson.chocolate).isTrue();
+    assertEquals(fromJson.diameter, 13);
+    assertTrue(fromJson.chocolate);
   }
 
   static class BaseAbcde {
@@ -107,15 +110,15 @@ public final class ClassJsonAdapterTest {
     value.d = 7;
     value.e = 8;
     String toJson = toJson(ExtendsBaseAbcde.class, value);
-    assertThat(toJson).isEqualTo("{\"a\":4,\"b\":5,\"c\":6,\"d\":7,\"e\":8}");
+    assertEquals(toJson, "{\"a\":4,\"b\":5,\"c\":6,\"d\":7,\"e\":8}");
 
     ExtendsBaseAbcde fromJson =
         fromJson(ExtendsBaseAbcde.class, "{\"a\":4,\"b\":5,\"c\":6,\"d\":7,\"e\":8}");
-    assertThat(fromJson.a).isEqualTo(4);
-    assertThat(fromJson.b).isEqualTo(5);
-    assertThat(fromJson.c).isEqualTo(6);
-    assertThat(fromJson.d).isEqualTo(7);
-    assertThat(fromJson.e).isEqualTo(8);
+    assertEquals(fromJson.a, 4);
+    assertEquals(fromJson.b, 5);
+    assertEquals(fromJson.c, 6);
+    assertEquals(fromJson.d, 7);
+    assertEquals(fromJson.e, 8);
   }
 
   static class StaticFields {
@@ -128,11 +131,11 @@ public final class ClassJsonAdapterTest {
     StaticFields value = new StaticFields();
     value.b = 12;
     String toJson = toJson(StaticFields.class, value);
-    assertThat(toJson).isEqualTo("{\"b\":12}");
+    assertEquals(toJson, "{\"b\":12}");
 
     StaticFields fromJson = fromJson(StaticFields.class, "{\"a\":13,\"b\":12}");
-    assertThat(StaticFields.a).isEqualTo(11); // Unchanged.
-    assertThat(fromJson.b).isEqualTo(12);
+    assertEquals(StaticFields.a, 11); // Unchanged.
+    assertEquals(fromJson.b, 12);
   }
 
   static class TransientFields {
@@ -146,11 +149,11 @@ public final class ClassJsonAdapterTest {
     value.a = 11;
     value.b = 12;
     String toJson = toJson(TransientFields.class, value);
-    assertThat(toJson).isEqualTo("{\"b\":12}");
+    assertEquals(toJson, "{\"b\":12}");
 
     TransientFields fromJson = fromJson(TransientFields.class, "{\"a\":13,\"b\":12}");
-    assertThat(fromJson.a).isEqualTo(0); // Not assigned.
-    assertThat(fromJson.b).isEqualTo(12);
+    assertEquals(fromJson.a, 0); // Not assigned.
+    assertEquals(fromJson.b, 12);
   }
 
   static class IgnoredFields {
@@ -166,11 +169,11 @@ public final class ClassJsonAdapterTest {
     value.a = 11;
     value.b = 12;
     String toJson = toJson(IgnoredFields.class, value);
-    assertThat(toJson).isEqualTo("{\"b\":12}");
+    assertEquals(toJson, "{\"b\":12}");
 
     IgnoredFields fromJson = fromJson(IgnoredFields.class, "{\"a\":13,\"b\":12}");
-    assertThat(fromJson.a).isEqualTo(0); // Not assigned.
-    assertThat(fromJson.b).isEqualTo(12);
+    assertEquals(fromJson.a, 0); // Not assigned.
+    assertEquals(fromJson.b, 12);
   }
 
   static class BaseA {
@@ -187,12 +190,13 @@ public final class ClassJsonAdapterTest {
       ClassJsonAdapter.Factory.create(ExtendsBaseA.class, NO_ANNOTATIONS, moshi);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Conflicting fields:\n"
-                  + "    int com.squareup.moshi.ClassJsonAdapterTest$ExtendsBaseA.a\n"
-                  + "    int com.squareup.moshi.ClassJsonAdapterTest$BaseA.a");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains(
+                  "Conflicting fields:\n"
+                      + "    int com.squareup.moshi.ClassJsonAdapterTest$ExtendsBaseA.a\n"
+                      + "    int com.squareup.moshi.ClassJsonAdapterTest$BaseA.a"));
     }
   }
 
@@ -209,12 +213,13 @@ public final class ClassJsonAdapterTest {
       ClassJsonAdapter.Factory.create(NameCollision.class, NO_ANNOTATIONS, moshi);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Conflicting fields:\n"
-                  + "    java.lang.String com.squareup.moshi.ClassJsonAdapterTest$NameCollision.foo\n"
-                  + "    java.lang.String com.squareup.moshi.ClassJsonAdapterTest$NameCollision.bar");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains(
+                  "Conflicting fields:\n"
+                      + "    java.lang.String com.squareup.moshi.ClassJsonAdapterTest$NameCollision.foo\n"
+                      + "    java.lang.String com.squareup.moshi.ClassJsonAdapterTest$NameCollision.bar"));
     }
   }
 
@@ -232,11 +237,11 @@ public final class ClassJsonAdapterTest {
     value.a = 11;
     ((TransientBaseA) value).a = 12;
     String toJson = toJson(ExtendsTransientBaseA.class, value);
-    assertThat(toJson).isEqualTo("{\"a\":11}");
+    assertEquals(toJson, "{\"a\":11}");
 
     ExtendsTransientBaseA fromJson = fromJson(ExtendsTransientBaseA.class, "{\"a\":11}");
-    assertThat(fromJson.a).isEqualTo(11);
-    assertThat(((TransientBaseA) fromJson).a).isEqualTo(0); // Not assigned.
+    assertEquals(fromJson.a, 11);
+    assertEquals(((TransientBaseA) fromJson).a, 0); // Not assigned.
   }
 
   static class NoArgConstructor {
@@ -251,8 +256,8 @@ public final class ClassJsonAdapterTest {
   @Test
   public void noArgConstructor() throws Exception {
     NoArgConstructor fromJson = fromJson(NoArgConstructor.class, "{\"b\":8}");
-    assertThat(fromJson.a).isEqualTo(5);
-    assertThat(fromJson.b).isEqualTo(8);
+    assertEquals(fromJson.a, 5);
+    assertEquals(fromJson.b, 8);
   }
 
   static class NoArgConstructorThrowsCheckedException {
@@ -267,7 +272,7 @@ public final class ClassJsonAdapterTest {
       fromJson(NoArgConstructorThrowsCheckedException.class, "{}");
       fail();
     } catch (RuntimeException expected) {
-      assertThat(expected.getCause()).hasMessageThat().isEqualTo("foo");
+      assertTrue(expected.getCause().getMessage().contains("foo"));
     }
   }
 
@@ -283,7 +288,7 @@ public final class ClassJsonAdapterTest {
       fromJson(NoArgConstructorThrowsUncheckedException.class, "{}");
       fail();
     } catch (UnsupportedOperationException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("foo");
+      assertTrue(expected.getMessage().contains("foo"));
     }
   }
 
@@ -296,8 +301,8 @@ public final class ClassJsonAdapterTest {
   public void noArgConstructorFieldDefaultsHonored() throws Exception {
     NoArgConstructorWithDefaultField fromJson =
         fromJson(NoArgConstructorWithDefaultField.class, "{\"b\":8}");
-    assertThat(fromJson.a).isEqualTo(5);
-    assertThat(fromJson.b).isEqualTo(8);
+    assertEquals(fromJson.a, 5);
+    assertEquals(fromJson.b, 8);
   }
 
   static class MagicConstructor {
@@ -311,7 +316,7 @@ public final class ClassJsonAdapterTest {
   @Test
   public void magicConstructor() throws Exception {
     MagicConstructor fromJson = fromJson(MagicConstructor.class, "{\"a\":8}");
-    assertThat(fromJson.a).isEqualTo(8);
+    assertEquals(fromJson.a, 8);
   }
 
   static class MagicConstructorWithDefaultField {
@@ -327,8 +332,8 @@ public final class ClassJsonAdapterTest {
   public void magicConstructorFieldDefaultsNotHonored() throws Exception {
     MagicConstructorWithDefaultField fromJson =
         fromJson(MagicConstructorWithDefaultField.class, "{\"b\":3}");
-    assertThat(fromJson.a).isEqualTo(0); // Surprising! No value is assigned.
-    assertThat(fromJson.b).isEqualTo(3);
+    assertEquals(fromJson.a, 0); // Surprising! No value is assigned.
+    assertEquals(fromJson.b, 3);
   }
 
   static class NullRootObject {
@@ -338,10 +343,10 @@ public final class ClassJsonAdapterTest {
   @Test
   public void nullRootObject() throws Exception {
     String toJson = toJson(PrivateFieldsPizza.class, null);
-    assertThat(toJson).isEqualTo("null");
+    assertEquals(toJson, "null");
 
     NullRootObject fromJson = fromJson(NullRootObject.class, "null");
-    assertThat(fromJson).isNull();
+    assertNull(fromJson);
   }
 
   static class NullFieldValue {
@@ -353,10 +358,10 @@ public final class ClassJsonAdapterTest {
     NullFieldValue value = new NullFieldValue();
     value.a = null;
     String toJson = toJson(NullFieldValue.class, value);
-    assertThat(toJson).isEqualTo("{\"a\":null}");
+    assertEquals(toJson, "{\"a\":null}");
 
     NullFieldValue fromJson = fromJson(NullFieldValue.class, "{\"a\":null}");
-    assertThat(fromJson.a).isNull();
+    assertNull(fromJson.a);
   }
 
   class NonStatic {}
@@ -367,11 +372,12 @@ public final class ClassJsonAdapterTest {
       ClassJsonAdapter.Factory.create(NonStatic.class, NO_ANNOTATIONS, moshi);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Cannot serialize non-static nested class "
-                  + "com.squareup.moshi.ClassJsonAdapterTest$NonStatic");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains(
+                  "Cannot serialize non-static nested class "
+                      + "com.squareup.moshi.ClassJsonAdapterTest$NonStatic"));
     }
   }
 
@@ -388,9 +394,10 @@ public final class ClassJsonAdapterTest {
       ClassJsonAdapter.Factory.create(c.getClass(), NO_ANNOTATIONS, moshi);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Cannot serialize anonymous class " + c.getClass().getName());
+      assertTrue(
+          expected
+              .getMessage()
+              .contains("Cannot serialize anonymous class " + c.getClass().getName()));
     }
   }
 
@@ -401,10 +408,12 @@ public final class ClassJsonAdapterTest {
       ClassJsonAdapter.Factory.create(Local.class, NO_ANNOTATIONS, moshi);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Cannot serialize local class " + "com.squareup.moshi.ClassJsonAdapterTest$1Local");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains(
+                  "Cannot serialize local class "
+                      + "com.squareup.moshi.ClassJsonAdapterTest$1Local"));
     }
   }
 
@@ -412,7 +421,7 @@ public final class ClassJsonAdapterTest {
 
   @Test
   public void interfaceNotSupported() throws Exception {
-    assertThat(ClassJsonAdapter.Factory.create(Interface.class, NO_ANNOTATIONS, moshi)).isNull();
+    assertNull(ClassJsonAdapter.Factory.create(Interface.class, NO_ANNOTATIONS, moshi));
   }
 
   abstract static class Abstract {}
@@ -423,11 +432,12 @@ public final class ClassJsonAdapterTest {
       ClassJsonAdapter.Factory.create(Abstract.class, NO_ANNOTATIONS, moshi);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "Cannot serialize abstract class "
-                  + "com.squareup.moshi.ClassJsonAdapterTest$Abstract");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains(
+                  "Cannot serialize abstract class "
+                      + "com.squareup.moshi.ClassJsonAdapterTest$Abstract"));
     }
   }
 
@@ -444,12 +454,12 @@ public final class ClassJsonAdapterTest {
     ExtendsPlatformClassWithPrivateField value = new ExtendsPlatformClassWithPrivateField();
     value.a = 4;
     String toJson = toJson(ExtendsPlatformClassWithPrivateField.class, value);
-    assertThat(toJson).isEqualTo("{\"a\":4}");
+    assertEquals(toJson, "{\"a\":4}");
 
     ExtendsPlatformClassWithPrivateField fromJson =
         fromJson(ExtendsPlatformClassWithPrivateField.class, "{\"a\":4,\"ID\":\"BAR\"}");
-    assertThat(fromJson.a).isEqualTo(4);
-    assertThat(fromJson.getID()).isEqualTo("FOO");
+    assertEquals(fromJson.a, 4);
+    assertEquals(fromJson.getID(), "FOO");
   }
 
   static class ExtendsPlatformClassWithProtectedField extends ByteArrayOutputStream {
@@ -467,13 +477,13 @@ public final class ClassJsonAdapterTest {
     value.write(5);
     value.write(6);
     String toJson = toJson(ExtendsPlatformClassWithProtectedField.class, value);
-    assertThat(toJson).isEqualTo("{\"a\":4,\"buf\":[5,6],\"count\":2}");
+    assertEquals(toJson, "{\"a\":4,\"buf\":[5,6],\"count\":2}");
 
     ExtendsPlatformClassWithProtectedField fromJson =
         fromJson(
             ExtendsPlatformClassWithProtectedField.class, "{\"a\":4,\"buf\":[5,6],\"count\":2}");
-    assertThat(fromJson.a).isEqualTo(4);
-    assertThat(fromJson.toByteArray()).asList().containsExactly((byte) 5, (byte) 6).inOrder();
+    assertEquals(4, fromJson.a);
+    assertArrayEquals(fromJson.toByteArray(), new byte[] {(byte) 5, (byte) 6});
   }
 
   static class NamedFields {
@@ -495,13 +505,13 @@ public final class ClassJsonAdapterTest {
     value.zipCode = "94043";
 
     String toJson = toJson(NamedFields.class, value);
-    assertThat(toJson)
-        .isEqualTo(
+    assertTrue(
+        toJson.contains(
             "{"
                 + "\"#\":[\"8005553333\",\"8005554444\"],"
                 + "\"@\":\"cash@square.com\","
                 + "\"zip code\":\"94043\""
-                + "}");
+                + "}"));
 
     NamedFields fromJson =
         fromJson(
@@ -511,9 +521,9 @@ public final class ClassJsonAdapterTest {
                 + "\"@\":\"cash@square.com\","
                 + "\"zip code\":\"94043\""
                 + "}");
-    assertThat(fromJson.phoneNumbers).isEqualTo(Arrays.asList("8005553333", "8005554444"));
-    assertThat(fromJson.emailAddress).isEqualTo("cash@square.com");
-    assertThat(fromJson.zipCode).isEqualTo("94043");
+    assertEquals(fromJson.phoneNumbers, Arrays.asList("8005553333", "8005554444"));
+    assertEquals(fromJson.emailAddress, "cash@square.com");
+    assertEquals(fromJson.zipCode, "94043");
   }
 
   static final class Box<T> {
@@ -534,8 +544,8 @@ public final class ClassJsonAdapterTest {
                     ClassJsonAdapterTest.class, Box.class, Integer.class),
                 NO_ANNOTATIONS,
                 moshi);
-    assertThat(adapter.fromJson("{\"data\":5}").data).isEqualTo(5);
-    assertThat(adapter.toJson(new Box<>(5))).isEqualTo("{\"data\":5}");
+    assertEquals(5, adapter.fromJson("{\"data\":5}").data.intValue());
+    assertEquals(adapter.toJson(new Box<>(5)), "{\"data\":5}");
   }
 
   private <T> String toJson(Class<T> type, T value) throws IOException {
@@ -550,9 +560,9 @@ public final class ClassJsonAdapterTest {
     jsonWriter.beginArray();
     jsonAdapter.toJson(jsonWriter, value);
     jsonWriter.endArray();
-    assertThat(buffer.readByte()).isEqualTo((byte) '[');
+    assertEquals(buffer.readByte(), (byte) '[');
     String json = buffer.readUtf8(buffer.size() - 1);
-    assertThat(buffer.readByte()).isEqualTo((byte) ']');
+    assertEquals(buffer.readByte(), (byte) ']');
     return json;
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/DeferredAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/DeferredAdapterTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -59,12 +59,11 @@ public final class DeferredAdapterTest {
                     @Override
                     public void run() {
                       GreenNode greenBlue = new GreenNode(new BlueNode(null, null));
-                      assertThat(moshi.adapter(GreenNode.class).toJson(greenBlue))
-                          .isEqualTo("{\"blue\":{}}");
+                      assertEquals(
+                          moshi.adapter(GreenNode.class).toJson(greenBlue), "{\"blue\":{}}");
 
                       RedNode redBlue = new RedNode(new BlueNode(null, null));
-                      assertThat(moshi.adapter(RedNode.class).toJson(redBlue))
-                          .isEqualTo("{\"blue\":{}}");
+                      assertEquals(moshi.adapter(RedNode.class).toJson(redBlue), "{\"blue\":{}}");
                     }
                   });
             }
@@ -75,10 +74,11 @@ public final class DeferredAdapterTest {
     Moshi moshi = new Moshi.Builder().add(factory).build();
 
     JsonAdapter<BlueNode> jsonAdapter = moshi.adapter(BlueNode.class);
-    assertThat(jsonAdapter.toJson(new BlueNode(new GreenNode(new BlueNode(null, null)), null)))
-        .isEqualTo("{\"green\":{\"blue\":{}}}");
+    assertEquals(
+        jsonAdapter.toJson(new BlueNode(new GreenNode(new BlueNode(null, null)), null)),
+        "{\"green\":{\"blue\":{}}}");
 
-    assertThat(failures).isEmpty();
+    assertEquals(0, failures.size());
   }
 
   private void doInAnotherThread(Runnable runnable) {

--- a/moshi/src/test/java/com/squareup/moshi/FlattenTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/FlattenTest.java
@@ -15,7 +15,8 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -52,7 +53,7 @@ public final class FlattenTest {
     writer.endFlatten(token);
     writer.endArray();
 
-    assertThat(factory.json()).isEqualTo("[1,2,3,4,5]");
+    assertEquals(factory.json(), "[1,2,3,4,5]");
   }
 
   @Test
@@ -76,7 +77,7 @@ public final class FlattenTest {
       writer.value("ccc");
     }
     writer.endObject();
-    assertThat(factory.json()).isEqualTo("{\"a\":\"aaa\",\"b\":\"bbb\",\"c\":\"ccc\"}");
+    assertEquals(factory.json(), "{\"a\":\"aaa\",\"b\":\"bbb\",\"c\":\"ccc\"}");
   }
 
   @Test
@@ -97,7 +98,7 @@ public final class FlattenTest {
       writer.value("c");
     }
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[\"a\",\"b\",\"c\"]");
+    assertEquals(factory.json(), "[\"a\",\"b\",\"c\"]");
   }
 
   @Test
@@ -128,7 +129,7 @@ public final class FlattenTest {
       writer.value("e");
     }
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[\"a\",\"b\",\"c\",\"d\",\"e\"]");
+    assertEquals(factory.json(), "[\"a\",\"b\",\"c\",\"d\",\"e\"]");
   }
 
   @Test
@@ -154,7 +155,7 @@ public final class FlattenTest {
       writer.value("d");
     }
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[\"a\",\"b\",\"c\",\"d\"]");
+    assertEquals(factory.json(), "[\"a\",\"b\",\"c\",\"d\"]");
   }
 
   @Test
@@ -181,7 +182,7 @@ public final class FlattenTest {
       writer.value("e");
     }
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[\"a\",\"b\",[\"c\"],\"d\",\"e\"]");
+    assertEquals(factory.json(), "[\"a\",\"b\",[\"c\"],\"d\",\"e\"]");
   }
 
   @Test
@@ -207,7 +208,7 @@ public final class FlattenTest {
       writer.value("d");
     }
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[\"a\",\"b\",[\"c\"],\"d\"]");
+    assertEquals(factory.json(), "[\"a\",\"b\",[\"c\"],\"d\"]");
   }
 
   @Test
@@ -242,7 +243,7 @@ public final class FlattenTest {
       writer.value("e");
     }
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[\"a\",\"b\",\"c\",\"d\",\"e\"]");
+    assertEquals(factory.json(), "[\"a\",\"b\",\"c\",\"d\",\"e\"]");
   }
 
   @Test
@@ -277,7 +278,7 @@ public final class FlattenTest {
       writer.endFlatten(token1);
     }
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[\"a\"]");
+    assertEquals(factory.json(), "[\"a\"]");
   }
 
   @Test
@@ -287,7 +288,7 @@ public final class FlattenTest {
       writer.beginFlatten();
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Nesting problem.");
+      assertTrue(e.getMessage().contains("Nesting problem."));
     }
   }
 
@@ -314,7 +315,7 @@ public final class FlattenTest {
       writer.endFlatten(token);
     }
     writer.endObject();
-    assertThat(factory.json()).isEqualTo("{\"a\":[\"aaa\"],\"b\":\"bbb\",\"c\":[\"ccc\"]}");
+    assertEquals(factory.json(), "{\"a\":[\"aaa\"],\"b\":\"bbb\",\"c\":[\"ccc\"]}");
   }
 
   @Test
@@ -346,6 +347,6 @@ public final class FlattenTest {
       writer.endFlatten(token);
     }
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[{\"a\":\"aaa\"},\"bbb\",\"ccc\",{\"d\":\"ddd\"}]");
+    assertEquals(factory.json(), "[{\"a\":\"aaa\"},\"bbb\",\"ccc\",{\"d\":\"ddd\"}]");
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonAdapterTest.java
@@ -15,7 +15,9 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
@@ -58,9 +60,9 @@ public final class JsonAdapterTest {
 
     JsonReader reader = factory.newReader("[-Infinity, NaN, Infinity]");
     reader.beginArray();
-    assertThat(lenient.fromJson(reader)).isEqualTo(Double.NEGATIVE_INFINITY);
-    assertThat(lenient.fromJson(reader)).isNaN();
-    assertThat(lenient.fromJson(reader)).isEqualTo(Double.POSITIVE_INFINITY);
+    assertEquals(Double.NEGATIVE_INFINITY, lenient.fromJson(reader), 0);
+    assertTrue(Double.isNaN(lenient.fromJson(reader)));
+    assertEquals(Double.POSITIVE_INFINITY, lenient.fromJson(reader), 0);
     reader.endArray();
 
     JsonWriter writer = factory.newWriter();
@@ -69,7 +71,7 @@ public final class JsonAdapterTest {
     lenient.toJson(writer, Double.NaN);
     lenient.toJson(writer, Double.POSITIVE_INFINITY);
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[-Infinity,NaN,Infinity]");
+    assertEquals(factory.json(), "[-Infinity,NaN,Infinity]");
   }
 
   @Test
@@ -89,9 +91,9 @@ public final class JsonAdapterTest {
 
     JsonReader reader = factory.newReader("[\"a\", null, \"c\"]");
     reader.beginArray();
-    assertThat(toUpperCase.fromJson(reader)).isEqualTo("A");
-    assertThat(toUpperCase.fromJson(reader)).isNull();
-    assertThat(toUpperCase.fromJson(reader)).isEqualTo("C");
+    assertEquals(toUpperCase.fromJson(reader), "A");
+    assertNull(toUpperCase.fromJson(reader));
+    assertEquals(toUpperCase.fromJson(reader), "C");
     reader.endArray();
 
     JsonWriter writer = factory.newWriter();
@@ -100,7 +102,7 @@ public final class JsonAdapterTest {
     toUpperCase.toJson(writer, null);
     toUpperCase.toJson(writer, "c");
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[\"A\",null,\"C\"]");
+    assertEquals(factory.json(), "[\"A\",null,\"C\"]");
   }
 
   @Test
@@ -120,15 +122,15 @@ public final class JsonAdapterTest {
 
     JsonReader reader = factory.newReader("[\"a\", null, \"c\"]");
     reader.beginArray();
-    assertThat(toUpperCase.fromJson(reader)).isEqualTo("A");
+    assertEquals(toUpperCase.fromJson(reader), "A");
     try {
       toUpperCase.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Unexpected null at $[1]");
-      assertThat(reader.<Object>nextNull()).isNull();
+      assertTrue(expected.getMessage().contains("Unexpected null at $[1]"));
+      assertNull(reader.nextNull());
     }
-    assertThat(toUpperCase.fromJson(reader)).isEqualTo("C");
+    assertEquals(toUpperCase.fromJson(reader), "C");
     reader.endArray();
 
     JsonWriter writer = factory.newWriter();
@@ -138,12 +140,12 @@ public final class JsonAdapterTest {
       toUpperCase.toJson(writer, null);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Unexpected null at $[1]");
+      assertTrue(expected.getMessage().contains("Unexpected null at $[1]"));
       writer.nullValue();
     }
     toUpperCase.toJson(writer, "c");
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[\"A\",null,\"C\"]");
+    assertEquals(factory.json(), "[\"A\",null,\"C\"]");
   }
 
   @Test
@@ -168,9 +170,9 @@ public final class JsonAdapterTest {
       alwaysSkip.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Cannot skip unexpected STRING at $[0]");
+      assertTrue(expected.getMessage().contains("Cannot skip unexpected STRING at $[0]"));
     }
-    assertThat(reader.nextString()).isEqualTo("a");
+    assertEquals(reader.nextString(), "a");
     reader.endArray();
   }
 
@@ -197,8 +199,8 @@ public final class JsonAdapterTest {
 
     JsonWriter writer = factory.newWriter();
     indent.toJson(writer, Arrays.asList("a", "b", "c"));
-    assertThat(factory.json())
-        .isEqualTo("" + "[\n" + "\t\t\t\"a\",\n" + "\t\t\t\"b\",\n" + "\t\t\t\"c\"\n" + "]");
+    assertEquals(
+        factory.json(), "" + "[\n" + "\t\t\t\"a\",\n" + "\t\t\t\"b\",\n" + "\t\t\t\"c\"\n" + "]");
   }
 
   @Test
@@ -219,7 +221,7 @@ public final class JsonAdapterTest {
       adapter.indent(null);
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessageThat().contains("Parameter specified as non-null is null");
+      assertTrue(expected.getMessage().contains("Parameter specified as non-null is null"));
     }
   }
 
@@ -244,7 +246,7 @@ public final class JsonAdapterTest {
 
     JsonWriter writer = factory.newWriter();
     serializeNulls.toJson(writer, Collections.<String, String>singletonMap("a", null));
-    assertThat(factory.json()).isEqualTo("{\"a\":null}");
+    assertEquals(factory.json(), "{\"a\":null}");
   }
 
   @Test
@@ -265,7 +267,7 @@ public final class JsonAdapterTest {
       brokenAdapter.fromJson("\"value\"");
       fail();
     } catch (JsonDataException e) {
-      assertThat(e).hasMessageThat().isEqualTo("JSON document was not fully consumed.");
+      assertTrue(e.getMessage().contains("JSON document was not fully consumed."));
     }
   }
 
@@ -287,9 +289,9 @@ public final class JsonAdapterTest {
       adapter.fromJson("true true");
       fail();
     } catch (JsonEncodingException e) {
-      assertThat(e)
-          .hasMessageThat()
-          .isEqualTo("Use JsonReader.setLenient(true) to accept malformed JSON at path $");
+      assertTrue(
+          e.getMessage()
+              .contains("Use JsonReader.setLenient(true) to accept malformed JSON at path $"));
     }
   }
 
@@ -307,7 +309,7 @@ public final class JsonAdapterTest {
             throw new AssertionError();
           }
         }.lenient();
-    assertThat(adapter.fromJson("true true")).isEqualTo(true);
+    assertEquals(adapter.fromJson("true true"), true);
   }
 
   @Test
@@ -324,18 +326,18 @@ public final class JsonAdapterTest {
             throw new AssertionError();
           }
         }.lenient().serializeNulls();
-    assertThat(adapter.fromJson("true true")).isEqualTo(true);
+    assertEquals(adapter.fromJson("true true"), true);
   }
 
   @Test
   public void nullSafeDoesntDuplicate() {
     JsonAdapter<Boolean> adapter = new Moshi.Builder().build().adapter(Boolean.class).nullSafe();
-    assertThat(adapter.nullSafe()).isSameInstanceAs(adapter);
+    assertTrue(adapter.nullSafe() instanceof JsonAdapter);
   }
 
   @Test
   public void nonNullDoesntDuplicate() {
     JsonAdapter<Boolean> adapter = new Moshi.Builder().build().adapter(Boolean.class).nonNull();
-    assertThat(adapter.nonNull()).isSameInstanceAs(adapter);
+    assertTrue(adapter.nonNull() instanceof JsonAdapter);
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonQualifiersTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonQualifiersTest.java
@@ -15,8 +15,9 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -33,11 +34,11 @@ public final class JsonQualifiersTest {
     StringAndFooString v1 = new StringAndFooString();
     v1.a = "aa";
     v1.b = "bar";
-    assertThat(adapter.toJson(v1)).isEqualTo("{\"a\":\"aa\",\"b\":\"foobar\"}");
+    assertEquals(adapter.toJson(v1), "{\"a\":\"aa\",\"b\":\"foobar\"}");
 
     StringAndFooString v2 = adapter.fromJson("{\"a\":\"aa\",\"b\":\"foobar\"}");
-    assertThat(v2.a).isEqualTo("aa");
-    assertThat(v2.b).isEqualTo("bar");
+    assertEquals(v2.a, "aa");
+    assertEquals(v2.b, "bar");
   }
 
   static class BuiltInTypesJsonAdapter {
@@ -62,11 +63,11 @@ public final class JsonQualifiersTest {
     StringAndFooString v1 = new StringAndFooString();
     v1.a = "aa";
     v1.b = "bar";
-    assertThat(adapter.toJson(v1)).isEqualTo("{\"a\":\"aa\",\"b\":\"foobar\"}");
+    assertEquals(adapter.toJson(v1), "{\"a\":\"aa\",\"b\":\"foobar\"}");
 
     StringAndFooString v2 = adapter.fromJson("{\"a\":\"aa\",\"b\":\"foobar\"}");
-    assertThat(v2.a).isEqualTo("aa");
-    assertThat(v2.b).isEqualTo("bar");
+    assertEquals(v2.a, "aa");
+    assertEquals(v2.b, "bar");
   }
 
   static class ReaderWriterJsonAdapter {
@@ -113,11 +114,11 @@ public final class JsonQualifiersTest {
     StringAndFooBazString v1 = new StringAndFooBazString();
     v1.a = "aa";
     v1.b = "bar";
-    assertThat(adapter.toJson(v1)).isEqualTo("{\"a\":\"aa\",\"b\":\"foobarbaz\"}");
+    assertEquals(adapter.toJson(v1), "{\"a\":\"aa\",\"b\":\"foobarbaz\"}");
 
     StringAndFooBazString v2 = adapter.fromJson("{\"a\":\"aa\",\"b\":\"foobarbaz\"}");
-    assertThat(v2.a).isEqualTo("aa");
-    assertThat(v2.b).isEqualTo("bar");
+    assertEquals(v2.a, "aa");
+    assertEquals(v2.b, "bar");
   }
 
   static class BuiltInTypesWithMultipleAnnotationsJsonAdapter {
@@ -145,11 +146,11 @@ public final class JsonQualifiersTest {
     StringAndFooBazString v1 = new StringAndFooBazString();
     v1.a = "aa";
     v1.b = "bar";
-    assertThat(adapter.toJson(v1)).isEqualTo("{\"a\":\"aa\",\"b\":\"foobarbaz\"}");
+    assertEquals(adapter.toJson(v1), "{\"a\":\"aa\",\"b\":\"foobarbaz\"}");
 
     StringAndFooBazString v2 = adapter.fromJson("{\"a\":\"aa\",\"b\":\"foobarbaz\"}");
-    assertThat(v2.a).isEqualTo("aa");
-    assertThat(v2.b).isEqualTo("bar");
+    assertEquals(v2.a, "aa");
+    assertEquals(v2.b, "bar");
   }
 
   static class ReaderWriterWithMultipleAnnotationsJsonAdapter {
@@ -182,11 +183,11 @@ public final class JsonQualifiersTest {
     StringAndFooBazString v1 = new StringAndFooBazString();
     v1.a = "aa";
     v1.b = "bar";
-    assertThat(adapter.toJson(v1)).isEqualTo("{\"a\":\"aa\",\"b\":\"foobarbaz\"}");
+    assertEquals(adapter.toJson(v1), "{\"a\":\"aa\",\"b\":\"foobarbaz\"}");
 
     StringAndFooBazString v2 = adapter.fromJson("{\"a\":\"aa\",\"b\":\"foobarbaz\"}");
-    assertThat(v2.a).isEqualTo("aa");
-    assertThat(v2.b).isEqualTo("bar");
+    assertEquals(v2.a, "aa");
+    assertEquals(v2.b, "bar");
   }
 
   static class BuiltInTypesDelegatingJsonAdapter {
@@ -217,11 +218,11 @@ public final class JsonQualifiersTest {
     StringAndFooBazString v1 = new StringAndFooBazString();
     v1.a = "aa";
     v1.b = "bar";
-    assertThat(adapter.toJson(v1)).isEqualTo("{\"a\":\"aa\",\"b\":\"foobarbaz\"}");
+    assertEquals(adapter.toJson(v1), "{\"a\":\"aa\",\"b\":\"foobarbaz\"}");
 
     StringAndFooBazString v2 = adapter.fromJson("{\"a\":\"aa\",\"b\":\"foobarbaz\"}");
-    assertThat(v2.a).isEqualTo("aa");
-    assertThat(v2.b).isEqualTo("bar");
+    assertEquals(v2.a, "aa");
+    assertEquals(v2.b, "bar");
   }
 
   @Test
@@ -247,11 +248,11 @@ public final class JsonQualifiersTest {
     StringAndFooString v1 = new StringAndFooString();
     v1.a = "aa";
     v1.b = "bar";
-    assertThat(adapter.toJson(v1)).isEqualTo("{\"a\":\"aa\",\"b\":\"foobar\"}");
+    assertEquals(adapter.toJson(v1), "{\"a\":\"aa\",\"b\":\"foobar\"}");
 
     StringAndFooString v2 = adapter.fromJson("{\"a\":\"aa\",\"b\":\"foobar\"}");
-    assertThat(v2.a).isEqualTo("aa");
-    assertThat(v2.b).isEqualTo("bar");
+    assertEquals(v2.a, "aa");
+    assertEquals(v2.b, "bar");
   }
 
   @Test
@@ -272,11 +273,11 @@ public final class JsonQualifiersTest {
     DateAndMillisDate v1 = new DateAndMillisDate();
     v1.a = new Date(5);
     v1.b = new Date(7);
-    assertThat(adapter.toJson(v1)).isEqualTo("{\"a\":5,\"b\":7}");
+    assertEquals(adapter.toJson(v1), "{\"a\":5,\"b\":7}");
 
     DateAndMillisDate v2 = adapter.fromJson("{\"a\":5,\"b\":7}");
-    assertThat(v2.a).isEqualTo(new Date(5));
-    assertThat(v2.b).isEqualTo(new Date(7));
+    assertEquals(v2.a, new Date(5));
+    assertEquals(v2.b, new Date(7));
   }
 
   /** Despite the fact that these methods are annotated, they match all dates. */
@@ -321,21 +322,21 @@ public final class JsonQualifiersTest {
       new Moshi.Builder().add(Date.class, Millis.class, jsonAdapter);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "interface com.squareup.moshi.JsonQualifiersTest$Millis "
-                  + "does not have @JsonQualifier");
+
+      assertEquals(
+          "interface com.squareup.moshi.JsonQualifiersTest$Millis "
+              + "does not have @JsonQualifier",
+          expected.getMessage());
     }
   }
 
   @Test
-  public void annotationsConflict() throws Exception {
+  public void annotationsConflict() {
     try {
       new Moshi.Builder().add(new AnnotationsConflictJsonAdapter());
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().contains("Conflicting @ToJson methods");
+      assertTrue(expected.getMessage().contains("Conflicting @ToJson methods"));
     }
   }
 
@@ -360,25 +361,24 @@ public final class JsonQualifiersTest {
       moshi.adapter(StringAndFooString.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "No @FromJson adapter for class java.lang.String annotated "
-                  + "[@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]"
-                  + "\nfor class java.lang.String b"
-                  + "\nfor class com.squareup.moshi.JsonQualifiersTest$StringAndFooString");
-      assertThat(expected).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
-      assertThat(expected.getCause())
-          .hasMessageThat()
-          .isEqualTo(
-              "No @FromJson adapter for class java.lang.String "
-                  + "annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
-      assertThat(expected.getCause()).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
-      assertThat(expected.getCause().getCause())
-          .hasMessageThat()
-          .isEqualTo(
-              "No next JsonAdapter for class "
-                  + "java.lang.String annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
+      assertEquals(
+          "No @FromJson adapter for class java.lang.String annotated "
+              + "[@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]"
+              + "\nfor class java.lang.String b"
+              + "\nfor class com.squareup.moshi.JsonQualifiersTest$StringAndFooString",
+          expected.getMessage());
+
+      assertTrue(expected.getCause() instanceof IllegalArgumentException);
+      assertEquals(
+          "No @FromJson adapter for class java.lang.String "
+              + "annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]",
+          expected.getCause().getMessage());
+
+      assertTrue(expected.getCause().getCause() instanceof IllegalArgumentException);
+      assertEquals(
+          "No next JsonAdapter for class "
+              + "java.lang.String annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]",
+          expected.getCause().getCause().getMessage());
     }
   }
 
@@ -398,25 +398,25 @@ public final class JsonQualifiersTest {
       moshi.adapter(StringAndFooString.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "No @ToJson adapter for class java.lang.String annotated "
-                  + "[@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]"
-                  + "\nfor class java.lang.String b"
-                  + "\nfor class com.squareup.moshi.JsonQualifiersTest$StringAndFooString");
-      assertThat(expected).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
-      assertThat(expected.getCause())
-          .hasMessageThat()
-          .isEqualTo(
-              "No @ToJson adapter for class java.lang.String "
-                  + "annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
-      assertThat(expected.getCause()).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
-      assertThat(expected.getCause().getCause())
-          .hasMessageThat()
-          .isEqualTo(
-              "No next JsonAdapter for class "
-                  + "java.lang.String annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]");
+
+      assertEquals(
+          "No @ToJson adapter for class java.lang.String annotated "
+              + "[@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]"
+              + "\nfor class java.lang.String b"
+              + "\nfor class com.squareup.moshi.JsonQualifiersTest$StringAndFooString",
+          expected.getMessage());
+
+      assertTrue(expected.getCause() instanceof IllegalArgumentException);
+      assertEquals(
+          "No @ToJson adapter for class java.lang.String "
+              + "annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]",
+          expected.getCause().getMessage());
+
+      assertTrue(expected.getCause().getCause() instanceof IllegalArgumentException);
+      assertEquals(
+          "No next JsonAdapter for class "
+              + "java.lang.String annotated [@com.squareup.moshi.JsonQualifiersTest$FooPrefix()]",
+          expected.getCause().getCause().getMessage());
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderPathTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderPathTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
@@ -39,157 +39,157 @@ public final class JsonReaderPathTest {
   @Test
   public void path() throws IOException {
     JsonReader reader = factory.newReader("{\"a\":[2,true,false,null,\"b\",{\"c\":\"d\"},[3]]}");
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
     reader.beginObject();
-    assertThat(reader.getPath()).isEqualTo("$.");
+    assertEquals(reader.getPath(), "$.");
     reader.nextName();
-    assertThat(reader.getPath()).isEqualTo("$.a");
+    assertEquals(reader.getPath(), "$.a");
     reader.beginArray();
-    assertThat(reader.getPath()).isEqualTo("$.a[0]");
+    assertEquals(reader.getPath(), "$.a[0]");
     reader.nextInt();
-    assertThat(reader.getPath()).isEqualTo("$.a[1]");
+    assertEquals(reader.getPath(), "$.a[1]");
     reader.nextBoolean();
-    assertThat(reader.getPath()).isEqualTo("$.a[2]");
+    assertEquals(reader.getPath(), "$.a[2]");
     reader.nextBoolean();
-    assertThat(reader.getPath()).isEqualTo("$.a[3]");
+    assertEquals(reader.getPath(), "$.a[3]");
     reader.nextNull();
-    assertThat(reader.getPath()).isEqualTo("$.a[4]");
+    assertEquals(reader.getPath(), "$.a[4]");
     reader.nextString();
-    assertThat(reader.getPath()).isEqualTo("$.a[5]");
+    assertEquals(reader.getPath(), "$.a[5]");
     reader.beginObject();
-    assertThat(reader.getPath()).isEqualTo("$.a[5].");
+    assertEquals(reader.getPath(), "$.a[5].");
     reader.nextName();
-    assertThat(reader.getPath()).isEqualTo("$.a[5].c");
+    assertEquals(reader.getPath(), "$.a[5].c");
     reader.nextString();
-    assertThat(reader.getPath()).isEqualTo("$.a[5].c");
+    assertEquals(reader.getPath(), "$.a[5].c");
     reader.endObject();
-    assertThat(reader.getPath()).isEqualTo("$.a[6]");
+    assertEquals(reader.getPath(), "$.a[6]");
     reader.beginArray();
-    assertThat(reader.getPath()).isEqualTo("$.a[6][0]");
+    assertEquals(reader.getPath(), "$.a[6][0]");
     reader.nextInt();
-    assertThat(reader.getPath()).isEqualTo("$.a[6][1]");
+    assertEquals(reader.getPath(), "$.a[6][1]");
     reader.endArray();
-    assertThat(reader.getPath()).isEqualTo("$.a[7]");
+    assertEquals(reader.getPath(), "$.a[7]");
     reader.endArray();
-    assertThat(reader.getPath()).isEqualTo("$.a");
+    assertEquals(reader.getPath(), "$.a");
     reader.endObject();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
   }
 
   @Test
   public void arrayOfObjects() throws IOException {
     JsonReader reader = factory.newReader("[{},{},{}]");
     reader.beginArray();
-    assertThat(reader.getPath()).isEqualTo("$[0]");
+    assertEquals(reader.getPath(), "$[0]");
     reader.beginObject();
-    assertThat(reader.getPath()).isEqualTo("$[0].");
+    assertEquals(reader.getPath(), "$[0].");
     reader.endObject();
-    assertThat(reader.getPath()).isEqualTo("$[1]");
+    assertEquals(reader.getPath(), "$[1]");
     reader.beginObject();
-    assertThat(reader.getPath()).isEqualTo("$[1].");
+    assertEquals(reader.getPath(), "$[1].");
     reader.endObject();
-    assertThat(reader.getPath()).isEqualTo("$[2]");
+    assertEquals(reader.getPath(), "$[2]");
     reader.beginObject();
-    assertThat(reader.getPath()).isEqualTo("$[2].");
+    assertEquals(reader.getPath(), "$[2].");
     reader.endObject();
-    assertThat(reader.getPath()).isEqualTo("$[3]");
+    assertEquals(reader.getPath(), "$[3]");
     reader.endArray();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
   }
 
   @Test
   public void arrayOfArrays() throws IOException {
     JsonReader reader = factory.newReader("[[],[],[]]");
     reader.beginArray();
-    assertThat(reader.getPath()).isEqualTo("$[0]");
+    assertEquals(reader.getPath(), "$[0]");
     reader.beginArray();
-    assertThat(reader.getPath()).isEqualTo("$[0][0]");
+    assertEquals(reader.getPath(), "$[0][0]");
     reader.endArray();
-    assertThat(reader.getPath()).isEqualTo("$[1]");
+    assertEquals(reader.getPath(), "$[1]");
     reader.beginArray();
-    assertThat(reader.getPath()).isEqualTo("$[1][0]");
+    assertEquals(reader.getPath(), "$[1][0]");
     reader.endArray();
-    assertThat(reader.getPath()).isEqualTo("$[2]");
+    assertEquals(reader.getPath(), "$[2]");
     reader.beginArray();
-    assertThat(reader.getPath()).isEqualTo("$[2][0]");
+    assertEquals(reader.getPath(), "$[2][0]");
     reader.endArray();
-    assertThat(reader.getPath()).isEqualTo("$[3]");
+    assertEquals(reader.getPath(), "$[3]");
     reader.endArray();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
   }
 
   @SuppressWarnings("CheckReturnValue")
   @Test
   public void objectPath() throws IOException {
     JsonReader reader = factory.newReader("{\"a\":1,\"b\":2}");
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
 
     reader.peek();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
     reader.beginObject();
-    assertThat(reader.getPath()).isEqualTo("$.");
+    assertEquals(reader.getPath(), "$.");
 
     reader.peek();
-    assertThat(reader.getPath()).isEqualTo("$.");
+    assertEquals(reader.getPath(), "$.");
     reader.nextName();
-    assertThat(reader.getPath()).isEqualTo("$.a");
+    assertEquals(reader.getPath(), "$.a");
 
     reader.peek();
-    assertThat(reader.getPath()).isEqualTo("$.a");
+    assertEquals(reader.getPath(), "$.a");
     reader.nextInt();
-    assertThat(reader.getPath()).isEqualTo("$.a");
+    assertEquals(reader.getPath(), "$.a");
 
     reader.peek();
-    assertThat(reader.getPath()).isEqualTo("$.a");
+    assertEquals(reader.getPath(), "$.a");
     reader.nextName();
-    assertThat(reader.getPath()).isEqualTo("$.b");
+    assertEquals(reader.getPath(), "$.b");
 
     reader.peek();
-    assertThat(reader.getPath()).isEqualTo("$.b");
+    assertEquals(reader.getPath(), "$.b");
     reader.nextInt();
-    assertThat(reader.getPath()).isEqualTo("$.b");
+    assertEquals(reader.getPath(), "$.b");
 
     reader.peek();
-    assertThat(reader.getPath()).isEqualTo("$.b");
+    assertEquals(reader.getPath(), "$.b");
     reader.endObject();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
 
     reader.peek();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
     reader.close();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
   }
 
   @SuppressWarnings("CheckReturnValue")
   @Test
   public void arrayPath() throws IOException {
     JsonReader reader = factory.newReader("[1,2]");
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
 
     reader.peek();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
     reader.beginArray();
-    assertThat(reader.getPath()).isEqualTo("$[0]");
+    assertEquals(reader.getPath(), "$[0]");
 
     reader.peek();
-    assertThat(reader.getPath()).isEqualTo("$[0]");
+    assertEquals(reader.getPath(), "$[0]");
     reader.nextInt();
-    assertThat(reader.getPath()).isEqualTo("$[1]");
+    assertEquals(reader.getPath(), "$[1]");
 
     reader.peek();
-    assertThat(reader.getPath()).isEqualTo("$[1]");
+    assertEquals(reader.getPath(), "$[1]");
     reader.nextInt();
-    assertThat(reader.getPath()).isEqualTo("$[2]");
+    assertEquals(reader.getPath(), "$[2]");
 
     reader.peek();
-    assertThat(reader.getPath()).isEqualTo("$[2]");
+    assertEquals(reader.getPath(), "$[2]");
     reader.endArray();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
 
     reader.peek();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
     reader.close();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
   }
 
   @Test
@@ -200,10 +200,10 @@ public final class JsonReaderPathTest {
     reader.setLenient(true);
     reader.beginArray();
     reader.endArray();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
     reader.beginArray();
     reader.endArray();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
   }
 
   @Test
@@ -212,7 +212,7 @@ public final class JsonReaderPathTest {
     reader.beginArray();
     reader.skipValue();
     reader.skipValue();
-    assertThat(reader.getPath()).isEqualTo("$[2]");
+    assertEquals(reader.getPath(), "$[2]");
   }
 
   @Test
@@ -220,7 +220,7 @@ public final class JsonReaderPathTest {
     JsonReader reader = factory.newReader("{\"a\":1}");
     reader.beginObject();
     reader.skipValue();
-    assertThat(reader.getPath()).isEqualTo("$.null");
+    assertEquals(reader.getPath(), "$.null");
   }
 
   @SuppressWarnings("CheckReturnValue")
@@ -230,9 +230,9 @@ public final class JsonReaderPathTest {
     reader.beginObject();
     reader.nextName();
     reader.skipValue();
-    assertThat(reader.getPath()).isEqualTo("$.null");
+    assertEquals(reader.getPath(), "$.null");
     reader.nextName();
-    assertThat(reader.getPath()).isEqualTo("$.b");
+    assertEquals(reader.getPath(), "$.b");
   }
 
   @Test
@@ -240,6 +240,6 @@ public final class JsonReaderPathTest {
     JsonReader reader = factory.newReader("[[1,2,3],4]");
     reader.beginArray();
     reader.skipValue();
-    assertThat(reader.getPath()).isEqualTo("$[1]");
+    assertEquals(reader.getPath(), "$[1]");
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonReaderTest.java
@@ -15,15 +15,9 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
-import static com.squareup.moshi.JsonReader.Token.BEGIN_ARRAY;
-import static com.squareup.moshi.JsonReader.Token.BEGIN_OBJECT;
-import static com.squareup.moshi.JsonReader.Token.NAME;
-import static com.squareup.moshi.JsonReader.Token.STRING;
+import static com.squareup.moshi.JsonReader.Token.*;
 import static com.squareup.moshi.TestUtil.repeat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.EOFException;
@@ -31,6 +25,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import okio.BufferedSource;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,72 +51,72 @@ public final class JsonReaderTest {
   public void readArray() throws IOException {
     JsonReader reader = newReader("[true, true]");
     reader.beginArray();
-    assertThat(reader.nextBoolean()).isTrue();
-    assertThat(reader.nextBoolean()).isTrue();
+    assertTrue(reader.nextBoolean());
+    assertTrue(reader.nextBoolean());
     reader.endArray();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
   public void readEmptyArray() throws IOException {
     JsonReader reader = newReader("[]");
     reader.beginArray();
-    assertThat(reader.hasNext()).isFalse();
+    assertFalse(reader.hasNext());
     reader.endArray();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
   public void readObject() throws IOException {
     JsonReader reader = newReader("{\"a\": \"android\", \"b\": \"banana\"}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.nextString()).isEqualTo("android");
-    assertThat(reader.nextName()).isEqualTo("b");
-    assertThat(reader.nextString()).isEqualTo("banana");
+    assertEquals(reader.nextName(), "a");
+    assertEquals(reader.nextString(), "android");
+    assertEquals(reader.nextName(), "b");
+    assertEquals(reader.nextString(), "banana");
     reader.endObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
   public void readEmptyObject() throws IOException {
     JsonReader reader = newReader("{}");
     reader.beginObject();
-    assertThat(reader.hasNext()).isFalse();
+    assertFalse(reader.hasNext());
     reader.endObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
   public void skipArray() throws IOException {
     JsonReader reader = newReader("{\"a\": [\"one\", \"two\", \"three\"], \"b\": 123}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     reader.skipValue();
-    assertThat(reader.nextName()).isEqualTo("b");
-    assertThat(reader.nextInt()).isEqualTo(123);
+    assertEquals(reader.nextName(), "b");
+    assertEquals(reader.nextInt(), 123);
     reader.endObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
   public void skipArrayAfterPeek() throws Exception {
     JsonReader reader = newReader("{\"a\": [\"one\", \"two\", \"three\"], \"b\": 123}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.peek()).isEqualTo(BEGIN_ARRAY);
+    assertEquals(reader.nextName(), "a");
+    assertEquals(reader.peek(), BEGIN_ARRAY);
     reader.skipValue();
-    assertThat(reader.nextName()).isEqualTo("b");
-    assertThat(reader.nextInt()).isEqualTo(123);
+    assertEquals(reader.nextName(), "b");
+    assertEquals(reader.nextInt(), 123);
     reader.endObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
   public void skipTopLevelObject() throws Exception {
     JsonReader reader = newReader("{\"a\": [\"one\", \"two\", \"three\"], \"b\": 123}");
     reader.skipValue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -129,12 +124,12 @@ public final class JsonReaderTest {
     JsonReader reader =
         newReader("{\"a\": { \"c\": [], \"d\": [true, true, {}] }, \"b\": \"banana\"}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     reader.skipValue();
-    assertThat(reader.nextName()).isEqualTo("b");
+    assertEquals(reader.nextName(), "b");
     reader.skipValue();
     reader.endObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -147,40 +142,40 @@ public final class JsonReaderTest {
             + "}";
     JsonReader reader = newReader(json);
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("one");
-    assertThat(reader.peek()).isEqualTo(BEGIN_OBJECT);
+    assertEquals(reader.nextName(), "one");
+    assertEquals(reader.peek(), BEGIN_OBJECT);
     reader.skipValue();
-    assertThat(reader.nextName()).isEqualTo("two");
-    assertThat(reader.peek()).isEqualTo(BEGIN_OBJECT);
+    assertEquals(reader.nextName(), "two");
+    assertEquals(reader.peek(), BEGIN_OBJECT);
     reader.skipValue();
-    assertThat(reader.nextName()).isEqualTo("three");
+    assertEquals(reader.nextName(), "three");
     reader.skipValue();
     reader.endObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
   public void skipInteger() throws IOException {
     JsonReader reader = newReader("{\"a\":123456789,\"b\":-123456789}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     reader.skipValue();
-    assertThat(reader.nextName()).isEqualTo("b");
+    assertEquals(reader.nextName(), "b");
     reader.skipValue();
     reader.endObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
   public void skipDouble() throws IOException {
     JsonReader reader = newReader("{\"a\":-123.456e-789,\"b\":123456789.0}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     reader.skipValue();
-    assertThat(reader.nextName()).isEqualTo("b");
+    assertEquals(reader.nextName(), "b");
     reader.skipValue();
     reader.endObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -188,18 +183,18 @@ public final class JsonReaderTest {
     JsonReader reader = newReader("{\"a\": 123}");
     reader.setFailOnUnknown(true);
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     try {
       reader.skipValue();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Cannot skip unexpected NUMBER at $.a");
+      assertTrue(expected.getMessage().contains("Cannot skip unexpected NUMBER at $.a"));
     }
     // Confirm that the reader is left in a consistent state after the exception.
     reader.setFailOnUnknown(false);
-    assertThat(reader.nextInt()).isEqualTo(123);
+    assertEquals(reader.nextInt(), 123);
     reader.endObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -207,18 +202,18 @@ public final class JsonReaderTest {
     JsonReader reader = newReader("[\"a\", 123]");
     reader.setFailOnUnknown(true);
     reader.beginArray();
-    assertThat(reader.nextString()).isEqualTo("a");
+    assertEquals(reader.nextString(), "a");
     try {
       reader.skipValue();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Cannot skip unexpected NUMBER at $[1]");
+      assertTrue(expected.getMessage().contains("Cannot skip unexpected NUMBER at $[1]"));
     }
     // Confirm that the reader is left in a consistent state after the exception.
     reader.setFailOnUnknown(false);
-    assertThat(reader.nextInt()).isEqualTo(123);
+    assertEquals(reader.nextInt(), 123);
     reader.endArray();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -226,14 +221,14 @@ public final class JsonReaderTest {
     String json = "{\n" + "   \"hello\": true,\n" + "   \"foo\": [\"world\"]\n" + "}";
     JsonReader reader = newReader(json);
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("hello");
-    assertThat(reader.nextBoolean()).isTrue();
-    assertThat(reader.nextName()).isEqualTo("foo");
+    assertEquals(reader.nextName(), "hello");
+    assertTrue(reader.nextBoolean());
+    assertEquals(reader.nextName(), "foo");
     reader.beginArray();
-    assertThat(reader.nextString()).isEqualTo("world");
+    assertEquals(reader.nextString(), "world");
     reader.endArray();
     reader.endObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -275,36 +270,36 @@ public final class JsonReaderTest {
             + "]";
     JsonReader reader = newReader(json);
     reader.beginArray();
-    assertThat(reader.nextString()).isEqualTo("a");
-    assertThat(reader.nextString()).isEqualTo("a\"");
-    assertThat(reader.nextString()).isEqualTo("\"");
-    assertThat(reader.nextString()).isEqualTo(":");
-    assertThat(reader.nextString()).isEqualTo(",");
-    assertThat(reader.nextString()).isEqualTo("\b");
-    assertThat(reader.nextString()).isEqualTo("\f");
-    assertThat(reader.nextString()).isEqualTo("\n");
-    assertThat(reader.nextString()).isEqualTo("\r");
-    assertThat(reader.nextString()).isEqualTo("\t");
-    assertThat(reader.nextString()).isEqualTo(" ");
-    assertThat(reader.nextString()).isEqualTo("\\");
-    assertThat(reader.nextString()).isEqualTo("{");
-    assertThat(reader.nextString()).isEqualTo("}");
-    assertThat(reader.nextString()).isEqualTo("[");
-    assertThat(reader.nextString()).isEqualTo("]");
-    assertThat(reader.nextString()).isEqualTo("\0");
-    assertThat(reader.nextString()).isEqualTo("\u0019");
-    assertThat(reader.nextString()).isEqualTo("\u20AC");
+    assertEquals(reader.nextString(), "a");
+    assertEquals(reader.nextString(), "a\"");
+    assertEquals(reader.nextString(), "\"");
+    assertEquals(reader.nextString(), ":");
+    assertEquals(reader.nextString(), ",");
+    assertEquals(reader.nextString(), "\b");
+    assertEquals(reader.nextString(), "\f");
+    assertEquals(reader.nextString(), "\n");
+    assertEquals(reader.nextString(), "\r");
+    assertEquals(reader.nextString(), "\t");
+    assertEquals(reader.nextString(), " ");
+    assertEquals(reader.nextString(), "\\");
+    assertEquals(reader.nextString(), "{");
+    assertEquals(reader.nextString(), "}");
+    assertEquals(reader.nextString(), "[");
+    assertEquals(reader.nextString(), "]");
+    assertEquals(reader.nextString(), "\0");
+    assertEquals(reader.nextString(), "\u0019");
+    assertEquals(reader.nextString(), "\u20AC");
     reader.endArray();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
   public void integersWithFractionalPartSpecified() throws IOException {
     JsonReader reader = newReader("[1.0,1.0,1.0]");
     reader.beginArray();
-    assertThat(reader.nextDouble()).isEqualTo(1.0);
-    assertThat(reader.nextInt()).isEqualTo(1);
-    assertThat(reader.nextLong()).isEqualTo(1L);
+    assertEquals(1.0, reader.nextDouble(), 0);
+    assertEquals(1, reader.nextInt(), 0);
+    assertEquals(1L, reader.nextLong(), 0);
   }
 
   @Test
@@ -321,17 +316,17 @@ public final class JsonReaderTest {
             + "2.718281828459045]";
     JsonReader reader = newReader(json);
     reader.beginArray();
-    assertThat(reader.nextDouble()).isEqualTo(-0.0);
-    assertThat(reader.nextDouble()).isEqualTo(1.0);
-    assertThat(reader.nextDouble()).isEqualTo(1.7976931348623157E308);
-    assertThat(reader.nextDouble()).isEqualTo(4.9E-324);
-    assertThat(reader.nextDouble()).isEqualTo(0.0);
-    assertThat(reader.nextDouble()).isEqualTo(-0.5);
-    assertThat(reader.nextDouble()).isEqualTo(2.2250738585072014E-308);
-    assertThat(reader.nextDouble()).isEqualTo(3.141592653589793);
-    assertThat(reader.nextDouble()).isEqualTo(2.718281828459045);
+    assertEquals(-0.0, reader.nextDouble(), 0);
+    assertEquals(1.0, reader.nextDouble(), 0);
+    assertEquals(1.7976931348623157E308, reader.nextDouble(), 0);
+    assertEquals(4.9E-324, reader.nextDouble(), 0);
+    assertEquals(0.0, reader.nextDouble(), 0);
+    assertEquals(-0.5, reader.nextDouble(), 0);
+    assertEquals(2.2250738585072014E-308, reader.nextDouble(), 0);
+    assertEquals(3.141592653589793, reader.nextDouble(), 0);
+    assertEquals(2.718281828459045, reader.nextDouble(), 0);
     reader.endArray();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -355,7 +350,7 @@ public final class JsonReaderTest {
       reader.nextDouble();
       fail();
     } catch (JsonEncodingException expected) {
-      assertThat(expected).hasMessageThat().contains("NaN");
+      assertTrue(expected.getMessage().contains("NaN"));
     }
   }
 
@@ -365,9 +360,9 @@ public final class JsonReaderTest {
     JsonReader reader = newReader(json);
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(Double.isNaN(reader.nextDouble())).isTrue();
-    assertThat(reader.nextDouble()).isEqualTo(Double.NEGATIVE_INFINITY);
-    assertThat(reader.nextDouble()).isEqualTo(Double.POSITIVE_INFINITY);
+    assertTrue(Double.isNaN(reader.nextDouble()));
+    assertEquals(Double.NEGATIVE_INFINITY, reader.nextDouble(), 0);
+    assertEquals(Double.POSITIVE_INFINITY, reader.nextDouble(), 0);
     reader.endArray();
   }
 
@@ -377,9 +372,9 @@ public final class JsonReaderTest {
     JsonReader reader = newReader(json);
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.nextDouble()).isNaN();
-    assertThat(reader.nextDouble()).isEqualTo(Double.NEGATIVE_INFINITY);
-    assertThat(reader.nextDouble()).isEqualTo(Double.POSITIVE_INFINITY);
+    assertTrue(Double.isNaN((reader.nextDouble())));
+    assertEquals(Double.NEGATIVE_INFINITY, reader.nextDouble(), 0);
+    assertEquals(Double.POSITIVE_INFINITY, reader.nextDouble(), 0);
     reader.endArray();
   }
 
@@ -391,39 +386,39 @@ public final class JsonReaderTest {
         "[0,0,0," + "1,1,1," + "-1,-1,-1," + "-9223372036854775808," + "9223372036854775807]";
     JsonReader reader = newReader(json);
     reader.beginArray();
-    assertThat(reader.nextLong()).isEqualTo(0L);
-    assertThat(reader.nextInt()).isEqualTo(0);
-    assertThat(reader.nextDouble()).isEqualTo(0.0d);
-    assertThat(reader.nextLong()).isEqualTo(1L);
-    assertThat(reader.nextInt()).isEqualTo(1);
-    assertThat(reader.nextDouble()).isEqualTo(1.0d);
-    assertThat(reader.nextLong()).isEqualTo(-1L);
-    assertThat(reader.nextInt()).isEqualTo(-1);
-    assertThat(reader.nextDouble()).isEqualTo(-1.0d);
+    assertEquals(reader.nextLong(), 0L);
+    assertEquals(reader.nextInt(), 0);
+    assertEquals(0.0d, reader.nextDouble(), 0);
+    assertEquals(reader.nextLong(), 1L);
+    assertEquals(reader.nextInt(), 1);
+    assertEquals(1.0d, reader.nextDouble(), 0);
+    assertEquals(reader.nextLong(), -1L);
+    assertEquals(reader.nextInt(), -1);
+    assertEquals(-1.0d, reader.nextDouble(), 0);
     try {
       reader.nextInt();
       fail();
     } catch (JsonDataException expected) {
     }
-    assertThat(reader.nextLong()).isEqualTo(Long.MIN_VALUE);
+    assertEquals(reader.nextLong(), Long.MIN_VALUE);
     try {
       reader.nextInt();
       fail();
     } catch (JsonDataException expected) {
     }
-    assertThat(reader.nextLong()).isEqualTo(Long.MAX_VALUE);
+    assertEquals(reader.nextLong(), Long.MAX_VALUE);
     reader.endArray();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
   public void booleans() throws IOException {
     JsonReader reader = newReader("[true,false]");
     reader.beginArray();
-    assertThat(reader.nextBoolean()).isTrue();
-    assertThat(reader.nextBoolean()).isFalse();
+    assertTrue(reader.nextBoolean());
+    assertFalse(reader.nextBoolean());
     reader.endArray();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -435,7 +430,7 @@ public final class JsonReaderTest {
       fail();
     } catch (JsonDataException expected) {
     }
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     try {
       reader.nextName();
       fail();
@@ -461,7 +456,7 @@ public final class JsonReaderTest {
       fail();
     } catch (JsonDataException expected) {
     }
-    assertThat(reader.nextBoolean()).isTrue();
+    assertTrue(reader.nextBoolean());
     try {
       reader.nextString();
       fail();
@@ -483,7 +478,7 @@ public final class JsonReaderTest {
     } catch (JsonDataException expected) {
     }
     reader.endObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
     reader.close();
   }
 
@@ -498,7 +493,7 @@ public final class JsonReaderTest {
       fail();
     } catch (JsonDataException expected) {
     }
-    assertThat(reader.nextDouble()).isEqualTo(1.5d);
+    assertEquals(1.5d, reader.nextDouble(), 0);
     reader.endArray();
   }
 
@@ -513,7 +508,7 @@ public final class JsonReaderTest {
       fail();
     } catch (JsonDataException expected) {
     }
-    assertThat(reader.nextLong()).isEqualTo(9223372036854775807L);
+    assertEquals(reader.nextLong(), 9223372036854775807L);
     reader.endArray();
   }
 
@@ -528,7 +523,7 @@ public final class JsonReaderTest {
       fail();
     } catch (JsonDataException expected) {
     }
-    assertThat(reader.nextDouble()).isEqualTo(1.5d);
+    assertEquals(1.5d, reader.nextDouble(), 0);
     reader.endArray();
   }
 
@@ -557,35 +552,35 @@ public final class JsonReaderTest {
   @Test
   public void topLevelValueTypes() throws IOException {
     JsonReader reader1 = newReader("true");
-    assertThat(reader1.nextBoolean()).isTrue();
-    assertThat(reader1.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertTrue(reader1.nextBoolean());
+    assertEquals(reader1.peek(), JsonReader.Token.END_DOCUMENT);
 
     JsonReader reader2 = newReader("false");
-    assertThat(reader2.nextBoolean()).isFalse();
-    assertThat(reader2.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertFalse(reader2.nextBoolean());
+    assertEquals(reader2.peek(), JsonReader.Token.END_DOCUMENT);
 
     JsonReader reader3 = newReader("null");
-    assertThat(reader3.<Object>nextNull()).isNull();
-    assertThat(reader3.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertNull(reader3.nextNull());
+    assertEquals(reader3.peek(), JsonReader.Token.END_DOCUMENT);
 
     JsonReader reader4 = newReader("123");
-    assertThat(reader4.nextInt()).isEqualTo(123);
-    assertThat(reader4.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader4.nextInt(), 123);
+    assertEquals(reader4.peek(), JsonReader.Token.END_DOCUMENT);
 
     JsonReader reader5 = newReader("123.4");
-    assertThat(reader5.nextDouble()).isEqualTo(123.4);
-    assertThat(reader5.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(123.4, reader5.nextDouble(), 0);
+    assertEquals(reader5.peek(), JsonReader.Token.END_DOCUMENT);
 
     JsonReader reader6 = newReader("\"a\"");
-    assertThat(reader6.nextString()).isEqualTo("a");
-    assertThat(reader6.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader6.nextString(), "a");
+    assertEquals(reader6.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
   public void topLevelValueTypeWithSkipValue() throws IOException {
     JsonReader reader = newReader("true");
     reader.skipValue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -594,14 +589,14 @@ public final class JsonReaderTest {
     for (int i = 0; i < 31; i++) {
       reader.beginArray();
     }
-    assertThat(reader.getPath())
-        .isEqualTo(
-            "$[0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0]"
-                + "[0][0][0][0][0][0][0][0][0][0][0][0][0]");
+    assertEquals(
+        reader.getPath(),
+        "$[0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0]"
+            + "[0][0][0][0][0][0][0][0][0][0][0][0][0]");
     for (int i = 0; i < 31; i++) {
       reader.endArray();
     }
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -616,15 +611,15 @@ public final class JsonReaderTest {
     JsonReader reader = newReader(json);
     for (int i = 0; i < 31; i++) {
       reader.beginObject();
-      assertThat(reader.nextName()).isEqualTo("a");
+      assertEquals(reader.nextName(), "a");
     }
-    assertThat(reader.getPath())
-        .isEqualTo("$.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a");
-    assertThat(reader.nextBoolean()).isTrue();
+    assertEquals(
+        reader.getPath(), "$.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a");
+    assertTrue(reader.nextBoolean());
     for (int i = 0; i < 31; i++) {
       reader.endObject();
     }
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -641,7 +636,7 @@ public final class JsonReaderTest {
     JsonReader reader = newReader(repeat('x', 8192));
     reader.setLenient(true);
     reader.skipValue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -657,7 +652,7 @@ public final class JsonReaderTest {
     JsonReader reader = newReader("\"" + repeat('x', 8192) + "\"");
     reader.setLenient(true);
     reader.skipValue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -665,7 +660,7 @@ public final class JsonReaderTest {
     JsonReader reader = newReader("[123e]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.peek()).isEqualTo(STRING);
+    assertEquals(reader.peek(), STRING);
   }
 
   @Test
@@ -673,7 +668,7 @@ public final class JsonReaderTest {
     JsonReader reader = newReader("[123e4b]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.peek()).isEqualTo(STRING);
+    assertEquals(reader.peek(), STRING);
   }
 
   @Test
@@ -681,29 +676,29 @@ public final class JsonReaderTest {
     JsonReader reader = newReader("[123eb]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.peek()).isEqualTo(STRING);
+    assertEquals(reader.peek(), STRING);
   }
 
   @Test
   public void emptyStringName() throws IOException {
     JsonReader reader = newReader("{\"\":true}");
     reader.setLenient(true);
-    assertThat(reader.peek()).isEqualTo(BEGIN_OBJECT);
+    assertEquals(reader.peek(), BEGIN_OBJECT);
     reader.beginObject();
-    assertThat(reader.peek()).isEqualTo(NAME);
-    assertThat(reader.nextName()).isEqualTo("");
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.BOOLEAN);
-    assertThat(reader.nextBoolean()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_OBJECT);
+    assertEquals(reader.peek(), NAME);
+    assertEquals(reader.nextName(), "");
+    assertEquals(reader.peek(), JsonReader.Token.BOOLEAN);
+    assertTrue(reader.nextBoolean());
+    assertEquals(reader.peek(), JsonReader.Token.END_OBJECT);
     reader.endObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
   public void validEscapes() throws IOException {
     JsonReader reader = newReader("[\"\\\"\\\\\\/\\b\\f\\n\\r\\t\"]");
     reader.beginArray();
-    assertThat(reader.nextString()).isEqualTo("\"\\/\b\f\n\r\t");
+    assertEquals(reader.nextString(), "\"\\/\b\f\n\r\t");
   }
 
   @Test
@@ -917,13 +912,13 @@ public final class JsonReaderTest {
 
     JsonReader reader = newReader("[0, 2.0, true, \"4\"]");
     reader.beginArray();
-    assertThat(reader.selectString(numbers)).isEqualTo(-1);
+    assertEquals(reader.selectString(numbers), -1);
     reader.skipValue();
-    assertThat(reader.selectString(numbers)).isEqualTo(-1);
+    assertEquals(reader.selectString(numbers), -1);
     reader.skipValue();
-    assertThat(reader.selectString(numbers)).isEqualTo(-1);
+    assertEquals(reader.selectString(numbers), -1);
     reader.skipValue();
-    assertThat(reader.selectString(numbers)).isEqualTo(3);
+    assertEquals(reader.selectString(numbers), 3);
     reader.endArray();
   }
 
@@ -931,9 +926,9 @@ public final class JsonReaderTest {
   public void stringToNumberCoersion() throws Exception {
     JsonReader reader = newReader("[\"0\", \"9223372036854775807\", \"1.5\"]");
     reader.beginArray();
-    assertThat(reader.nextInt()).isEqualTo(0);
-    assertThat(reader.nextLong()).isEqualTo(9223372036854775807L);
-    assertThat(reader.nextDouble()).isEqualTo(1.5d);
+    assertEquals(reader.nextInt(), 0);
+    assertEquals(reader.nextLong(), 9223372036854775807L);
+    assertEquals(1.5d, reader.nextDouble(), 0);
     reader.endArray();
   }
 
@@ -941,8 +936,8 @@ public final class JsonReaderTest {
   public void unnecessaryPrecisionNumberCoersion() throws Exception {
     JsonReader reader = newReader("[\"0.0\", \"9223372036854775807.0\"]");
     reader.beginArray();
-    assertThat(reader.nextInt()).isEqualTo(0);
-    assertThat(reader.nextLong()).isEqualTo(9223372036854775807L);
+    assertEquals(reader.nextInt(), 0);
+    assertEquals(reader.nextLong(), 9223372036854775807L);
     reader.endArray();
   }
 
@@ -951,9 +946,9 @@ public final class JsonReaderTest {
     JsonReader reader = newReader("[\"NaN\", \"Infinity\", \"-Infinity\"]");
     reader.beginArray();
     reader.setLenient(true);
-    assertThat(reader.nextDouble()).isNaN();
-    assertThat(reader.nextDouble()).isEqualTo(Double.POSITIVE_INFINITY);
-    assertThat(reader.nextDouble()).isEqualTo(Double.NEGATIVE_INFINITY);
+    assertTrue(Double.isNaN((reader.nextDouble())));
+    assertEquals(Double.POSITIVE_INFINITY, reader.nextDouble(), 0);
+    assertEquals(Double.NEGATIVE_INFINITY, reader.nextDouble(), 0);
     reader.endArray();
   }
 
@@ -966,7 +961,7 @@ public final class JsonReaderTest {
       fail();
     } catch (JsonDataException expected) {
     }
-    assertThat(reader.nextString()).isEqualTo("a");
+    assertEquals(reader.nextString(), "a");
     reader.endArray();
   }
 
@@ -979,7 +974,7 @@ public final class JsonReaderTest {
       fail();
     } catch (JsonDataException expected) {
     }
-    assertThat(reader.nextString()).isEqualTo("a");
+    assertEquals(reader.nextString(), "a");
     reader.endArray();
   }
 
@@ -992,7 +987,7 @@ public final class JsonReaderTest {
       fail();
     } catch (JsonDataException expected) {
     }
-    assertThat(reader.nextString()).isEqualTo("a");
+    assertEquals(reader.nextString(), "a");
     reader.endArray();
   }
 
@@ -1000,36 +995,35 @@ public final class JsonReaderTest {
   public void readJsonValueInt() throws IOException {
     JsonReader reader = newReader("1");
     Object value = reader.readJsonValue();
-    assertThat(value).isEqualTo(1.0);
+    assertEquals(value, 1.0);
   }
 
   @Test
   public void readJsonValueMap() throws IOException {
     JsonReader reader = newReader("{\"hello\": \"world\"}");
     Object value = reader.readJsonValue();
-    assertThat(value).isEqualTo(Collections.singletonMap("hello", "world"));
+    assertEquals(value, Collections.singletonMap("hello", "world"));
   }
 
   @Test
   public void readJsonValueList() throws IOException {
     JsonReader reader = newReader("[\"a\", \"b\"]");
     Object value = reader.readJsonValue();
-    assertThat(value).isEqualTo(Arrays.asList("a", "b"));
+    assertEquals(value, Arrays.asList("a", "b"));
   }
 
   @Test
   public void readJsonValueListMultipleTypes() throws IOException {
     JsonReader reader = newReader("[\"a\", 5, false]");
     Object value = reader.readJsonValue();
-    assertThat(value).isEqualTo(Arrays.asList("a", 5.0, false));
+    assertEquals(value, Arrays.asList("a", 5.0, false));
   }
 
   @Test
   public void readJsonValueNestedListInMap() throws IOException {
     JsonReader reader = newReader("{\"pizzas\": [\"cheese\", \"pepperoni\"]}");
     Object value = reader.readJsonValue();
-    assertThat(value)
-        .isEqualTo(Collections.singletonMap("pizzas", Arrays.asList("cheese", "pepperoni")));
+    assertEquals(value, Collections.singletonMap("pizzas", Arrays.asList("cheese", "pepperoni")));
   }
 
   @Test
@@ -1037,7 +1031,7 @@ public final class JsonReaderTest {
     JsonReader reader = newReader("{\"a\":1}");
     reader.beginObject();
     reader.skipName();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.NUMBER);
+    assertEquals(reader.peek(), JsonReader.Token.NUMBER);
     reader.skipValue();
     reader.endObject();
   }
@@ -1053,7 +1047,7 @@ public final class JsonReaderTest {
       reader.skipName();
       fail();
     } catch (JsonDataException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Cannot skip unexpected NAME at $.b");
+      assertTrue(e.getMessage().contains("Cannot skip unexpected NAME at $.b"));
     }
   }
 
@@ -1065,14 +1059,14 @@ public final class JsonReaderTest {
       fail();
     } catch (JsonDataException expected) {
     }
-    assertThat(reader.nextInt()).isEqualTo(1);
+    assertEquals(reader.nextInt(), 1);
   }
 
   @Test
   public void emptyDocumentHasNextReturnsFalse() throws IOException {
     JsonReader reader = newReader("1");
     reader.readJsonValue();
-    assertThat(reader.hasNext()).isFalse();
+    assertFalse(reader.hasNext());
   }
 
   @Test
@@ -1083,12 +1077,10 @@ public final class JsonReaderTest {
       reader.skipValue();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected a value but was END_OBJECT at path $.");
+      assertTrue(expected.getMessage().contains("Expected a value but was END_OBJECT at path $."));
     }
     reader.endObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -1099,12 +1091,10 @@ public final class JsonReaderTest {
       reader.skipValue();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected a value but was END_ARRAY at path $[0]");
+      assertTrue(expected.getMessage().contains("Expected a value but was END_ARRAY at path $[0]"));
     }
     reader.endArray();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -1115,39 +1105,37 @@ public final class JsonReaderTest {
       reader.skipValue();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected a value but was END_DOCUMENT at path $");
+      assertTrue(expected.getMessage().contains("Expected a value but was END_DOCUMENT at path $"));
     }
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
   public void basicPeekJson() throws IOException {
     JsonReader reader = newReader("{\"a\":12,\"b\":[34,56],\"c\":78}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.nextInt()).isEqualTo(12);
-    assertThat(reader.nextName()).isEqualTo("b");
+    assertEquals(reader.nextName(), "a");
+    assertEquals(reader.nextInt(), 12);
+    assertEquals(reader.nextName(), "b");
     reader.beginArray();
-    assertThat(reader.nextInt()).isEqualTo(34);
+    assertEquals(reader.nextInt(), 34);
 
     // Peek.
     JsonReader peekReader = reader.peekJson();
-    assertThat(peekReader.nextInt()).isEqualTo(56);
+    assertEquals(peekReader.nextInt(), 56);
     peekReader.endArray();
-    assertThat(peekReader.nextName()).isEqualTo("c");
-    assertThat(peekReader.nextInt()).isEqualTo(78);
+    assertEquals(peekReader.nextName(), "c");
+    assertEquals(peekReader.nextInt(), 78);
     peekReader.endObject();
-    assertThat(peekReader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(peekReader.peek(), JsonReader.Token.END_DOCUMENT);
 
     // Read again.
-    assertThat(reader.nextInt()).isEqualTo(56);
+    assertEquals(reader.nextInt(), 56);
     reader.endArray();
-    assertThat(reader.nextName()).isEqualTo("c");
-    assertThat(reader.nextInt()).isEqualTo(78);
+    assertEquals(reader.nextName(), "c");
+    assertEquals(reader.nextInt(), 78);
     reader.endObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   /**
@@ -1173,51 +1161,51 @@ public final class JsonReaderTest {
       case 0:
         if (until == 0) break;
         reader.beginArray();
-        assertThat(reader.getPath()).isEqualTo("$[0]");
+        assertEquals(reader.getPath(), "$[0]");
       case 1:
         if (until == 1) break;
-        assertThat(reader.nextInt()).isEqualTo(12);
-        assertThat(reader.getPath()).isEqualTo("$[1]");
+        assertEquals(reader.nextInt(), 12);
+        assertEquals(reader.getPath(), "$[1]");
       case 2:
         if (until == 2) break;
-        assertThat(reader.nextInt()).isEqualTo(34);
-        assertThat(reader.getPath()).isEqualTo("$[2]");
+        assertEquals(reader.nextInt(), 34);
+        assertEquals(reader.getPath(), "$[2]");
       case 3:
         if (until == 3) break;
         reader.beginObject();
-        assertThat(reader.getPath()).isEqualTo("$[2].");
+        assertEquals(reader.getPath(), "$[2].");
       case 4:
         if (until == 4) break;
-        assertThat(reader.nextName()).isEqualTo("a");
-        assertThat(reader.getPath()).isEqualTo("$[2].a");
+        assertEquals(reader.nextName(), "a");
+        assertEquals(reader.getPath(), "$[2].a");
       case 5:
         if (until == 5) break;
-        assertThat(reader.nextInt()).isEqualTo(56);
-        assertThat(reader.getPath()).isEqualTo("$[2].a");
+        assertEquals(reader.nextInt(), 56);
+        assertEquals(reader.getPath(), "$[2].a");
       case 6:
         if (until == 6) break;
-        assertThat(reader.nextName()).isEqualTo("b");
-        assertThat(reader.getPath()).isEqualTo("$[2].b");
+        assertEquals(reader.nextName(), "b");
+        assertEquals(reader.getPath(), "$[2].b");
       case 7:
         if (until == 7) break;
-        assertThat(reader.nextInt()).isEqualTo(78);
-        assertThat(reader.getPath()).isEqualTo("$[2].b");
+        assertEquals(reader.nextInt(), 78);
+        assertEquals(reader.getPath(), "$[2].b");
       case 8:
         if (until == 8) break;
         reader.endObject();
-        assertThat(reader.getPath()).isEqualTo("$[3]");
+        assertEquals(reader.getPath(), "$[3]");
       case 9:
         if (until == 9) break;
-        assertThat(reader.nextInt()).isEqualTo(90);
-        assertThat(reader.getPath()).isEqualTo("$[4]");
+        assertEquals(reader.nextInt(), 90);
+        assertEquals(reader.getPath(), "$[4]");
       case 10:
         if (until == 10) break;
         reader.endArray();
-        assertThat(reader.getPath()).isEqualTo("$");
+        assertEquals(reader.getPath(), "$");
       case 11:
         if (until == 11) break;
-        assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
-        assertThat(reader.getPath()).isEqualTo("$");
+        assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
+        assertEquals(reader.getPath(), "$");
     }
   }
 
@@ -1326,7 +1314,7 @@ public final class JsonReaderTest {
     JsonReader reader = newReader("{}");
     reader.beginObject();
     reader.promoteNameToValue();
-    assertThat(reader.hasNext()).isFalse();
+    assertFalse(reader.hasNext());
     reader.endObject();
   }
 
@@ -1335,7 +1323,9 @@ public final class JsonReaderTest {
     String[] options = new String[] {"a", "b", "c"};
     JsonReader.Options abc = JsonReader.Options.of("a", "b", "c");
     List<String> strings = abc.strings();
-    assertThat(options).asList().containsExactlyElementsIn(strings).inOrder();
+    List<String> optionList = Arrays.stream(options).collect(Collectors.toList());
+    assertTrue(optionList.containsAll(strings));
+    assertTrue(strings.containsAll(optionList));
     try {
       // Confirm it's unmodifiable and we can't mutate the original underlying array
       strings.add("d");
@@ -1350,9 +1340,9 @@ public final class JsonReaderTest {
     // language=JSON
     JsonReader reader = newReader("{\"a\":\"this is a string\"}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     try (BufferedSource valueSource = reader.nextSource()) {
-      assertThat(valueSource.readUtf8()).isEqualTo("\"this is a string\"");
+      assertEquals(valueSource.readUtf8(), "\"this is a string\"");
     }
   }
 
@@ -1361,9 +1351,9 @@ public final class JsonReaderTest {
     // language=JSON
     JsonReader reader = newReader("{\"a\":-2.0}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     try (BufferedSource valueSource = reader.nextSource()) {
-      assertThat(valueSource.readUtf8()).isEqualTo("-2.0");
+      assertEquals(valueSource.readUtf8(), "-2.0");
     }
   }
 
@@ -1372,9 +1362,9 @@ public final class JsonReaderTest {
     // language=JSON
     JsonReader reader = newReader("{\"a\":null}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     try (BufferedSource valueSource = reader.nextSource()) {
-      assertThat(valueSource.readUtf8()).isEqualTo("null");
+      assertEquals(valueSource.readUtf8(), "null");
     }
   }
 
@@ -1383,9 +1373,9 @@ public final class JsonReaderTest {
     // language=JSON
     JsonReader reader = newReader("{\"a\":false}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     try (BufferedSource valueSource = reader.nextSource()) {
-      assertThat(valueSource.readUtf8()).isEqualTo("false");
+      assertEquals(valueSource.readUtf8(), "false");
     }
   }
 
@@ -1394,9 +1384,9 @@ public final class JsonReaderTest {
     // language=JSON
     JsonReader reader = newReader("{\"a\":{\"b\":2.0,\"c\":3.0}}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     try (BufferedSource valueSource = reader.nextSource()) {
-      assertThat(valueSource.readUtf8()).isEqualTo("{\"b\":2.0,\"c\":3.0}");
+      assertEquals(valueSource.readUtf8(), "{\"b\":2.0,\"c\":3.0}");
     }
   }
 
@@ -1405,9 +1395,9 @@ public final class JsonReaderTest {
     // language=JSON
     JsonReader reader = newReader("{\"a\":[2.0,2.0,3.0]}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     try (BufferedSource valueSource = reader.nextSource()) {
-      assertThat(valueSource.readUtf8()).isEqualTo("[2.0,2.0,3.0]");
+      assertEquals(valueSource.readUtf8(), "[2.0,2.0,3.0]");
     }
   }
 
@@ -1420,10 +1410,10 @@ public final class JsonReaderTest {
     // language=JSON
     JsonReader reader = newReader("{\"a\":\"b\"}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.selectString(JsonReader.Options.of("x'"))).isEqualTo(-1);
+    assertEquals(reader.nextName(), "a");
+    assertEquals(reader.selectString(JsonReader.Options.of("x'")), -1);
     try (BufferedSource valueSource = reader.nextSource()) {
-      assertThat(valueSource.readUtf8()).isEqualTo("\"b\"");
+      assertEquals(valueSource.readUtf8(), "\"b\"");
     }
   }
 
@@ -1433,18 +1423,18 @@ public final class JsonReaderTest {
     // language=JSON
     JsonReader reader = newReader("{\"a\":\"b\",\"c\":\"d\"}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     reader.nextSource(); // Not closed.
-    assertThat(reader.nextName()).isEqualTo("c");
-    assertThat(reader.nextString()).isEqualTo("d");
+    assertEquals(reader.nextName(), "c");
+    assertEquals(reader.nextString(), "d");
   }
 
   @SuppressWarnings("rawtypes")
   @Test
   public void tags() throws IOException {
     JsonReader reader = newReader("{}");
-    assertThat(reader.tag(Integer.class)).isNull();
-    assertThat(reader.tag(CharSequence.class)).isNull();
+    assertNull(reader.tag(Integer.class));
+    assertNull(reader.tag(CharSequence.class));
 
     reader.setTag(Integer.class, 1);
     reader.setTag(CharSequence.class, "Foo");
@@ -1452,18 +1442,18 @@ public final class JsonReaderTest {
       reader.setTag((Class) CharSequence.class, 1);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Tag value must be of type java.lang.CharSequence");
+      assertTrue(
+          expected.getMessage().contains("Tag value must be of type java.lang.CharSequence"));
     }
 
     Object intTag = reader.tag(Integer.class);
-    assertThat(intTag).isEqualTo(1);
-    assertThat(intTag).isInstanceOf(Integer.class);
+    assertEquals(intTag, 1);
+    assertNotNull(intTag);
+    assertTrue(intTag instanceof Integer);
     Object charSequenceTag = reader.tag(CharSequence.class);
-    assertThat(charSequenceTag).isEqualTo("Foo");
-    assertThat(charSequenceTag).isInstanceOf(String.class);
-    assertThat(reader.tag(String.class)).isNull();
+    assertEquals(charSequenceTag, "Foo");
+    assertTrue(charSequenceTag instanceof String);
+    assertNull(reader.tag(String.class));
   }
 
   /** Peek a value, then read it, recursively. */

--- a/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.moshi.JsonReader.Token.BEGIN_ARRAY;
 import static com.squareup.moshi.JsonReader.Token.BEGIN_OBJECT;
 import static com.squareup.moshi.JsonReader.Token.BOOLEAN;
@@ -28,8 +27,7 @@ import static com.squareup.moshi.JsonReader.Token.STRING;
 import static com.squareup.moshi.TestUtil.MAX_DEPTH;
 import static com.squareup.moshi.TestUtil.newReader;
 import static com.squareup.moshi.TestUtil.repeat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -50,12 +48,12 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader1 = JsonReader.of(buffer);
     reader1.beginObject();
     reader1.endObject();
-    assertThat(buffer.size()).isEqualTo(2);
+    assertEquals(buffer.size(), 2);
 
     JsonReader reader2 = JsonReader.of(buffer);
     reader2.beginObject();
     reader2.endObject();
-    assertThat(buffer.size()).isEqualTo(0);
+    assertEquals(buffer.size(), 0);
   }
 
   @Test
@@ -63,12 +61,12 @@ public final class JsonUtf8ReaderTest {
     Buffer buffer = new Buffer().writeUtf8("{\"a\": \"android\", \"b\": \"banana\"}");
     JsonReader reader = JsonReader.of(buffer);
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.nextString()).isEqualTo("android");
-    assertThat(reader.nextName()).isEqualTo("b");
-    assertThat(reader.nextString()).isEqualTo("banana");
+    assertEquals(reader.nextName(), "a");
+    assertEquals(reader.nextString(), "android");
+    assertEquals(reader.nextName(), "b");
+    assertEquals(reader.nextString(), "banana");
     reader.endObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -76,12 +74,12 @@ public final class JsonUtf8ReaderTest {
     Buffer buffer = new Buffer().writeUtf8("{\"a\": \"android\", \"b\": \"banana\"}");
     JsonReader reader = JsonReader.of(Okio.buffer(new ForwardingSource(buffer) {}));
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.nextString()).isEqualTo("android");
-    assertThat(reader.nextName()).isEqualTo("b");
-    assertThat(reader.nextString()).isEqualTo("banana");
+    assertEquals(reader.nextName(), "a");
+    assertEquals(reader.nextString(), "android");
+    assertEquals(reader.nextName(), "b");
+    assertEquals(reader.nextString(), "banana");
     reader.endObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -167,9 +165,9 @@ public final class JsonUtf8ReaderTest {
       fail();
     } catch (JsonEncodingException expected) {
     }
-    assertThat(reader.nextString()).isEqualTo("01");
+    assertEquals(reader.nextString(), "01");
     reader.endArray();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -177,13 +175,13 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[truey]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.peek()).isEqualTo(STRING);
+    assertEquals(reader.peek(), STRING);
     try {
       reader.nextBoolean();
       fail();
     } catch (JsonDataException expected) {
     }
-    assertThat(reader.nextString()).isEqualTo("truey");
+    assertEquals(reader.nextString(), "truey");
     reader.endArray();
   }
 
@@ -229,8 +227,8 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[" + s + "]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.STRING);
-    assertThat(reader.nextString()).isEqualTo(s);
+    assertEquals(reader.peek(), JsonReader.Token.STRING);
+    assertEquals(reader.nextString(), s);
     reader.endArray();
   }
 
@@ -239,13 +237,13 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[12.34e5x]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.peek()).isEqualTo(STRING);
+    assertEquals(reader.peek(), STRING);
     try {
       reader.nextInt();
       fail();
     } catch (JsonDataException expected) {
     }
-    assertThat(reader.nextString()).isEqualTo("12.34e5x");
+    assertEquals(reader.nextString(), "12.34e5x");
   }
 
   @Test
@@ -253,8 +251,8 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[-9223372036854775808]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.peek()).isEqualTo(NUMBER);
-    assertThat(reader.nextLong()).isEqualTo(-9223372036854775808L);
+    assertEquals(reader.peek(), NUMBER);
+    assertEquals(reader.nextLong(), -9223372036854775808L);
   }
 
   @Test
@@ -262,8 +260,8 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[9223372036854775807]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.peek()).isEqualTo(NUMBER);
-    assertThat(reader.nextLong()).isEqualTo(9223372036854775807L);
+    assertEquals(reader.peek(), NUMBER);
+    assertEquals(reader.nextLong(), 9223372036854775807L);
   }
 
   @Test
@@ -271,7 +269,7 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[22233720368547758070]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.peek()).isEqualTo(NUMBER);
+    assertEquals(reader.peek(), NUMBER);
     try {
       reader.nextLong();
       fail();
@@ -284,7 +282,7 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[-22233720368547758070]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.peek()).isEqualTo(NUMBER);
+    assertEquals(reader.peek(), NUMBER);
     try {
       reader.nextLong();
       fail();
@@ -297,7 +295,7 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[9223372036854775808]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.peek()).isEqualTo(NUMBER);
+    assertEquals(reader.peek(), NUMBER);
     try {
       reader.nextLong();
       fail();
@@ -310,7 +308,7 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[9223372036854775806.5]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.peek()).isEqualTo(NUMBER);
+    assertEquals(reader.peek(), NUMBER);
     try {
       reader.nextLong();
       fail();
@@ -323,13 +321,13 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[-9223372036854775809]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.peek()).isEqualTo(NUMBER);
+    assertEquals(reader.peek(), NUMBER);
     try {
       reader.nextLong();
       fail();
     } catch (JsonDataException expected) {
     }
-    assertThat(reader.nextDouble()).isEqualTo(-9223372036854775809d);
+    assertEquals(-9223372036854775809d, reader.nextDouble(), 0);
   }
 
   @Test
@@ -337,7 +335,7 @@ public final class JsonUtf8ReaderTest {
     String json = "[9223372036854775806.000]";
     JsonReader reader = newReader(json);
     reader.beginArray();
-    assertThat(reader.nextLong()).isEqualTo(9223372036854775806L);
+    assertEquals(reader.nextLong(), 9223372036854775806L);
     reader.endArray();
   }
 
@@ -346,13 +344,13 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[-92233720368547758080]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.peek()).isEqualTo(NUMBER);
+    assertEquals(reader.peek(), NUMBER);
     try {
       reader.nextLong();
       fail();
     } catch (JsonDataException expected) {
     }
-    assertThat(reader.nextDouble()).isEqualTo(-92233720368547758080d);
+    assertEquals(-92233720368547758080d, reader.nextDouble(), 0);
   }
 
   @Test
@@ -366,12 +364,12 @@ public final class JsonUtf8ReaderTest {
   public void numberToStringCoersion() throws Exception {
     JsonReader reader = newReader("[0, 9223372036854775807, 2.5, 3.010, \"a\", \"5\"]");
     reader.beginArray();
-    assertThat(reader.nextString()).isEqualTo("0");
-    assertThat(reader.nextString()).isEqualTo("9223372036854775807");
-    assertThat(reader.nextString()).isEqualTo("2.5");
-    assertThat(reader.nextString()).isEqualTo("3.010");
-    assertThat(reader.nextString()).isEqualTo("a");
-    assertThat(reader.nextString()).isEqualTo("5");
+    assertEquals(reader.nextString(), "0");
+    assertEquals(reader.nextString(), "9223372036854775807");
+    assertEquals(reader.nextString(), "2.5");
+    assertEquals(reader.nextString(), "3.010");
+    assertEquals(reader.nextString(), "a");
+    assertEquals(reader.nextString(), "5");
     reader.endArray();
   }
 
@@ -380,29 +378,29 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[\"12\u00334\"]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.peek()).isEqualTo(STRING);
-    assertThat(reader.nextInt()).isEqualTo(1234);
+    assertEquals(reader.peek(), STRING);
+    assertEquals(reader.nextInt(), 1234);
   }
 
   @Test
   public void mixedCaseLiterals() throws IOException {
     JsonReader reader = newReader("[True,TruE,False,FALSE,NULL,nulL]");
     reader.beginArray();
-    assertThat(reader.nextBoolean()).isTrue();
-    assertThat(reader.nextBoolean()).isTrue();
-    assertThat(reader.nextBoolean()).isFalse();
-    assertThat(reader.nextBoolean()).isFalse();
+    assertTrue(reader.nextBoolean());
+    assertTrue(reader.nextBoolean());
+    assertFalse(reader.nextBoolean());
+    assertFalse(reader.nextBoolean());
     reader.nextNull();
     reader.nextNull();
     reader.endArray();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
   public void missingValue() throws IOException {
     JsonReader reader = newReader("{\"a\":}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     try {
       reader.nextString();
       fail();
@@ -414,8 +412,8 @@ public final class JsonUtf8ReaderTest {
   public void prematureEndOfInput() throws IOException {
     JsonReader reader = newReader("{\"a\":true,");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.nextBoolean()).isTrue();
+    assertEquals(reader.nextName(), "a");
+    assertTrue(reader.nextBoolean());
     try {
       reader.nextName();
       fail();
@@ -459,7 +457,7 @@ public final class JsonUtf8ReaderTest {
   public void strictNameValueSeparator() throws IOException {
     JsonReader reader = newReader("{\"a\"=true}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     try {
       reader.nextBoolean();
       fail();
@@ -468,7 +466,7 @@ public final class JsonUtf8ReaderTest {
 
     reader = newReader("{\"a\"=>true}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     try {
       reader.nextBoolean();
       fail();
@@ -481,21 +479,21 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("{\"a\"=true}");
     reader.setLenient(true);
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.nextBoolean()).isTrue();
+    assertEquals(reader.nextName(), "a");
+    assertTrue(reader.nextBoolean());
 
     reader = newReader("{\"a\"=>true}");
     reader.setLenient(true);
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.nextBoolean()).isTrue();
+    assertEquals(reader.nextName(), "a");
+    assertTrue(reader.nextBoolean());
   }
 
   @Test
   public void strictNameValueSeparatorWithSkipValue() throws IOException {
     JsonReader reader = newReader("{\"a\"=true}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     try {
       reader.skipValue();
       fail();
@@ -504,7 +502,7 @@ public final class JsonUtf8ReaderTest {
 
     reader = newReader("{\"a\"=>true}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     try {
       reader.skipValue();
       fail();
@@ -516,19 +514,19 @@ public final class JsonUtf8ReaderTest {
   public void commentsInStringValue() throws Exception {
     JsonReader reader = newReader("[\"// comment\"]");
     reader.beginArray();
-    assertThat(reader.nextString()).isEqualTo("// comment");
+    assertEquals(reader.nextString(), "// comment");
     reader.endArray();
 
     reader = newReader("{\"a\":\"#someComment\"}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.nextString()).isEqualTo("#someComment");
+    assertEquals(reader.nextName(), "a");
+    assertEquals(reader.nextString(), "#someComment");
     reader.endObject();
 
     reader = newReader("{\"#//a\":\"#some //Comment\"}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("#//a");
-    assertThat(reader.nextString()).isEqualTo("#some //Comment");
+    assertEquals(reader.nextName(), "#//a");
+    assertEquals(reader.nextString(), "#some //Comment");
     reader.endObject();
   }
 
@@ -564,22 +562,22 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[// comment \n true]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.nextBoolean()).isTrue();
+    assertTrue(reader.nextBoolean());
 
     reader = newReader("[# comment \n true]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.nextBoolean()).isTrue();
+    assertTrue(reader.nextBoolean());
 
     reader = newReader("[/* comment */ true]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.nextBoolean()).isTrue();
+    assertTrue(reader.nextBoolean());
 
     reader = newReader("a//");
     reader.setLenient(true);
-    assertThat(reader.nextString()).isEqualTo("a");
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.nextString(), "a");
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -625,15 +623,15 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("{a:true}");
     reader.setLenient(true);
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
   }
 
   @Test
   public void jsonIsSingleUnquotedString() throws IOException {
     JsonReader reader = newReader("abc");
     reader.setLenient(true);
-    assertThat(reader.nextString()).isEqualTo("abc");
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.nextString(), "abc");
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -663,7 +661,7 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("{'a':true}");
     reader.setLenient(true);
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
   }
 
   @Test
@@ -704,7 +702,7 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[a]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.nextString()).isEqualTo("a");
+    assertEquals(reader.nextString(), "a");
   }
 
   @Test
@@ -712,7 +710,7 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[a#comment\n]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.nextString()).isEqualTo("a");
+    assertEquals(reader.nextString(), "a");
     reader.endArray();
   }
 
@@ -732,7 +730,7 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("['a']");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.nextString()).isEqualTo("a");
+    assertEquals(reader.nextString(), "a");
   }
 
   @Test
@@ -763,8 +761,8 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[true;true]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.nextBoolean()).isTrue();
-    assertThat(reader.nextBoolean()).isTrue();
+    assertTrue(reader.nextBoolean());
+    assertTrue(reader.nextBoolean());
   }
 
   @Test
@@ -783,7 +781,7 @@ public final class JsonUtf8ReaderTest {
   public void strictSemicolonDelimitedNameValuePair() throws IOException {
     JsonReader reader = newReader("{\"a\":true;\"b\":true}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     try {
       reader.nextBoolean();
       reader.nextName();
@@ -797,16 +795,16 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("{\"a\":true;\"b\":true}");
     reader.setLenient(true);
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.nextBoolean()).isTrue();
-    assertThat(reader.nextName()).isEqualTo("b");
+    assertEquals(reader.nextName(), "a");
+    assertTrue(reader.nextBoolean());
+    assertEquals(reader.nextName(), "b");
   }
 
   @Test
   public void strictSemicolonDelimitedNameValuePairWithSkipValue() throws IOException {
     JsonReader reader = newReader("{\"a\":true;\"b\":true}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     try {
       reader.skipValue();
       reader.skipValue();
@@ -819,7 +817,7 @@ public final class JsonUtf8ReaderTest {
   public void strictUnnecessaryArraySeparators() throws IOException {
     JsonReader reader = newReader("[true,,true]");
     reader.beginArray();
-    assertThat(reader.nextBoolean()).isTrue();
+    assertTrue(reader.nextBoolean());
     try {
       reader.nextNull();
       fail();
@@ -836,7 +834,7 @@ public final class JsonUtf8ReaderTest {
 
     reader = newReader("[true,]");
     reader.beginArray();
-    assertThat(reader.nextBoolean()).isTrue();
+    assertTrue(reader.nextBoolean());
     try {
       reader.nextNull();
       fail();
@@ -857,22 +855,22 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[true,,true]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.nextBoolean()).isTrue();
+    assertTrue(reader.nextBoolean());
     reader.nextNull();
-    assertThat(reader.nextBoolean()).isTrue();
+    assertTrue(reader.nextBoolean());
     reader.endArray();
 
     reader = newReader("[,true]");
     reader.setLenient(true);
     reader.beginArray();
     reader.nextNull();
-    assertThat(reader.nextBoolean()).isTrue();
+    assertTrue(reader.nextBoolean());
     reader.endArray();
 
     reader = newReader("[true,]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.nextBoolean()).isTrue();
+    assertTrue(reader.nextBoolean());
     reader.nextNull();
     reader.endArray();
 
@@ -888,7 +886,7 @@ public final class JsonUtf8ReaderTest {
   public void strictUnnecessaryArraySeparatorsWithSkipValue() throws IOException {
     JsonReader reader = newReader("[true,,true]");
     reader.beginArray();
-    assertThat(reader.nextBoolean()).isTrue();
+    assertTrue(reader.nextBoolean());
     try {
       reader.skipValue();
       fail();
@@ -905,7 +903,7 @@ public final class JsonUtf8ReaderTest {
 
     reader = newReader("[true,]");
     reader.beginArray();
-    assertThat(reader.nextBoolean()).isTrue();
+    assertTrue(reader.nextBoolean());
     try {
       reader.skipValue();
       fail();
@@ -939,10 +937,10 @@ public final class JsonUtf8ReaderTest {
     reader.setLenient(true);
     reader.beginArray();
     reader.endArray();
-    assertThat(reader.nextBoolean()).isTrue();
+    assertTrue(reader.nextBoolean());
     reader.beginObject();
     reader.endObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -1033,7 +1031,7 @@ public final class JsonUtf8ReaderTest {
       reader1.peek();
       fail();
     } catch (JsonEncodingException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo(message);
+      assertTrue(expected.getMessage().contains(message));
     }
 
     // Also validate that it works when skipping.
@@ -1045,7 +1043,7 @@ public final class JsonUtf8ReaderTest {
       reader2.peek();
       fail();
     } catch (JsonEncodingException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo(message);
+      assertTrue(expected.getMessage().contains(message));
     }
   }
 
@@ -1064,7 +1062,7 @@ public final class JsonUtf8ReaderTest {
       reader.peek();
       fail();
     } catch (JsonEncodingException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected value at path $[1].a[2]");
+      assertTrue(expected.getMessage().contains("Expected value at path $[1].a[2]"));
     }
   }
 
@@ -1079,7 +1077,7 @@ public final class JsonUtf8ReaderTest {
       reader.peek();
       fail();
     } catch (JsonEncodingException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected value at path $.null[1]");
+      assertTrue(expected.getMessage().contains("Expected value at path $.null[1]"));
     }
   }
 
@@ -1089,7 +1087,7 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[0." + repeat('9', 8192) + "]");
     reader.beginArray();
     try {
-      assertThat(reader.nextDouble()).isEqualTo(1d);
+      assertEquals(reader.nextDouble(), 1d);
       fail();
     } catch (JsonEncodingException expected) {
     }
@@ -1101,10 +1099,10 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[0." + repeat('9', 8192) + "]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.STRING);
-    assertThat(reader.nextDouble()).isEqualTo(1d);
+    assertEquals(reader.peek(), JsonReader.Token.STRING);
+    assertEquals(reader.nextDouble(), 1d);
     reader.endArray();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -1113,7 +1111,7 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[" + literal + "]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.nextString()).isEqualTo(literal);
+    assertEquals(reader.nextString(), literal);
     reader.endArray();
   }
 
@@ -1127,9 +1125,8 @@ public final class JsonUtf8ReaderTest {
       reader.beginArray();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Nesting too deep at $" + repeat("[0]", MAX_DEPTH));
+      assertTrue(
+          expected.getMessage().contains("Nesting too deep at $" + repeat("[0]", MAX_DEPTH)));
     }
   }
 
@@ -1145,15 +1142,13 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader(json);
     for (int i = 0; i < MAX_DEPTH; i++) {
       reader.beginObject();
-      assertThat(reader.nextName()).isEqualTo("a");
+      assertEquals(reader.nextName(), "a");
     }
     try {
       reader.beginObject();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Nesting too deep at $" + repeat(".a", MAX_DEPTH));
+      assertTrue(expected.getMessage().contains("Nesting too deep at $" + repeat(".a", MAX_DEPTH)));
     }
   }
 
@@ -1196,8 +1191,8 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("{\"a\":\"android\"x");
     reader.setLenient(true);
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.nextString()).isEqualTo("android");
+    assertEquals(reader.nextName(), "a");
+    assertEquals(reader.nextString(), "android");
     try {
       reader.peek();
       fail();
@@ -1213,7 +1208,7 @@ public final class JsonUtf8ReaderTest {
     String json = "[\"" + string + "\"]";
     JsonReader reader = newReader(json);
     reader.beginArray();
-    assertThat(reader.nextString()).isEqualTo(string);
+    assertEquals(reader.nextString(), string);
     reader.endArray();
   }
 
@@ -1226,7 +1221,7 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader(json);
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.nextString()).isEqualTo(string);
+    assertEquals(reader.nextString(), string);
     reader.endArray();
   }
 
@@ -1239,7 +1234,7 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader(json);
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.nextString()).isEqualTo(string);
+    assertEquals(reader.nextString(), string);
     try {
       reader.peek();
       fail();
@@ -1251,8 +1246,8 @@ public final class JsonUtf8ReaderTest {
   public void strictExtraCommasInMaps() throws IOException {
     JsonReader reader = newReader("{\"a\":\"b\",}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.nextString()).isEqualTo("b");
+    assertEquals(reader.nextName(), "a");
+    assertEquals(reader.nextString(), "b");
     try {
       reader.peek();
       fail();
@@ -1265,8 +1260,8 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("{\"a\":\"b\",}");
     reader.setLenient(true);
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.nextString()).isEqualTo("b");
+    assertEquals(reader.nextName(), "a");
+    assertEquals(reader.nextString(), "b");
     try {
       reader.peek();
       fail();
@@ -1328,7 +1323,7 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[\"string");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.STRING);
+    assertEquals(reader.peek(), JsonReader.Token.STRING);
     try {
       reader.nextString();
       fail();
@@ -1344,7 +1339,7 @@ public final class JsonUtf8ReaderTest {
       reader.nextString();
       fail();
     } catch (JsonEncodingException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Invalid escape sequence: \\i at path $[0]");
+      assertTrue(expected.getMessage().contains("Invalid escape sequence: \\i at path $[0]"));
     }
   }
 
@@ -1353,7 +1348,7 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("[\"str\\ing\"]");
     reader.setLenient(true);
     reader.beginArray();
-    assertThat(reader.nextString()).isEqualTo("string");
+    assertEquals(reader.nextString(), "string");
   }
 
   private void assertDocument(String document, Object... expectations) throws IOException {
@@ -1369,13 +1364,13 @@ public final class JsonUtf8ReaderTest {
       } else if (expectation == END_ARRAY) {
         reader.endArray();
       } else if (expectation == NAME) {
-        assertThat(reader.nextName()).isEqualTo("name");
+        assertEquals(reader.nextName(), "name");
       } else if (expectation == BOOLEAN) {
-        assertThat(reader.nextBoolean()).isFalse();
+        assertFalse(reader.nextBoolean());
       } else if (expectation == STRING) {
-        assertThat(reader.nextString()).isEqualTo("string");
+        assertEquals(reader.nextString(), "string");
       } else if (expectation == NUMBER) {
-        assertThat(reader.nextInt()).isEqualTo(123);
+        assertEquals(reader.nextInt(), 123);
       } else if (expectation == NULL) {
         reader.nextNull();
       } else if (expectation instanceof Class
@@ -1397,9 +1392,9 @@ public final class JsonUtf8ReaderTest {
     // language=JSON
     JsonReader reader = newReader("{\n  \"a\": {\n    \"b\": 2,\n    \"c\": 3\n  }\n}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     try (BufferedSource valueSource = reader.nextSource()) {
-      assertThat(valueSource.readUtf8()).isEqualTo("{\n    \"b\": 2,\n    \"c\": 3\n  }");
+      assertEquals(valueSource.readUtf8(), "{\n    \"b\": 2,\n    \"c\": 3\n  }");
     }
   }
 
@@ -1408,9 +1403,9 @@ public final class JsonUtf8ReaderTest {
     // language=JSON
     JsonReader reader = newReader("{\n  \"a\": -2\n}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
     try (BufferedSource valueSource = reader.nextSource()) {
-      assertThat(valueSource.readUtf8()).isEqualTo("-2");
+      assertEquals(valueSource.readUtf8(), "-2");
     }
   }
 
@@ -1430,15 +1425,15 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = JsonReader.of(Okio.buffer((Source) stream));
     reader.beginArray();
     BufferedSource source = reader.nextSource();
-    assertThat(source.readUtf8(1)).isEqualTo("\"");
+    assertEquals(source.readUtf8(1), "\"");
     stream.writeUtf8("hello");
-    assertThat(source.readUtf8(5)).isEqualTo("hello");
+    assertEquals(source.readUtf8(5), "hello");
     stream.writeUtf8("world");
-    assertThat(source.readUtf8(5)).isEqualTo("world");
+    assertEquals(source.readUtf8(5), "world");
     stream.writeUtf8("\"");
-    assertThat(source.readUtf8(1)).isEqualTo("\"");
+    assertEquals(source.readUtf8(1), "\"");
     stream.writeUtf8("]");
-    assertThat(source.exhausted()).isTrue();
+    assertTrue(source.exhausted());
     reader.endArray();
   }
 
@@ -1447,9 +1442,9 @@ public final class JsonUtf8ReaderTest {
     // language=JSON
     JsonReader reader = newReader("[\"p\u0065psi\"]");
     reader.beginArray();
-    assertThat(reader.selectName(JsonReader.Options.of("coke"))).isEqualTo(-1);
+    assertEquals(reader.selectName(JsonReader.Options.of("coke")), -1);
     try (BufferedSource valueSource = reader.nextSource()) {
-      assertThat(valueSource.readUtf8()).isEqualTo("\"pepsi\""); // not the original characters!
+      assertEquals(valueSource.readUtf8(), "\"pepsi\""); // not the original characters!
     }
   }
 
@@ -1460,9 +1455,9 @@ public final class JsonUtf8ReaderTest {
     reader.beginObject();
     reader.promoteNameToValue();
     try (BufferedSource valueSource = reader.nextSource()) {
-      assertThat(valueSource.readUtf8()).isEqualTo("\"a\"");
+      assertEquals(valueSource.readUtf8(), "\"a\"");
     }
-    assertThat(reader.nextBoolean()).isEqualTo(true);
+    assertTrue(reader.nextBoolean());
     reader.endObject();
   }
 
@@ -1472,22 +1467,22 @@ public final class JsonUtf8ReaderTest {
     JsonReader reader = newReader("{\"a\":true,\"b\":[],\"c\":false}");
     reader.beginObject();
 
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.getPath()).isEqualTo("$.a");
-    assertThat(reader.nextBoolean()).isTrue();
-    assertThat(reader.getPath()).isEqualTo("$.a");
+    assertEquals(reader.nextName(), "a");
+    assertEquals(reader.getPath(), "$.a");
+    assertTrue(reader.nextBoolean());
+    assertEquals(reader.getPath(), "$.a");
 
-    assertThat(reader.nextName()).isEqualTo("b");
+    assertEquals(reader.nextName(), "b");
     try (BufferedSource valueSource = reader.nextSource()) {
-      assertThat(reader.getPath()).isEqualTo("$.b");
-      assertThat(valueSource.readUtf8()).isEqualTo("[]");
+      assertEquals(reader.getPath(), "$.b");
+      assertEquals(valueSource.readUtf8(), "[]");
     }
-    assertThat(reader.getPath()).isEqualTo("$.b");
+    assertEquals(reader.getPath(), "$.b");
 
-    assertThat(reader.nextName()).isEqualTo("c");
-    assertThat(reader.getPath()).isEqualTo("$.c");
-    assertThat(reader.nextBoolean()).isFalse();
-    assertThat(reader.getPath()).isEqualTo("$.c");
+    assertEquals(reader.nextName(), "c");
+    assertEquals(reader.getPath(), "$.c");
+    assertFalse(reader.nextBoolean());
+    assertEquals(reader.getPath(), "$.c");
     reader.endObject();
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonUtf8WriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonUtf8WriterTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import okio.Buffer;
@@ -59,7 +59,7 @@ public final class JsonUtf8WriterTest {
             + "      \"i\": 9.0\n"
             + "   }\n"
             + "}";
-    assertThat(buffer.readUtf8()).isEqualTo(expected);
+    assertEquals(buffer.readUtf8(), expected);
   }
 
   @Test
@@ -98,7 +98,7 @@ public final class JsonUtf8WriterTest {
             + "      9.0\n"
             + "   ]\n"
             + "]";
-    assertThat(buffer.readUtf8()).isEqualTo(expected);
+    assertEquals(buffer.readUtf8(), expected);
   }
 
   @Test
@@ -110,7 +110,7 @@ public final class JsonUtf8WriterTest {
     writer.name("a").value(2);
     writer.endObject();
     // JsonWriter doesn't attempt to detect duplicate names
-    assertThat(buffer.readUtf8()).isEqualTo("{\"a\":1,\"a\":2}");
+    assertEquals(buffer.readUtf8(), "{\"a\":1,\"a\":2}");
   }
 
   @Test
@@ -127,6 +127,6 @@ public final class JsonUtf8WriterTest {
     writer.name("d");
     writer.value(new Buffer().writeUtf8("null"));
     writer.endObject();
-    assertThat(buffer.readUtf8()).isEqualTo("{\"a\":[\"value\"],\"b\":2,\"c\":3,\"d\":null}");
+    assertEquals(buffer.readUtf8(), "{\"a\":[\"value\"],\"b\":2,\"c\":3,\"d\":null}");
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
@@ -15,11 +15,14 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.moshi.TestUtil.MAX_DEPTH;
 import static com.squareup.moshi.TestUtil.repeat;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -41,31 +44,31 @@ public final class JsonValueReaderTest {
     root.add(null);
     JsonReader reader = new JsonValueReader(root);
 
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.BEGIN_ARRAY);
+    assertTrue(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.BEGIN_ARRAY);
     reader.beginArray();
 
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.STRING);
-    assertThat(reader.nextString()).isEqualTo("s");
+    assertTrue(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.STRING);
+    assertEquals(reader.nextString(), "s");
 
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.NUMBER);
-    assertThat(reader.nextDouble()).isEqualTo(1.5d);
+    assertTrue(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.NUMBER);
+    assertEquals(reader.nextDouble(), 1.5d, 0);
 
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.BOOLEAN);
-    assertThat(reader.nextBoolean()).isEqualTo(true);
+    assertTrue(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.BOOLEAN);
+    assertEquals(reader.nextBoolean(), true);
 
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.NULL);
-    assertThat(reader.<Object>nextNull()).isNull();
+    assertTrue(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.NULL);
+    assertNull(reader.nextNull());
 
-    assertThat(reader.hasNext()).isFalse();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_ARRAY);
+    assertFalse(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.END_ARRAY);
     reader.endArray();
 
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -77,39 +80,39 @@ public final class JsonValueReaderTest {
     root.put("d", null);
     JsonReader reader = new JsonValueReader(root);
 
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.BEGIN_OBJECT);
+    assertTrue(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.BEGIN_OBJECT);
     reader.beginObject();
 
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.NAME);
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.STRING);
-    assertThat(reader.nextString()).isEqualTo("s");
+    assertTrue(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.NAME);
+    assertEquals(reader.nextName(), "a");
+    assertEquals(reader.peek(), JsonReader.Token.STRING);
+    assertEquals(reader.nextString(), "s");
 
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.NAME);
-    assertThat(reader.nextName()).isEqualTo("b");
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.NUMBER);
-    assertThat(reader.nextDouble()).isEqualTo(1.5d);
+    assertTrue(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.NAME);
+    assertEquals(reader.nextName(), "b");
+    assertEquals(reader.peek(), JsonReader.Token.NUMBER);
+    assertEquals(reader.nextDouble(), 1.5d, 0);
 
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.NAME);
-    assertThat(reader.nextName()).isEqualTo("c");
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.BOOLEAN);
-    assertThat(reader.nextBoolean()).isEqualTo(true);
+    assertTrue(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.NAME);
+    assertEquals(reader.nextName(), "c");
+    assertEquals(reader.peek(), JsonReader.Token.BOOLEAN);
+    assertEquals(reader.nextBoolean(), true);
 
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.NAME);
-    assertThat(reader.nextName()).isEqualTo("d");
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.NULL);
-    assertThat(reader.<Object>nextNull()).isNull();
+    assertTrue(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.NAME);
+    assertEquals(reader.nextName(), "d");
+    assertEquals(reader.peek(), JsonReader.Token.NULL);
+    assertNull(reader.nextNull());
 
-    assertThat(reader.hasNext()).isFalse();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_OBJECT);
+    assertFalse(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.END_OBJECT);
     reader.endObject();
 
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -118,51 +121,51 @@ public final class JsonValueReaderTest {
         singletonList(singletonMap("a", singletonList(singletonMap("b", 1.5d))));
     JsonReader reader = new JsonValueReader(root);
 
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.BEGIN_ARRAY);
+    assertTrue(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.BEGIN_ARRAY);
     reader.beginArray();
 
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.BEGIN_OBJECT);
+    assertTrue(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.BEGIN_OBJECT);
     reader.beginObject();
 
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.NAME);
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertTrue(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.NAME);
+    assertEquals(reader.nextName(), "a");
 
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.BEGIN_ARRAY);
+    assertTrue(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.BEGIN_ARRAY);
     reader.beginArray();
 
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.BEGIN_OBJECT);
+    assertTrue(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.BEGIN_OBJECT);
     reader.beginObject();
 
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.NAME);
-    assertThat(reader.nextName()).isEqualTo("b");
+    assertTrue(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.NAME);
+    assertEquals(reader.nextName(), "b");
 
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.NUMBER);
-    assertThat(reader.nextDouble()).isEqualTo(1.5d);
+    assertTrue(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.NUMBER);
+    assertEquals(reader.nextDouble(), 1.5d, 0);
 
-    assertThat(reader.hasNext()).isFalse();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_OBJECT);
+    assertFalse(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.END_OBJECT);
     reader.endObject();
 
-    assertThat(reader.hasNext()).isFalse();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_ARRAY);
+    assertFalse(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.END_ARRAY);
     reader.endArray();
 
-    assertThat(reader.hasNext()).isFalse();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_OBJECT);
+    assertFalse(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.END_OBJECT);
     reader.endObject();
 
-    assertThat(reader.hasNext()).isFalse();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_ARRAY);
+    assertFalse(reader.hasNext());
+    assertEquals(reader.peek(), JsonReader.Token.END_ARRAY);
     reader.endArray();
 
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -172,14 +175,14 @@ public final class JsonValueReaderTest {
     JsonReader reader = new JsonValueReader(root);
     reader.beginObject();
     reader.promoteNameToValue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.STRING);
-    assertThat(reader.nextString()).isEqualTo("a");
+    assertEquals(reader.peek(), JsonReader.Token.STRING);
+    assertEquals(reader.nextString(), "a");
 
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.STRING);
-    assertThat(reader.nextString()).isEqualTo("b");
+    assertEquals(reader.peek(), JsonReader.Token.STRING);
+    assertEquals(reader.nextString(), "b");
     reader.endObject();
 
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -191,9 +194,10 @@ public final class JsonValueReaderTest {
       reader.endArray();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected END_ARRAY but was s, a java.lang.String, at path $[0]");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains("Expected END_ARRAY but was s, a java.lang.String, at path $[0]"));
     }
   }
 
@@ -206,7 +210,7 @@ public final class JsonValueReaderTest {
       reader.endObject();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().startsWith("Expected END_OBJECT but was a=b");
+      assertTrue(expected.getMessage().startsWith("Expected END_OBJECT but was a=b"));
     }
   }
 
@@ -219,9 +223,11 @@ public final class JsonValueReaderTest {
       reader.peek();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected a JSON value but was x, a java.lang.StringBuilder, at path $[0]");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains(
+                  "Expected a JSON value but was x, a java.lang.StringBuilder, at path $[0]"));
     }
   }
 
@@ -234,9 +240,8 @@ public final class JsonValueReaderTest {
       reader.nextName();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected NAME but was x, a java.lang.StringBuilder, at path $.");
+      assertEquals(
+          "Expected NAME but was x, a java.lang.StringBuilder, at path $.", expected.getMessage());
     }
   }
 
@@ -249,7 +254,7 @@ public final class JsonValueReaderTest {
       reader.nextName();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected NAME but was null at path $.");
+      assertEquals("Expected NAME but was null at path $.", expected.getMessage());
     }
   }
 
@@ -261,9 +266,9 @@ public final class JsonValueReaderTest {
       reader.nextInt();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]");
+      assertEquals(
+          "Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]",
+          expected.getMessage());
     }
   }
 
@@ -275,9 +280,9 @@ public final class JsonValueReaderTest {
       reader.nextLong();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]");
+      assertEquals(
+          "Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]",
+          expected.getMessage());
     }
   }
 
@@ -289,9 +294,9 @@ public final class JsonValueReaderTest {
       reader.nextDouble();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]");
+      assertEquals(
+          "Expected NUMBER but was 1, a java.lang.StringBuilder, at path $[0]",
+          expected.getMessage());
     }
   }
 
@@ -303,9 +308,9 @@ public final class JsonValueReaderTest {
       reader.nextString();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected STRING but was s, a java.lang.StringBuilder, at path $[0]");
+      assertEquals(
+          "Expected STRING but was s, a java.lang.StringBuilder, at path $[0]",
+          expected.getMessage());
     }
   }
 
@@ -317,9 +322,9 @@ public final class JsonValueReaderTest {
       reader.nextBoolean();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected BOOLEAN but was true, a java.lang.StringBuilder, at path $[0]");
+      assertEquals(
+          "Expected BOOLEAN but was true, a java.lang.StringBuilder, at path $[0]",
+          expected.getMessage());
     }
   }
 
@@ -331,9 +336,9 @@ public final class JsonValueReaderTest {
       reader.nextNull();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected NULL but was null, a java.lang.StringBuilder, at path $[0]");
+      assertEquals(
+          "Expected NULL but was null, a java.lang.StringBuilder, at path $[0]",
+          expected.getMessage());
     }
   }
 
@@ -341,7 +346,7 @@ public final class JsonValueReaderTest {
   public void skipRoot() throws Exception {
     JsonReader reader = new JsonValueReader(singletonList(new StringBuilder("x")));
     reader.skipValue();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
@@ -354,14 +359,14 @@ public final class JsonValueReaderTest {
 
     reader.beginArray();
 
-    assertThat(reader.getPath()).isEqualTo("$[0]");
-    assertThat(reader.nextString()).isEqualTo("a");
+    assertEquals(reader.getPath(), "$[0]");
+    assertEquals(reader.nextString(), "a");
 
-    assertThat(reader.getPath()).isEqualTo("$[1]");
+    assertEquals(reader.getPath(), "$[1]");
     reader.skipValue();
 
-    assertThat(reader.getPath()).isEqualTo("$[2]");
-    assertThat(reader.nextString()).isEqualTo("c");
+    assertEquals(reader.getPath(), "$[2]");
+    assertEquals(reader.nextString(), "c");
 
     reader.endArray();
   }
@@ -376,20 +381,20 @@ public final class JsonValueReaderTest {
 
     reader.beginObject();
 
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.getPath()).isEqualTo("$.a");
-    assertThat(reader.nextString()).isEqualTo("s");
-    assertThat(reader.getPath()).isEqualTo("$.a");
+    assertEquals(reader.nextName(), "a");
+    assertEquals(reader.getPath(), "$.a");
+    assertEquals(reader.nextString(), "s");
+    assertEquals(reader.getPath(), "$.a");
 
     reader.skipValue();
-    assertThat(reader.getPath()).isEqualTo("$.null");
-    assertThat(reader.nextDouble()).isEqualTo(1.5d);
-    assertThat(reader.getPath()).isEqualTo("$.null");
+    assertEquals(reader.getPath(), "$.null");
+    assertEquals(reader.nextDouble(), 1.5d, 0);
+    assertEquals(reader.getPath(), "$.null");
 
-    assertThat(reader.nextName()).isEqualTo("c");
-    assertThat(reader.getPath()).isEqualTo("$.c");
-    assertThat(reader.nextBoolean()).isEqualTo(true);
-    assertThat(reader.getPath()).isEqualTo("$.c");
+    assertEquals(reader.nextName(), "c");
+    assertEquals(reader.getPath(), "$.c");
+    assertEquals(reader.nextBoolean(), true);
+    assertEquals(reader.getPath(), "$.c");
 
     reader.endObject();
   }
@@ -404,20 +409,20 @@ public final class JsonValueReaderTest {
 
     reader.beginObject();
 
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.getPath()).isEqualTo("$.a");
-    assertThat(reader.nextString()).isEqualTo("s");
-    assertThat(reader.getPath()).isEqualTo("$.a");
+    assertEquals(reader.nextName(), "a");
+    assertEquals(reader.getPath(), "$.a");
+    assertEquals(reader.nextString(), "s");
+    assertEquals(reader.getPath(), "$.a");
 
-    assertThat(reader.nextName()).isEqualTo("b");
-    assertThat(reader.getPath()).isEqualTo("$.b");
+    assertEquals(reader.nextName(), "b");
+    assertEquals(reader.getPath(), "$.b");
     reader.skipValue();
-    assertThat(reader.getPath()).isEqualTo("$.null");
+    assertEquals(reader.getPath(), "$.null");
 
-    assertThat(reader.nextName()).isEqualTo("c");
-    assertThat(reader.getPath()).isEqualTo("$.c");
-    assertThat(reader.nextBoolean()).isEqualTo(true);
-    assertThat(reader.getPath()).isEqualTo("$.c");
+    assertEquals(reader.nextName(), "c");
+    assertEquals(reader.getPath(), "$.c");
+    assertEquals(reader.nextBoolean(), true);
+    assertEquals(reader.getPath(), "$.c");
 
     reader.endObject();
   }
@@ -432,7 +437,7 @@ public final class JsonValueReaderTest {
       reader.skipValue();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Cannot skip unexpected STRING at $[0]");
+      assertEquals("Cannot skip unexpected STRING at $[0]", expected.getMessage());
     }
   }
 
@@ -461,12 +466,12 @@ public final class JsonValueReaderTest {
     JsonReader reader =
         new JsonValueReader(Arrays.asList(0, 9223372036854775807L, 2.5d, 3.01f, "a", "5"));
     reader.beginArray();
-    assertThat(reader.nextString()).isEqualTo("0");
-    assertThat(reader.nextString()).isEqualTo("9223372036854775807");
-    assertThat(reader.nextString()).isEqualTo("2.5");
-    assertThat(reader.nextString()).isEqualTo("3.01");
-    assertThat(reader.nextString()).isEqualTo("a");
-    assertThat(reader.nextString()).isEqualTo("5");
+    assertEquals(reader.nextString(), "0");
+    assertEquals(reader.nextString(), "9223372036854775807");
+    assertEquals(reader.nextString(), "2.5");
+    assertEquals(reader.nextString(), "3.01");
+    assertEquals(reader.nextString(), "a");
+    assertEquals(reader.nextString(), "5");
     reader.endArray();
   }
 
@@ -484,9 +489,7 @@ public final class JsonValueReaderTest {
       reader.beginArray();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Nesting too deep at $" + repeat("[0]", MAX_DEPTH + 1));
+      assertEquals("Nesting too deep at $" + repeat("[0]", MAX_DEPTH + 1), expected.getMessage());
     }
   }
 
@@ -499,15 +502,13 @@ public final class JsonValueReaderTest {
     JsonReader reader = new JsonValueReader(root);
     for (int i = 0; i < MAX_DEPTH; i++) {
       reader.beginObject();
-      assertThat(reader.nextName()).isEqualTo("a");
+      assertEquals(reader.nextName(), "a");
     }
     try {
       reader.beginObject();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Nesting too deep at $" + repeat(".a", MAX_DEPTH) + ".");
+      assertEquals("Nesting too deep at $" + repeat(".a", MAX_DEPTH) + ".", expected.getMessage());
     }
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueSourceTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueSourceTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.io.EOFException;
@@ -26,33 +26,34 @@ import org.junit.Test;
 public final class JsonValueSourceTest {
   @Test
   public void simpleValues() throws IOException {
-    assertThat(jsonPrefix("{\"hello\": \"world\"}, 1, 2, 3")).isEqualTo("{\"hello\": \"world\"}");
-    assertThat(jsonPrefix("['hello', 'world'], 1, 2, 3")).isEqualTo("['hello', 'world']");
-    assertThat(jsonPrefix("\"hello\", 1, 2, 3")).isEqualTo("\"hello\"");
+    assertEquals(jsonPrefix("{\"hello\": \"world\"}, 1, 2, 3"), "{\"hello\": \"world\"}");
+    assertEquals(jsonPrefix("['hello', 'world'], 1, 2, 3"), "['hello', 'world']");
+    assertEquals(jsonPrefix("\"hello\", 1, 2, 3"), "\"hello\"");
   }
 
   @Test
   public void braceMatching() throws IOException {
-    assertThat(jsonPrefix("[{},{},[],[{}]],[]")).isEqualTo("[{},{},[],[{}]]");
-    assertThat(jsonPrefix("[\"a\",{\"b\":{\"c\":{\"d\":[\"e\"]}}}],[]"))
-        .isEqualTo("[\"a\",{\"b\":{\"c\":{\"d\":[\"e\"]}}}]");
+    assertEquals(jsonPrefix("[{},{},[],[{}]],[]"), "[{},{},[],[{}]]");
+    assertEquals(
+        jsonPrefix("[\"a\",{\"b\":{\"c\":{\"d\":[\"e\"]}}}],[]"),
+        "[\"a\",{\"b\":{\"c\":{\"d\":[\"e\"]}}}]");
   }
 
   @Test
   public void stringEscapes() throws IOException {
-    assertThat(jsonPrefix("[\"12\\u00334\"],[]")).isEqualTo("[\"12\\u00334\"]");
-    assertThat(jsonPrefix("[\"12\\n34\"],[]")).isEqualTo("[\"12\\n34\"]");
-    assertThat(jsonPrefix("[\"12\\\"34\"],[]")).isEqualTo("[\"12\\\"34\"]");
-    assertThat(jsonPrefix("[\"12\\'34\"],[]")).isEqualTo("[\"12\\'34\"]");
-    assertThat(jsonPrefix("[\"12\\\\34\"],[]")).isEqualTo("[\"12\\\\34\"]");
-    assertThat(jsonPrefix("[\"12\\\\\"],[]")).isEqualTo("[\"12\\\\\"]");
+    assertEquals(jsonPrefix("[\"12\\u00334\"],[]"), "[\"12\\u00334\"]");
+    assertEquals(jsonPrefix("[\"12\\n34\"],[]"), "[\"12\\n34\"]");
+    assertEquals(jsonPrefix("[\"12\\\"34\"],[]"), "[\"12\\\"34\"]");
+    assertEquals(jsonPrefix("[\"12\\'34\"],[]"), "[\"12\\'34\"]");
+    assertEquals(jsonPrefix("[\"12\\\\34\"],[]"), "[\"12\\\\34\"]");
+    assertEquals(jsonPrefix("[\"12\\\\\"],[]"), "[\"12\\\\\"]");
   }
 
   @Test
   public void bracesInStrings() throws IOException {
-    assertThat(jsonPrefix("[\"]\"],[]")).isEqualTo("[\"]\"]");
-    assertThat(jsonPrefix("[\"\\]\"],[]")).isEqualTo("[\"\\]\"]");
-    assertThat(jsonPrefix("[\"\\[\"],[]")).isEqualTo("[\"\\[\"]");
+    assertEquals(jsonPrefix("[\"]\"],[]"), "[\"]\"]");
+    assertEquals(jsonPrefix("[\"\\]\"],[]"), "[\"\\]\"]");
+    assertEquals(jsonPrefix("[\"\\[\"],[]"), "[\"\\[\"]");
   }
 
   @Test
@@ -122,30 +123,30 @@ public final class JsonValueSourceTest {
 
   @Test
   public void lenientSingleQuotedStrings() throws IOException {
-    assertThat(jsonPrefix("['hello', 'world'], 1, 2, 3")).isEqualTo("['hello', 'world']");
-    assertThat(jsonPrefix("'abc\\'', 123")).isEqualTo("'abc\\''");
+    assertEquals(jsonPrefix("['hello', 'world'], 1, 2, 3"), "['hello', 'world']");
+    assertEquals(jsonPrefix("'abc\\'', 123"), "'abc\\''");
   }
 
   @Test
   public void lenientCStyleComments() throws IOException {
-    assertThat(jsonPrefix("[\"a\"/* \"b\" */,\"c\"],[]")).isEqualTo("[\"a\"/* \"b\" */,\"c\"]");
-    assertThat(jsonPrefix("[\"a\"/*]*/],[]")).isEqualTo("[\"a\"/*]*/]");
-    assertThat(jsonPrefix("[\"a\"/**/],[]")).isEqualTo("[\"a\"/**/]");
-    assertThat(jsonPrefix("[\"a\"/*/ /*/],[]")).isEqualTo("[\"a\"/*/ /*/]");
-    assertThat(jsonPrefix("[\"a\"/*/ **/],[]")).isEqualTo("[\"a\"/*/ **/]");
+    assertEquals(jsonPrefix("[\"a\"/* \"b\" */,\"c\"],[]"), "[\"a\"/* \"b\" */,\"c\"]");
+    assertEquals(jsonPrefix("[\"a\"/*]*/],[]"), "[\"a\"/*]*/]");
+    assertEquals(jsonPrefix("[\"a\"/**/],[]"), "[\"a\"/**/]");
+    assertEquals(jsonPrefix("[\"a\"/*/ /*/],[]"), "[\"a\"/*/ /*/]");
+    assertEquals(jsonPrefix("[\"a\"/*/ **/],[]"), "[\"a\"/*/ **/]");
   }
 
   @Test
   public void lenientEndOfLineComments() throws IOException {
-    assertThat(jsonPrefix("[\"a\"// \"b\" \n,\"c\"],[]")).isEqualTo("[\"a\"// \"b\" \n,\"c\"]");
-    assertThat(jsonPrefix("[\"a\"// \"b\" \r\n,\"c\"],[]")).isEqualTo("[\"a\"// \"b\" \r\n,\"c\"]");
-    assertThat(jsonPrefix("[\"a\"// \"b\" \r,\"c\"],[]")).isEqualTo("[\"a\"// \"b\" \r,\"c\"]");
-    assertThat(jsonPrefix("[\"a\"//]\r\n\"c\"],[]")).isEqualTo("[\"a\"//]\r\n\"c\"]");
+    assertEquals(jsonPrefix("[\"a\"// \"b\" \n,\"c\"],[]"), "[\"a\"// \"b\" \n,\"c\"]");
+    assertEquals(jsonPrefix("[\"a\"// \"b\" \r\n,\"c\"],[]"), "[\"a\"// \"b\" \r\n,\"c\"]");
+    assertEquals(jsonPrefix("[\"a\"// \"b\" \r,\"c\"],[]"), "[\"a\"// \"b\" \r,\"c\"]");
+    assertEquals(jsonPrefix("[\"a\"//]\r\n\"c\"],[]"), "[\"a\"//]\r\n\"c\"]");
   }
 
   @Test
   public void lenientSlashInToken() throws IOException {
-    assertThat(jsonPrefix("{a/b:\"c\"},[]")).isEqualTo("{a/b:\"c\"}");
+    assertEquals(jsonPrefix("{a/b:\"c\"},[]"), "{a/b:\"c\"}");
   }
 
   @Test
@@ -185,7 +186,7 @@ public final class JsonValueSourceTest {
     jsonValueSource.close();
     jsonValueSource.discard();
 
-    assertThat(allData.readUtf8()).isEqualTo(",[\"d\", \"e\"]");
+    assertEquals(allData.readUtf8(), ",[\"d\", \"e\"]");
   }
 
   private String jsonPrefix(String string) throws IOException {
@@ -197,7 +198,7 @@ public final class JsonValueSourceTest {
 
     String result = jsonPrefixBuffer.readUtf8();
     String remainder = allData.readUtf8();
-    assertThat(result + remainder).isEqualTo(string);
+    assertEquals(result + remainder, string);
 
     return result;
   }

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueWriterTest.java
@@ -15,8 +15,9 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
 import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -42,8 +43,11 @@ public final class JsonValueWriterTest {
     writer.value(true);
     writer.nullValue();
     writer.endArray();
-
-    assertThat((List<Object>) writer.root()).containsExactly("s", 1.5d, true, null);
+    List<Object> values = (List<Object>) writer.root();
+    assertEquals("s", values.get(0));
+    assertEquals(1.5d, values.get(1));
+    assertEquals(true, values.get(2));
+    assertEquals(null, values.get(3));
   }
 
   @Test
@@ -57,9 +61,19 @@ public final class JsonValueWriterTest {
     writer.name("c").value(true);
     writer.name("d").nullValue();
     writer.endObject();
+    Map<String, Object> valuesMap = (Map<String, Object>) writer.root();
 
-    assertThat((Map<String, Object>) writer.root())
-        .containsExactly("a", "s", "b", 1.5d, "c", true, "d", null);
+    List<String> keys = Arrays.asList("a", "b", "c", "d");
+    List<Object> values = Arrays.asList("s", 1.5d, true, null);
+
+    assertEquals("s", valuesMap.get("a"));
+    assertEquals(1.5d, valuesMap.get("b"));
+    assertEquals(true, valuesMap.get("c"));
+    assertEquals(null, valuesMap.get("d"));
+    assertTrue(valuesMap.keySet().containsAll(keys));
+    assertTrue(keys.containsAll(valuesMap.keySet()));
+    assertTrue(values.containsAll(valuesMap.values()));
+    assertTrue(valuesMap.values().containsAll(values));
   }
 
   @Test
@@ -71,14 +85,12 @@ public final class JsonValueWriterTest {
       writer.name("a").value(2L);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Map key 'a' has multiple values at path $.a: 1 and 2");
+      assertEquals("Map key 'a' has multiple values at path $.a: 1 and 2", expected.getMessage());
     }
   }
 
   @Test
-  public void valueLongEmitsLong() throws Exception {
+  public void valueLongEmitsLong() {
     JsonValueWriter writer = new JsonValueWriter();
     writer.beginArray();
     writer.value(Long.MIN_VALUE);
@@ -88,8 +100,8 @@ public final class JsonValueWriterTest {
     writer.value(Long.MAX_VALUE);
     writer.endArray();
 
-    List<Number> numbers = Arrays.<Number>asList(Long.MIN_VALUE, -1L, 0L, 1L, Long.MAX_VALUE);
-    assertThat((List<?>) writer.root()).isEqualTo(numbers);
+    List<Number> numbers = Arrays.asList(Long.MIN_VALUE, -1L, 0L, 1L, Long.MAX_VALUE);
+    assertEquals(writer.root(), numbers);
   }
 
   @Test
@@ -145,7 +157,7 @@ public final class JsonValueWriterTest {
             Double.MAX_VALUE,
             Double.POSITIVE_INFINITY,
             Double.NaN);
-    assertThat((List<?>) writer.root()).isEqualTo(numbers);
+    assertEquals((List<?>) writer.root(), numbers);
   }
 
   @Test
@@ -158,9 +170,8 @@ public final class JsonValueWriterTest {
     writer.value(Long.valueOf(Long.MIN_VALUE));
     writer.endArray();
 
-    List<Number> numbers =
-        Arrays.<Number>asList(-128L, -32768L, -2147483648L, -9223372036854775808L);
-    assertThat((List<?>) writer.root()).isEqualTo(numbers);
+    List<Number> numbers = Arrays.asList(-128L, -32768L, -2147483648L, -9223372036854775808L);
+    assertEquals(writer.root(), numbers);
   }
 
   @Test
@@ -171,8 +182,8 @@ public final class JsonValueWriterTest {
     writer.value(Double.valueOf(0.5d));
     writer.endArray();
 
-    List<Number> numbers = Arrays.<Number>asList(0.5d, 0.5d);
-    assertThat((List<?>) writer.root()).isEqualTo(numbers);
+    List<Number> numbers = Arrays.asList(0.5d, 0.5d);
+    assertEquals(writer.root(), numbers);
   }
 
   @Test
@@ -221,7 +232,7 @@ public final class JsonValueWriterTest {
             new BigDecimal("0.5"),
             new BigDecimal("100000e15"),
             new BigDecimal("0.0000100e-10"));
-    assertThat((List<?>) writer.root()).isEqualTo(numbers);
+    assertEquals((List<?>) writer.root(), numbers);
   }
 
   @Test
@@ -235,12 +246,12 @@ public final class JsonValueWriterTest {
     writer.endArray();
 
     List<Number> numbers =
-        Arrays.<Number>asList(
+        Arrays.asList(
             new BigDecimal("-9223372036854775809"),
             new BigDecimal("-9223372036854775808"),
             new BigDecimal("0.5"),
             new BigDecimal("1.0"));
-    assertThat((List<?>) writer.root()).isEqualTo(numbers);
+    assertEquals(writer.root(), numbers);
   }
 
   @Test
@@ -256,8 +267,20 @@ public final class JsonValueWriterTest {
     writer.name("d");
     writer.value(new Buffer().writeUtf8("null"));
     writer.endObject();
-    assertThat((Map<String, Object>) writer.root())
-        .containsExactly("a", singletonList("value"), "b", 2.0d, "c", 3L, "d", null);
+
+    Map<String, Object> valuesMap = (Map<String, Object>) writer.root();
+
+    List<String> keys = Arrays.asList("a", "b", "c", "d");
+    List<Object> values = Arrays.asList(singletonList("value"), 2.0d, 3L, null);
+
+    assertEquals(singletonList("value"), valuesMap.get("a"));
+    assertEquals(2.0d, valuesMap.get("b"));
+    assertEquals(3L, valuesMap.get("c"));
+    assertEquals(null, valuesMap.get("d"));
+    assertTrue(valuesMap.keySet().containsAll(keys));
+    assertTrue(keys.containsAll(valuesMap.keySet()));
+    assertTrue(values.containsAll(valuesMap.values()));
+    assertTrue(valuesMap.values().containsAll(values));
   }
 
   /**

--- a/moshi/src/test/java/com/squareup/moshi/JsonWriterPathTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonWriterPathTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
@@ -39,173 +39,173 @@ public final class JsonWriterPathTest {
   @Test
   public void path() throws IOException {
     JsonWriter writer = factory.newWriter();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
     writer.beginObject();
-    assertThat(writer.getPath()).isEqualTo("$.");
+    assertEquals(writer.getPath(), "$.");
     writer.name("a");
-    assertThat(writer.getPath()).isEqualTo("$.a");
+    assertEquals(writer.getPath(), "$.a");
     writer.beginArray();
-    assertThat(writer.getPath()).isEqualTo("$.a[0]");
+    assertEquals(writer.getPath(), "$.a[0]");
     writer.value(2);
-    assertThat(writer.getPath()).isEqualTo("$.a[1]");
+    assertEquals(writer.getPath(), "$.a[1]");
     writer.value(true);
-    assertThat(writer.getPath()).isEqualTo("$.a[2]");
+    assertEquals(writer.getPath(), "$.a[2]");
     writer.value(false);
-    assertThat(writer.getPath()).isEqualTo("$.a[3]");
+    assertEquals(writer.getPath(), "$.a[3]");
     writer.nullValue();
-    assertThat(writer.getPath()).isEqualTo("$.a[4]");
+    assertEquals(writer.getPath(), "$.a[4]");
     writer.value("b");
-    assertThat(writer.getPath()).isEqualTo("$.a[5]");
+    assertEquals(writer.getPath(), "$.a[5]");
     writer.beginObject();
-    assertThat(writer.getPath()).isEqualTo("$.a[5].");
+    assertEquals(writer.getPath(), "$.a[5].");
     writer.name("c");
-    assertThat(writer.getPath()).isEqualTo("$.a[5].c");
+    assertEquals(writer.getPath(), "$.a[5].c");
     writer.value("d");
-    assertThat(writer.getPath()).isEqualTo("$.a[5].c");
+    assertEquals(writer.getPath(), "$.a[5].c");
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$.a[6]");
+    assertEquals(writer.getPath(), "$.a[6]");
     writer.beginArray();
-    assertThat(writer.getPath()).isEqualTo("$.a[6][0]");
+    assertEquals(writer.getPath(), "$.a[6][0]");
     writer.value(3);
-    assertThat(writer.getPath()).isEqualTo("$.a[6][1]");
+    assertEquals(writer.getPath(), "$.a[6][1]");
     writer.endArray();
-    assertThat(writer.getPath()).isEqualTo("$.a[7]");
+    assertEquals(writer.getPath(), "$.a[7]");
     writer.endArray();
-    assertThat(writer.getPath()).isEqualTo("$.a");
+    assertEquals(writer.getPath(), "$.a");
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
   }
 
   @Test
   public void arrayOfObjects() throws IOException {
     JsonWriter writer = factory.newWriter();
     writer.beginArray();
-    assertThat(writer.getPath()).isEqualTo("$[0]");
+    assertEquals(writer.getPath(), "$[0]");
     writer.beginObject();
-    assertThat(writer.getPath()).isEqualTo("$[0].");
+    assertEquals(writer.getPath(), "$[0].");
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$[1]");
+    assertEquals(writer.getPath(), "$[1]");
     writer.beginObject();
-    assertThat(writer.getPath()).isEqualTo("$[1].");
+    assertEquals(writer.getPath(), "$[1].");
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$[2]");
+    assertEquals(writer.getPath(), "$[2]");
     writer.beginObject();
-    assertThat(writer.getPath()).isEqualTo("$[2].");
+    assertEquals(writer.getPath(), "$[2].");
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$[3]");
+    assertEquals(writer.getPath(), "$[3]");
     writer.endArray();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
   }
 
   @Test
   public void arrayOfArrays() throws IOException {
     JsonWriter writer = factory.newWriter();
     writer.beginArray();
-    assertThat(writer.getPath()).isEqualTo("$[0]");
+    assertEquals(writer.getPath(), "$[0]");
     writer.beginArray();
-    assertThat(writer.getPath()).isEqualTo("$[0][0]");
+    assertEquals(writer.getPath(), "$[0][0]");
     writer.endArray();
-    assertThat(writer.getPath()).isEqualTo("$[1]");
+    assertEquals(writer.getPath(), "$[1]");
     writer.beginArray();
-    assertThat(writer.getPath()).isEqualTo("$[1][0]");
+    assertEquals(writer.getPath(), "$[1][0]");
     writer.endArray();
-    assertThat(writer.getPath()).isEqualTo("$[2]");
+    assertEquals(writer.getPath(), "$[2]");
     writer.beginArray();
-    assertThat(writer.getPath()).isEqualTo("$[2][0]");
+    assertEquals(writer.getPath(), "$[2][0]");
     writer.endArray();
-    assertThat(writer.getPath()).isEqualTo("$[3]");
+    assertEquals(writer.getPath(), "$[3]");
     writer.endArray();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
   }
 
   @Test
   public void objectPath() throws IOException {
     JsonWriter writer = factory.newWriter();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
     writer.beginObject();
-    assertThat(writer.getPath()).isEqualTo("$.");
+    assertEquals(writer.getPath(), "$.");
     writer.name("a");
-    assertThat(writer.getPath()).isEqualTo("$.a");
+    assertEquals(writer.getPath(), "$.a");
     writer.value(1);
-    assertThat(writer.getPath()).isEqualTo("$.a");
+    assertEquals(writer.getPath(), "$.a");
     writer.name("b");
-    assertThat(writer.getPath()).isEqualTo("$.b");
+    assertEquals(writer.getPath(), "$.b");
     writer.value(2);
-    assertThat(writer.getPath()).isEqualTo("$.b");
+    assertEquals(writer.getPath(), "$.b");
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
     writer.close();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
   }
 
   @Test
   public void nestedObjects() throws IOException {
     JsonWriter writer = factory.newWriter();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
     writer.beginObject();
-    assertThat(writer.getPath()).isEqualTo("$.");
+    assertEquals(writer.getPath(), "$.");
     writer.name("a");
-    assertThat(writer.getPath()).isEqualTo("$.a");
+    assertEquals(writer.getPath(), "$.a");
     writer.beginObject();
-    assertThat(writer.getPath()).isEqualTo("$.a.");
+    assertEquals(writer.getPath(), "$.a.");
     writer.name("b");
-    assertThat(writer.getPath()).isEqualTo("$.a.b");
+    assertEquals(writer.getPath(), "$.a.b");
     writer.beginObject();
-    assertThat(writer.getPath()).isEqualTo("$.a.b.");
+    assertEquals(writer.getPath(), "$.a.b.");
     writer.name("c");
-    assertThat(writer.getPath()).isEqualTo("$.a.b.c");
+    assertEquals(writer.getPath(), "$.a.b.c");
     writer.nullValue();
-    assertThat(writer.getPath()).isEqualTo("$.a.b.c");
+    assertEquals(writer.getPath(), "$.a.b.c");
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$.a.b");
+    assertEquals(writer.getPath(), "$.a.b");
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$.a");
+    assertEquals(writer.getPath(), "$.a");
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
   }
 
   @Test
   public void arrayPath() throws IOException {
     JsonWriter writer = factory.newWriter();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
     writer.beginArray();
-    assertThat(writer.getPath()).isEqualTo("$[0]");
+    assertEquals(writer.getPath(), "$[0]");
     writer.value(1);
-    assertThat(writer.getPath()).isEqualTo("$[1]");
+    assertEquals(writer.getPath(), "$[1]");
     writer.value(true);
-    assertThat(writer.getPath()).isEqualTo("$[2]");
+    assertEquals(writer.getPath(), "$[2]");
     writer.value("a");
-    assertThat(writer.getPath()).isEqualTo("$[3]");
+    assertEquals(writer.getPath(), "$[3]");
     writer.value(5.5d);
-    assertThat(writer.getPath()).isEqualTo("$[4]");
+    assertEquals(writer.getPath(), "$[4]");
     writer.value(BigInteger.ONE);
-    assertThat(writer.getPath()).isEqualTo("$[5]");
+    assertEquals(writer.getPath(), "$[5]");
     writer.endArray();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
     writer.close();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
   }
 
   @Test
   public void nestedArrays() throws IOException {
     JsonWriter writer = factory.newWriter();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
     writer.beginArray();
-    assertThat(writer.getPath()).isEqualTo("$[0]");
+    assertEquals(writer.getPath(), "$[0]");
     writer.beginArray();
-    assertThat(writer.getPath()).isEqualTo("$[0][0]");
+    assertEquals(writer.getPath(), "$[0][0]");
     writer.beginArray();
-    assertThat(writer.getPath()).isEqualTo("$[0][0][0]");
+    assertEquals(writer.getPath(), "$[0][0][0]");
     writer.nullValue();
-    assertThat(writer.getPath()).isEqualTo("$[0][0][1]");
+    assertEquals(writer.getPath(), "$[0][0][1]");
     writer.endArray();
-    assertThat(writer.getPath()).isEqualTo("$[0][1]");
+    assertEquals(writer.getPath(), "$[0][1]");
     writer.endArray();
-    assertThat(writer.getPath()).isEqualTo("$[1]");
+    assertEquals(writer.getPath(), "$[1]");
     writer.endArray();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
     writer.close();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
   }
 
   @Test
@@ -216,28 +216,28 @@ public final class JsonWriterPathTest {
     writer.setLenient(true);
     writer.beginArray();
     writer.endArray();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
     writer.beginArray();
     writer.endArray();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
   }
 
   @Test
   public void skipNulls() throws IOException {
     JsonWriter writer = factory.newWriter();
     writer.setSerializeNulls(false);
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
     writer.beginObject();
-    assertThat(writer.getPath()).isEqualTo("$.");
+    assertEquals(writer.getPath(), "$.");
     writer.name("a");
-    assertThat(writer.getPath()).isEqualTo("$.a");
+    assertEquals(writer.getPath(), "$.a");
     writer.nullValue();
-    assertThat(writer.getPath()).isEqualTo("$.a");
+    assertEquals(writer.getPath(), "$.a");
     writer.name("b");
-    assertThat(writer.getPath()).isEqualTo("$.b");
+    assertEquals(writer.getPath(), "$.b");
     writer.nullValue();
-    assertThat(writer.getPath()).isEqualTo("$.b");
+    assertEquals(writer.getPath(), "$.b");
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$");
+    assertEquals(writer.getPath(), "$");
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonWriterTest.java
@@ -15,9 +15,11 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.moshi.TestUtil.MAX_DEPTH;
 import static com.squareup.moshi.TestUtil.repeat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
@@ -53,7 +55,7 @@ public final class JsonWriterTest {
     writer.nullValue();
     writer.endObject();
     writer.close();
-    assertThat(factory.json()).isEqualTo("{}");
+    assertEquals(factory.json(), "{}");
   }
 
   @Test
@@ -65,7 +67,7 @@ public final class JsonWriterTest {
     writer.nullValue();
     writer.endObject();
     writer.close();
-    assertThat(factory.json()).isEqualTo("{\"a\":null}");
+    assertEquals(factory.json(), "{\"a\":null}");
   }
 
   @Test
@@ -73,7 +75,7 @@ public final class JsonWriterTest {
     JsonWriter writer = factory.newWriter();
     writer.value(true);
     writer.close();
-    assertThat(factory.json()).isEqualTo("true");
+    assertEquals(factory.json(), "true");
   }
 
   @Test
@@ -81,7 +83,7 @@ public final class JsonWriterTest {
     JsonWriter writer = factory.newWriter();
     writer.nullValue();
     writer.close();
-    assertThat(factory.json()).isEqualTo("null");
+    assertEquals(factory.json(), "null");
   }
 
   @Test
@@ -89,7 +91,7 @@ public final class JsonWriterTest {
     JsonWriter writer = factory.newWriter();
     writer.value(123);
     writer.close();
-    assertThat(factory.json()).isEqualTo("123");
+    assertEquals(factory.json(), "123");
   }
 
   @Test
@@ -97,7 +99,7 @@ public final class JsonWriterTest {
     JsonWriter writer = factory.newWriter();
     writer.value(123.4);
     writer.close();
-    assertThat(factory.json()).isEqualTo("123.4");
+    assertEquals(factory.json(), "123.4");
   }
 
   @Test
@@ -105,7 +107,7 @@ public final class JsonWriterTest {
     JsonWriter writer = factory.newWriter();
     writer.value("a");
     writer.close();
-    assertThat(factory.json()).isEqualTo("\"a\"");
+    assertEquals(factory.json(), "\"a\"");
   }
 
   @Test
@@ -207,7 +209,7 @@ public final class JsonWriterTest {
     writer.name("a");
     writer.value((String) null);
     writer.endObject();
-    assertThat(factory.json()).isEqualTo("{\"a\":null}");
+    assertEquals(factory.json(), "{\"a\":null}");
   }
 
   @Test
@@ -267,17 +269,17 @@ public final class JsonWriterTest {
     writer.value(Math.E);
     writer.endArray();
     writer.close();
-    assertThat(factory.json())
-        .isEqualTo(
-            "[-0.0,"
-                + "1.0,"
-                + "1.7976931348623157E308,"
-                + "4.9E-324,"
-                + "0.0,"
-                + "-0.5,"
-                + "2.2250738585072014E-308,"
-                + "3.141592653589793,"
-                + "2.718281828459045]");
+    assertEquals(
+        factory.json(),
+        "[-0.0,"
+            + "1.0,"
+            + "1.7976931348623157E308,"
+            + "4.9E-324,"
+            + "0.0,"
+            + "-0.5,"
+            + "2.2250738585072014E-308,"
+            + "3.141592653589793,"
+            + "2.718281828459045]");
   }
 
   @Test
@@ -291,8 +293,8 @@ public final class JsonWriterTest {
     writer.value(Long.MAX_VALUE);
     writer.endArray();
     writer.close();
-    assertThat(factory.json())
-        .isEqualTo("[0," + "1," + "-1," + "-9223372036854775808," + "9223372036854775807]");
+    assertEquals(
+        factory.json(), "[0," + "1," + "-1," + "-9223372036854775808," + "9223372036854775807]");
   }
 
   @Test
@@ -307,12 +309,12 @@ public final class JsonWriterTest {
     writer.value(new BigDecimal("3.141592653589793238462643383"));
     writer.endArray();
     writer.close();
-    assertThat(factory.json())
-        .isEqualTo(
-            "[0,"
-                + "9223372036854775808,"
-                + "-9223372036854775809,"
-                + "3.141592653589793238462643383]");
+    assertEquals(
+        factory.json(),
+        "[0,"
+            + "9223372036854775808,"
+            + "-9223372036854775809,"
+            + "3.141592653589793238462643383]");
   }
 
   @Test
@@ -322,7 +324,7 @@ public final class JsonWriterTest {
     writer.value((Number) null);
     writer.endArray();
     writer.close();
-    assertThat(factory.json()).isEqualTo("[null]");
+    assertEquals(factory.json(), "[null]");
   }
 
   @Test
@@ -332,7 +334,7 @@ public final class JsonWriterTest {
     writer.value(true);
     writer.value(false);
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[true,false]");
+    assertEquals(factory.json(), "[true,false]");
   }
 
   @Test
@@ -343,7 +345,7 @@ public final class JsonWriterTest {
     writer.value((Boolean) false);
     writer.value((Boolean) null);
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[true,false,null]");
+    assertEquals(factory.json(), "[true,false,null]");
   }
 
   @Test
@@ -352,7 +354,7 @@ public final class JsonWriterTest {
     writer.beginArray();
     writer.nullValue();
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[null]");
+    assertEquals(factory.json(), "[null]");
   }
 
   @Test
@@ -378,26 +380,26 @@ public final class JsonWriterTest {
     writer.value("\0");
     writer.value("\u0019");
     writer.endArray();
-    assertThat(factory.json())
-        .isEqualTo(
-            "[\"a\","
-                + "\"a\\\"\","
-                + "\"\\\"\","
-                + "\":\","
-                + "\",\","
-                + "\"\\b\","
-                + "\"\\f\","
-                + "\"\\n\","
-                + "\"\\r\","
-                + "\"\\t\","
-                + "\" \","
-                + "\"\\\\\","
-                + "\"{\","
-                + "\"}\","
-                + "\"[\","
-                + "\"]\","
-                + "\"\\u0000\","
-                + "\"\\u0019\"]");
+    assertEquals(
+        factory.json(),
+        "[\"a\","
+            + "\"a\\\"\","
+            + "\"\\\"\","
+            + "\":\","
+            + "\",\","
+            + "\"\\b\","
+            + "\"\\f\","
+            + "\"\\n\","
+            + "\"\\r\","
+            + "\"\\t\","
+            + "\" \","
+            + "\"\\\\\","
+            + "\"{\","
+            + "\"}\","
+            + "\"[\","
+            + "\"]\","
+            + "\"\\u0000\","
+            + "\"\\u0019\"]");
   }
 
   @Test
@@ -406,7 +408,7 @@ public final class JsonWriterTest {
     writer.beginArray();
     writer.value("\u2028 \u2029");
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[\"\\u2028 \\u2029\"]");
+    assertEquals(factory.json(), "[\"\\u2028 \\u2029\"]");
   }
 
   @Test
@@ -414,7 +416,7 @@ public final class JsonWriterTest {
     JsonWriter writer = factory.newWriter();
     writer.beginArray();
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[]");
+    assertEquals(factory.json(), "[]");
   }
 
   @Test
@@ -422,7 +424,7 @@ public final class JsonWriterTest {
     JsonWriter writer = factory.newWriter();
     writer.beginObject();
     writer.endObject();
-    assertThat(factory.json()).isEqualTo("{}");
+    assertEquals(factory.json(), "{}");
   }
 
   @Test
@@ -438,7 +440,7 @@ public final class JsonWriterTest {
     writer.name("d").value(true);
     writer.endObject();
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[{\"a\":5,\"b\":false}," + "{\"c\":6,\"d\":true}]");
+    assertEquals(factory.json(), "[{\"a\":5,\"b\":false}," + "{\"c\":6,\"d\":true}]");
   }
 
   @Test
@@ -456,7 +458,7 @@ public final class JsonWriterTest {
     writer.value(true);
     writer.endArray();
     writer.endObject();
-    assertThat(factory.json()).isEqualTo("{\"a\":[5,false]," + "\"b\":[6,true]}");
+    assertEquals(factory.json(), "{\"a\":[5,false]," + "\"b\":[6,true]}");
   }
 
   @Test
@@ -468,7 +470,7 @@ public final class JsonWriterTest {
     for (int i = 0; i < MAX_DEPTH; i++) {
       writer.endArray();
     }
-    assertThat(factory.json()).isEqualTo(repeat("[", MAX_DEPTH) + repeat("]", MAX_DEPTH));
+    assertEquals(factory.json(), repeat("[", MAX_DEPTH) + repeat("]", MAX_DEPTH));
   }
 
   @Test
@@ -481,9 +483,11 @@ public final class JsonWriterTest {
       writer.beginArray();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Nesting too deep at $" + repeat("[0]", MAX_DEPTH) + ": circular reference?");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains(
+                  "Nesting too deep at $" + repeat("[0]", MAX_DEPTH) + ": circular reference?"));
     }
   }
 
@@ -498,8 +502,7 @@ public final class JsonWriterTest {
     for (int i = 0; i < MAX_DEPTH; i++) {
       writer.endObject();
     }
-    assertThat(factory.json())
-        .isEqualTo(repeat("{\"a\":", MAX_DEPTH) + "true" + repeat("}", MAX_DEPTH));
+    assertEquals(factory.json(), repeat("{\"a\":", MAX_DEPTH) + "true" + repeat("}", MAX_DEPTH));
   }
 
   @Test
@@ -513,9 +516,11 @@ public final class JsonWriterTest {
       writer.beginObject();
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Nesting too deep at $" + repeat(".a", MAX_DEPTH) + ": circular reference?");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains(
+                  "Nesting too deep at $" + repeat(".a", MAX_DEPTH) + ": circular reference?"));
     }
   }
 
@@ -530,7 +535,7 @@ public final class JsonWriterTest {
     writer.beginArray();
     writer.endArray();
     writer.close();
-    assertThat(factory.json()).isEqualTo("[][]");
+    assertEquals(factory.json(), "[][]");
   }
 
   @Test
@@ -628,7 +633,7 @@ public final class JsonWriterTest {
       writer.name("a");
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Nesting problem.");
+      assertTrue(expected.getMessage().contains("Nesting problem."));
     }
   }
 
@@ -641,7 +646,7 @@ public final class JsonWriterTest {
       writer.name("b");
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Nesting problem.");
+      assertTrue(expected.getMessage().contains("Nesting problem."));
     }
   }
 
@@ -653,7 +658,7 @@ public final class JsonWriterTest {
       writer.name("a");
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Nesting problem.");
+      assertTrue(expected.getMessage().contains("Nesting problem."));
     }
   }
 
@@ -666,7 +671,7 @@ public final class JsonWriterTest {
       writer.endObject();
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Dangling name: a");
+      assertTrue(expected.getMessage().contains("Dangling name: a"));
     }
   }
 
@@ -683,7 +688,7 @@ public final class JsonWriterTest {
     value.writeByte('"');
     value.close();
     writer.endObject();
-    assertThat(factory.json()).isEqualTo("{\"a\":\"ffffffffffffffffsup-1\"}");
+    assertEquals(factory.json(), "{\"a\":\"ffffffffffffffffsup-1\"}");
   }
 
   @Test
@@ -694,14 +699,14 @@ public final class JsonWriterTest {
     writer.valueSink().writeByte('"').writeUtf8("sup").writeByte('"').close();
     writer.valueSink().writeUtf8("-1.0").close();
     writer.endArray();
-    assertThat(factory.json()).isEqualTo("[\"ffffffffffffffff\",\"sup\",-1.0]");
+    assertEquals(factory.json(), "[\"ffffffffffffffff\",\"sup\",-1.0]");
   }
 
   @Test
   public void streamingValueTopLevel() throws IOException {
     JsonWriter writer = factory.newWriter();
     writer.valueSink().writeUtf8("-1.0").close();
-    assertThat(factory.json()).isEqualTo("-1.0");
+    assertEquals(factory.json(), "-1.0");
   }
 
   @Test
@@ -714,7 +719,7 @@ public final class JsonWriterTest {
       writer.valueSink();
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Sink from valueSink() was not closed");
+      assertTrue(e.getMessage().contains("Sink from valueSink() was not closed"));
     }
   }
 
@@ -729,7 +734,7 @@ public final class JsonWriterTest {
       writer.valueSink().writeByte('0').close();
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Nesting problem.");
+      assertTrue(e.getMessage().contains("Nesting problem."));
     }
   }
 
@@ -743,7 +748,7 @@ public final class JsonWriterTest {
       writer.value("b");
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Sink from valueSink() was not closed");
+      assertTrue(e.getMessage().contains("Sink from valueSink() was not closed"));
     }
   }
 
@@ -757,7 +762,7 @@ public final class JsonWriterTest {
       writer.name("b");
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Nesting problem.");
+      assertTrue(e.getMessage().contains("Nesting problem."));
     }
   }
 
@@ -773,7 +778,7 @@ public final class JsonWriterTest {
       sink.writeByte('1');
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e).hasMessageThat().isEqualTo("closed");
+      assertTrue(e.getMessage().contains("closed"));
     }
   }
 
@@ -788,7 +793,7 @@ public final class JsonWriterTest {
     sink.close();
     writer.endObject();
     sink.close();
-    assertThat(factory.json()).isEqualTo("{\"a\":1.0}");
+    assertEquals(factory.json(), "{\"a\":1.0}");
     sink.close();
   }
 
@@ -813,20 +818,20 @@ public final class JsonWriterTest {
     writer.jsonValue(map);
     writer.endArray();
 
-    assertThat(factory.json())
-        .isEqualTo(
-            "["
-                + "null,"
-                + "1.1,"
-                + "1,"
-                + "1,"
-                + "true,"
-                + "\"one\","
-                + "[],"
-                + "[1,2,null,3],"
-                + "{},"
-                + "{\"one\":\"uno\",\"two\":null}"
-                + "]");
+    assertEquals(
+        factory.json(),
+        "["
+            + "null,"
+            + "1.1,"
+            + "1,"
+            + "1,"
+            + "true,"
+            + "\"one\","
+            + "[],"
+            + "[1,2,null,3],"
+            + "{},"
+            + "{\"one\":\"uno\",\"two\":null}"
+            + "]");
   }
 
   @Test
@@ -835,14 +840,14 @@ public final class JsonWriterTest {
       factory.newWriter().jsonValue(new Object());
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Unsupported type: java.lang.Object");
+      assertTrue(e.getMessage().contains("Unsupported type: java.lang.Object"));
     }
 
     try {
       factory.newWriter().jsonValue('1');
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Unsupported type: java.lang.Character");
+      assertTrue(e.getMessage().contains("Unsupported type: java.lang.Character"));
     }
 
     Map<Integer, String> mapWrongKey = new LinkedHashMap<>();
@@ -851,9 +856,7 @@ public final class JsonWriterTest {
       factory.newWriter().jsonValue(mapWrongKey);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e)
-          .hasMessageThat()
-          .isEqualTo("Map keys must be of type String: java.lang.Integer");
+      assertTrue(e.getMessage().contains("Map keys must be of type String: java.lang.Integer"));
     }
 
     Map<String, String> mapNullKey = new LinkedHashMap<>();
@@ -862,7 +865,7 @@ public final class JsonWriterTest {
       factory.newWriter().jsonValue(mapNullKey);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().isEqualTo("Map keys must be non-null");
+      assertTrue(e.getMessage().contains("Map keys must be non-null"));
     }
   }
 
@@ -874,7 +877,7 @@ public final class JsonWriterTest {
     writer.value("a");
     writer.value("b");
     writer.endObject();
-    assertThat(factory.json()).isEqualTo("{\"a\":\"b\"}");
+    assertEquals(factory.json(), "{\"a\":\"b\"}");
   }
 
   @Test
@@ -885,7 +888,7 @@ public final class JsonWriterTest {
     writer.value(5.0);
     writer.value("b");
     writer.endObject();
-    assertThat(factory.json()).isEqualTo("{\"5.0\":\"b\"}");
+    assertEquals(factory.json(), "{\"5.0\":\"b\"}");
   }
 
   @Test
@@ -896,7 +899,7 @@ public final class JsonWriterTest {
     writer.value(5L);
     writer.value("b");
     writer.endObject();
-    assertThat(factory.json()).isEqualTo("{\"5\":\"b\"}");
+    assertEquals(factory.json(), "{\"5\":\"b\"}");
   }
 
   @Test
@@ -907,7 +910,7 @@ public final class JsonWriterTest {
     writer.value(BigInteger.ONE);
     writer.value("b");
     writer.endObject();
-    assertThat(factory.json()).isEqualTo("{\"1\":\"b\"}");
+    assertEquals(factory.json(), "{\"1\":\"b\"}");
   }
 
   @Test
@@ -919,9 +922,8 @@ public final class JsonWriterTest {
       writer.nullValue();
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("null cannot be used as a map key in JSON at path $.");
+      assertTrue(
+          expected.getMessage().contains("null cannot be used as a map key in JSON at path $."));
     }
   }
 
@@ -934,9 +936,8 @@ public final class JsonWriterTest {
       writer.value(true);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Boolean cannot be used as a map key in JSON at path $.");
+      assertTrue(
+          expected.getMessage().contains("Boolean cannot be used as a map key in JSON at path $."));
     }
   }
 
@@ -949,7 +950,7 @@ public final class JsonWriterTest {
       writer.name("a");
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Nesting problem.");
+      assertTrue(expected.getMessage().contains("Nesting problem."));
     }
   }
 
@@ -959,15 +960,15 @@ public final class JsonWriterTest {
     writer.beginObject();
     writer.promoteValueToName();
     writer.endObject();
-    assertThat(factory.json()).isEqualTo("{}");
+    assertEquals(factory.json(), "{}");
   }
 
   @SuppressWarnings("rawtypes")
   @Test
   public void tags() throws IOException {
     JsonWriter writer = factory.newWriter();
-    assertThat(writer.tag(Integer.class)).isNull();
-    assertThat(writer.tag(CharSequence.class)).isNull();
+    assertNull(writer.tag(Integer.class));
+    assertNull(writer.tag(CharSequence.class));
 
     writer.setTag(Integer.class, 1);
     writer.setTag(CharSequence.class, "Foo");
@@ -975,17 +976,16 @@ public final class JsonWriterTest {
       writer.setTag((Class) CharSequence.class, 1);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Tag value must be of type java.lang.CharSequence");
+      assertTrue(
+          expected.getMessage().contains("Tag value must be of type java.lang.CharSequence"));
     }
 
     Object intTag = writer.tag(Integer.class);
-    assertThat(intTag).isEqualTo(1);
-    assertThat(intTag).isInstanceOf(Integer.class);
+    assertEquals(intTag, 1);
+    assertTrue(intTag instanceof Integer);
     Object charSequenceTag = writer.tag(CharSequence.class);
-    assertThat(charSequenceTag).isEqualTo("Foo");
-    assertThat(charSequenceTag).isInstanceOf(String.class);
-    assertThat(writer.tag(String.class)).isNull();
+    assertEquals(charSequenceTag, "Foo");
+    assertTrue(charSequenceTag instanceof String);
+    assertNull(writer.tag(String.class));
   }
 }

--- a/moshi/src/test/java/com/squareup/moshi/LinkedHashTreeMapTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/LinkedHashTreeMapTest.java
@@ -15,11 +15,16 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.squareup.moshi.LinkedHashTreeMap.Node;
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import org.junit.Test;
@@ -32,8 +37,13 @@ public final class LinkedHashTreeMapTest {
     map.put("a", "android");
     map.put("c", "cola");
     map.put("b", "bbq");
-    assertThat(map.keySet()).containsExactly("a", "c", "b");
-    assertThat(map.values()).containsExactly("android", "cola", "bbq");
+    List<String> keys = Arrays.asList("a", "c", "b");
+    List<String> values = Arrays.asList("android", "cola", "bbq");
+
+    assertTrue(map.keySet().containsAll(keys));
+    assertTrue(keys.containsAll(map.keySet()));
+    assertTrue(map.values().containsAll(values));
+    assertTrue(values.containsAll(map.values()));
   }
 
   @Test
@@ -47,7 +57,11 @@ public final class LinkedHashTreeMapTest {
     it.next();
     it.next();
     it.remove();
-    assertThat(map.keySet()).containsExactly("a", "c");
+
+    List<String> keys = Arrays.asList("a", "c");
+
+    assertTrue(map.keySet().containsAll(keys));
+    assertTrue(keys.containsAll(map.keySet()));
   }
 
   @Test
@@ -74,35 +88,36 @@ public final class LinkedHashTreeMapTest {
   public void ContainsNonComparableKeyReturnsFalse() {
     LinkedHashTreeMap<Object, String> map = new LinkedHashTreeMap<>();
     map.put("a", "android");
-    assertThat(map).doesNotContainKey(new Object());
+
+    assertFalse(map.containsKey(new Object()));
   }
 
   @Test
   public void containsNullKeyIsAlwaysFalse() {
     LinkedHashTreeMap<String, String> map = new LinkedHashTreeMap<>();
     map.put("a", "android");
-    assertThat(map).doesNotContainKey(null);
+    assertFalse(map.containsKey(null));
   }
 
   @Test
   public void putOverrides() throws Exception {
     LinkedHashTreeMap<String, String> map = new LinkedHashTreeMap<>();
-    assertThat(map.put("d", "donut")).isNull();
-    assertThat(map.put("e", "eclair")).isNull();
-    assertThat(map.put("f", "froyo")).isNull();
-    assertThat(map.size()).isEqualTo(3);
+    assertNull(map.put("d", "donut"));
+    assertNull(map.put("e", "eclair"));
+    assertNull(map.put("f", "froyo"));
+    assertEquals(map.size(), 3);
 
-    assertThat(map.get("d")).isEqualTo("donut");
-    assertThat(map.put("d", "done")).isEqualTo("donut");
-    assertThat(map).hasSize(3);
+    assertEquals(map.get("d"), "donut");
+    assertEquals(map.put("d", "done"), "donut");
+    assertEquals(3, map.size());
   }
 
   @Test
   public void emptyStringValues() {
     LinkedHashTreeMap<String, String> map = new LinkedHashTreeMap<>();
     map.put("a", "");
-    assertThat(map.containsKey("a")).isTrue();
-    assertThat(map.get("a")).isEqualTo("");
+    assertTrue(map.containsKey("a"));
+    assertEquals(map.get("a"), "");
   }
 
   // NOTE that this does not happen every time, but given the below predictable random,
@@ -120,8 +135,8 @@ public final class LinkedHashTreeMapTest {
 
     for (int i = 0; i < keys.length; i++) {
       String key = keys[i];
-      assertThat(map.containsKey(key)).isTrue();
-      assertThat(map.get(key)).isEqualTo("" + i);
+      assertTrue(map.containsKey(key));
+      assertEquals(map.get(key), "" + i);
     }
   }
 
@@ -132,8 +147,8 @@ public final class LinkedHashTreeMapTest {
     map.put("c", "cola");
     map.put("b", "bbq");
     map.clear();
-    assertThat(map.keySet()).containsExactly();
-    assertThat(map).isEmpty();
+    assertEquals(0, map.keySet().size());
+    assertEquals(0, map.getSize());
   }
 
   @Test
@@ -150,8 +165,8 @@ public final class LinkedHashTreeMapTest {
     map2.put("D", 4);
     map2.put("A", 1);
 
-    assertThat(map2).isEqualTo(map1);
-    assertThat(map2.hashCode()).isEqualTo(map1.hashCode());
+    assertEquals(map2, map1);
+    assertEquals(map2.hashCode(), map1.hashCode());
   }
 
   @Test
@@ -178,9 +193,9 @@ public final class LinkedHashTreeMapTest {
     AvlIterator<String, String> iterator = new AvlIterator<>();
     iterator.reset(root);
     for (String value : values) {
-      assertThat(iterator.next().getKey()).isEqualTo(value);
+      assertEquals(iterator.next().getKey(), value);
     }
-    assertThat(iterator.next()).isNull();
+    assertNull(iterator.next());
   }
 
   @Test
@@ -240,7 +255,7 @@ public final class LinkedHashTreeMapTest {
 
     Node<String, String>[] newTable = LinkedHashTreeMapKt.doubleCapacity(oldTable);
     assertTree("(b d f)", newTable[0]); // Even hash codes!
-    assertThat(newTable[1]).isNull();
+    assertNull(newTable[1]);
 
     for (Node<?, ?> node : newTable) {
       if (node != null) {
@@ -270,7 +285,7 @@ public final class LinkedHashTreeMapTest {
   }
 
   private void assertTree(String expected, Node<?, ?> root) {
-    assertThat(toString(root)).isEqualTo(expected);
+    assertEquals(toString(root), expected);
     assertConsistent(root);
   }
 
@@ -278,17 +293,17 @@ public final class LinkedHashTreeMapTest {
     int leftHeight = 0;
     if (node.left != null) {
       assertConsistent(node.left);
-      assertThat(node.left.parent).isSameInstanceAs(node);
+      assertEquals(node.left.parent.getClass(), node.getClass());
       leftHeight = node.left.height;
     }
     int rightHeight = 0;
     if (node.right != null) {
       assertConsistent(node.right);
-      assertThat(node.right.parent).isSameInstanceAs(node);
+      assertEquals(node.right.parent.getClass(), node.getClass());
       rightHeight = node.right.height;
     }
     if (node.parent != null) {
-      assertThat(node.parent.left == node || node.parent.right == node).isTrue();
+      assertTrue(node.parent.left == node || node.parent.right == node);
     }
     if (Math.max(leftHeight, rightHeight) + 1 != node.height) {
       fail();

--- a/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MapJsonAdapterTest.java
@@ -15,9 +15,12 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.moshi.TestUtil.newReader;
 import static com.squareup.moshi.internal.Util.NO_ANNOTATIONS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -40,15 +43,13 @@ public final class MapJsonAdapterTest {
     map.put("c", null);
 
     String toJson = toJson(String.class, Boolean.class, map);
-    assertThat(toJson).isEqualTo("{\"a\":true,\"b\":false,\"c\":null}");
+    assertEquals(toJson, "{\"a\":true,\"b\":false,\"c\":null}");
 
     Map<String, Boolean> fromJson =
         fromJson(String.class, Boolean.class, "{\"a\":true,\"b\":false,\"c\":null}");
-    assertThat(fromJson)
-        .containsExactly(
-            "a", true,
-            "b", false,
-            "c", null);
+    assertTrue(fromJson.get("a"));
+    assertFalse(fromJson.get("b"));
+    assertNull(fromJson.get("c"));
   }
 
   @Test
@@ -60,7 +61,7 @@ public final class MapJsonAdapterTest {
       toJson(String.class, Boolean.class, map);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Map key is null at $.");
+      assertTrue(expected.getMessage().contains("Map key is null at $."));
     }
   }
 
@@ -69,10 +70,10 @@ public final class MapJsonAdapterTest {
     Map<String, Boolean> map = new LinkedHashMap<>();
 
     String toJson = toJson(String.class, Boolean.class, map);
-    assertThat(toJson).isEqualTo("{}");
+    assertEquals(toJson, "{}");
 
     Map<String, Boolean> fromJson = fromJson(String.class, Boolean.class, "{}");
-    assertThat(fromJson).isEmpty();
+    assertTrue(fromJson.isEmpty());
   }
 
   @Test
@@ -83,11 +84,11 @@ public final class MapJsonAdapterTest {
     JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.setLenient(true);
     jsonAdapter.toJson(jsonWriter, null);
-    assertThat(buffer.readUtf8()).isEqualTo("null");
+    assertEquals(buffer.readUtf8(), "null");
 
     JsonReader jsonReader = newReader("null");
     jsonReader.setLenient(true);
-    assertThat(jsonAdapter.fromJson(jsonReader)).isEqualTo(null);
+    assertNull(jsonAdapter.fromJson(jsonReader));
   }
 
   @Test
@@ -106,10 +107,10 @@ public final class MapJsonAdapterTest {
     Buffer buffer = new Buffer();
     JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonAdapter.toJson(jsonWriter, map);
-    assertThat(buffer.readUtf8()).isEqualTo(asJson);
+    assertEquals(buffer.readUtf8(), asJson);
 
     JsonReader jsonReader = newReader(asJson);
-    assertThat(jsonAdapter.fromJson(jsonReader)).isEqualTo(map);
+    assertEquals(jsonAdapter.fromJson(jsonReader), map);
   }
 
   @Test
@@ -121,12 +122,11 @@ public final class MapJsonAdapterTest {
     map.put("b", 4);
 
     String toJson = toJson(String.class, Integer.class, map);
-    assertThat(toJson).isEqualTo("{\"c\":1,\"a\":2,\"d\":3,\"b\":4}");
+    assertEquals(toJson, "{\"c\":1,\"a\":2,\"d\":3,\"b\":4}");
 
     Map<String, Integer> fromJson =
         fromJson(String.class, Integer.class, "{\"c\":1,\"a\":2,\"d\":3,\"b\":4}");
-    assertThat(new ArrayList<Object>(fromJson.keySet()))
-        .isEqualTo(Arrays.asList("c", "a", "d", "b"));
+    assertEquals(new ArrayList<Object>(fromJson.keySet()), Arrays.asList("c", "a", "d", "b"));
   }
 
   @Test
@@ -135,9 +135,8 @@ public final class MapJsonAdapterTest {
       fromJson(String.class, Integer.class, "{\"c\":1,\"c\":2}");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Map key 'c' has multiple values at path $.c: 1 and 2");
+      assertTrue(
+          expected.getMessage().contains("Map key 'c' has multiple values at path $.c: 1 and 2"));
     }
   }
 
@@ -150,15 +149,13 @@ public final class MapJsonAdapterTest {
     map.put(7, null);
 
     String toJson = toJson(Integer.class, Boolean.class, map);
-    assertThat(toJson).isEqualTo("{\"5\":true,\"6\":false,\"7\":null}");
+    assertEquals(toJson, "{\"5\":true,\"6\":false,\"7\":null}");
 
     Map<Integer, Boolean> fromJson =
         fromJson(Integer.class, Boolean.class, "{\"5\":true,\"6\":false,\"7\":null}");
-    assertThat(fromJson)
-        .containsExactly(
-            5, true,
-            6, false,
-            7, null);
+    assertTrue(fromJson.get(5));
+    assertFalse(fromJson.get(6));
+    assertNull(fromJson.get(7));
   }
 
   @Test
@@ -174,8 +171,8 @@ public final class MapJsonAdapterTest {
     jsonObject.put("7", null);
 
     JsonAdapter<Map<Integer, Boolean>> jsonAdapter = mapAdapter(Integer.class, Boolean.class);
-    assertThat(jsonAdapter.serializeNulls().toJsonValue(map)).isEqualTo(jsonObject);
-    assertThat(jsonAdapter.fromJsonValue(jsonObject)).isEqualTo(map);
+    assertEquals(jsonAdapter.serializeNulls().toJsonValue(map), jsonObject);
+    assertEquals(jsonAdapter.fromJsonValue(jsonObject), map);
   }
 
   @Test
@@ -187,17 +184,15 @@ public final class MapJsonAdapterTest {
       adapter.toJson(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Boolean cannot be used as a map key in JSON at path $.");
+      assertTrue(
+          expected.getMessage().contains("Boolean cannot be used as a map key in JSON at path $."));
     }
     try {
       adapter.toJsonValue(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Boolean cannot be used as a map key in JSON at path $.");
+      assertTrue(
+          expected.getMessage().contains("Boolean cannot be used as a map key in JSON at path $."));
     }
   }
 
@@ -212,17 +207,17 @@ public final class MapJsonAdapterTest {
       adapter.toJson(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Object cannot be used as a map key in JSON at path $.");
+      assertTrue(
+          expected.getMessage().contains("Object cannot be used as a map key in JSON at path $."));
     }
     try {
       adapter.toJsonValue(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Object cannot be " + "used as a map key in JSON at path $.");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains("Object cannot be " + "used as a map key in JSON at path $."));
     }
   }
 
@@ -236,17 +231,15 @@ public final class MapJsonAdapterTest {
       adapter.toJson(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Array cannot be used as a map key in JSON at path $.");
+      assertTrue(
+          expected.getMessage().contains("Array cannot be used as a map key in JSON at path $."));
     }
     try {
       adapter.toJsonValue(map);
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Array cannot be used as a map key in JSON at path $.");
+      assertTrue(
+          expected.getMessage().contains("Array cannot be used as a map key in JSON at path $."));
     }
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTest.java
@@ -15,10 +15,13 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.moshi.TestUtil.newReader;
 import static com.squareup.moshi.TestUtil.repeat;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import android.util.Pair;
@@ -40,6 +43,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -53,19 +57,19 @@ public final class MoshiTest {
   public void booleanAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Boolean> adapter = moshi.adapter(boolean.class).lenient();
-    assertThat(adapter.fromJson("true")).isTrue();
-    assertThat(adapter.fromJson("TRUE")).isTrue();
-    assertThat(adapter.toJson(true)).isEqualTo("true");
-    assertThat(adapter.fromJson("false")).isFalse();
-    assertThat(adapter.fromJson("FALSE")).isFalse();
-    assertThat(adapter.toJson(false)).isEqualTo("false");
+    assertTrue(adapter.fromJson("true"));
+    assertTrue(adapter.fromJson("TRUE"));
+    assertEquals(adapter.toJson(true), "true");
+    assertFalse(adapter.fromJson("false"));
+    assertFalse(adapter.fromJson("FALSE"));
+    assertEquals(adapter.toJson(false), "false");
 
     // Nulls not allowed for boolean.class
     try {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a boolean but was NULL at path $");
+      assertTrue(expected.getMessage().contains("Expected a boolean but was NULL at path $"));
     }
 
     try {
@@ -79,45 +83,45 @@ public final class MoshiTest {
   public void BooleanAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Boolean> adapter = moshi.adapter(Boolean.class).lenient();
-    assertThat(adapter.fromJson("true")).isTrue();
-    assertThat(adapter.toJson(true)).isEqualTo("true");
-    assertThat(adapter.fromJson("false")).isFalse();
-    assertThat(adapter.toJson(false)).isEqualTo("false");
+    assertTrue(adapter.fromJson("true"));
+    assertEquals(adapter.toJson(true), "true");
+    assertFalse(adapter.fromJson("false"));
+    assertEquals(adapter.toJson(false), "false");
     // Allow nulls for Boolean.class
-    assertThat(adapter.fromJson("null")).isEqualTo(null);
-    assertThat(adapter.toJson(null)).isEqualTo("null");
+    assertEquals(adapter.fromJson("null"), null);
+    assertEquals(adapter.toJson(null), "null");
   }
 
   @Test
   public void byteAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Byte> adapter = moshi.adapter(byte.class).lenient();
-    assertThat(adapter.fromJson("1")).isEqualTo((byte) 1);
-    assertThat(adapter.toJson((byte) -2)).isEqualTo("254");
+    assertEquals(Objects.requireNonNull(adapter.fromJson("1")).byteValue(), (byte) 1);
+    assertEquals(adapter.toJson((byte) -2), "254");
 
     // Canonical byte representation is unsigned, but parse the whole range -128..255
-    assertThat(adapter.fromJson("-128")).isEqualTo((byte) -128);
-    assertThat(adapter.fromJson("128")).isEqualTo((byte) -128);
-    assertThat(adapter.toJson((byte) -128)).isEqualTo("128");
+    assertEquals(Objects.requireNonNull(adapter.fromJson("-128")).byteValue(), (byte) -128);
+    assertEquals(Objects.requireNonNull(adapter.fromJson("128")).byteValue(), (byte) -128);
+    assertEquals(adapter.toJson((byte) -128), "128");
 
-    assertThat(adapter.fromJson("255")).isEqualTo((byte) -1);
-    assertThat(adapter.toJson((byte) -1)).isEqualTo("255");
+    assertEquals(adapter.fromJson("255").byteValue(), (byte) -1);
+    assertEquals(adapter.toJson((byte) -1), "255");
 
-    assertThat(adapter.fromJson("127")).isEqualTo((byte) 127);
-    assertThat(adapter.toJson((byte) 127)).isEqualTo("127");
+    assertEquals(Objects.requireNonNull(adapter.fromJson("127")).byteValue(), (byte) 127);
+    assertEquals(adapter.toJson((byte) 127), "127");
 
     try {
       adapter.fromJson("256");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a byte but was 256 at path $");
+      assertTrue(expected.getMessage().contains("Expected a byte but was 256 at path $"));
     }
 
     try {
       adapter.fromJson("-129");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a byte but was -129 at path $");
+      assertTrue(expected.getMessage().contains("Expected a byte but was -129 at path "));
     }
 
     // Nulls not allowed for byte.class
@@ -125,7 +129,7 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected an int but was NULL at path $");
+      assertTrue(expected.getMessage().contains("Expected an int but was NULL at path "));
     }
 
     try {
@@ -139,20 +143,20 @@ public final class MoshiTest {
   public void ByteAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Byte> adapter = moshi.adapter(Byte.class).lenient();
-    assertThat(adapter.fromJson("1")).isEqualTo((byte) 1);
-    assertThat(adapter.toJson((byte) -2)).isEqualTo("254");
+    assertEquals(adapter.fromJson("1").byteValue(), (byte) 1);
+    assertEquals(adapter.toJson((byte) -2), "254");
     // Allow nulls for Byte.class
-    assertThat(adapter.fromJson("null")).isEqualTo(null);
-    assertThat(adapter.toJson(null)).isEqualTo("null");
+    assertEquals(adapter.fromJson("null"), null);
+    assertEquals(adapter.toJson(null), "null");
   }
 
   @Test
   public void charAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Character> adapter = moshi.adapter(char.class).lenient();
-    assertThat(adapter.fromJson("\"a\"")).isEqualTo('a');
-    assertThat(adapter.fromJson("'a'")).isEqualTo('a');
-    assertThat(adapter.toJson('b')).isEqualTo("\"b\"");
+    assertEquals(adapter.fromJson("\"a\"").charValue(), 'a');
+    assertEquals(adapter.fromJson("'a'").charValue(), 'a');
+    assertEquals(adapter.toJson('b'), "\"b\"");
 
     // Exhaustively test all valid characters.  Use an int to loop so we can check termination.
     for (int i = 0; i <= Character.MAX_VALUE; ++i) {
@@ -199,8 +203,8 @@ public final class MoshiTest {
           break;
       }
       s = '"' + s + '"';
-      assertThat(adapter.toJson(c)).isEqualTo(s);
-      assertThat(adapter.fromJson(s)).isEqualTo(c);
+      assertEquals(adapter.toJson(c), s);
+      assertEquals(adapter.fromJson(s).charValue(), c);
     }
 
     try {
@@ -208,7 +212,7 @@ public final class MoshiTest {
       adapter.fromJson("'ab'");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a char but was \"ab\" at path $");
+      assertTrue(expected.getMessage().contains("Expected a char but was \"ab\" at path "));
     }
 
     // Nulls not allowed for char.class
@@ -216,7 +220,7 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a string but was NULL at path $");
+      assertTrue(expected.getMessage().contains("Expected a string but was NULL at path "));
     }
 
     try {
@@ -230,51 +234,51 @@ public final class MoshiTest {
   public void CharacterAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Character> adapter = moshi.adapter(Character.class).lenient();
-    assertThat(adapter.fromJson("\"a\"")).isEqualTo('a');
-    assertThat(adapter.fromJson("'a'")).isEqualTo('a');
-    assertThat(adapter.toJson('b')).isEqualTo("\"b\"");
+    assertEquals(adapter.fromJson("\"a\"").charValue(), 'a');
+    assertEquals(adapter.fromJson("'a'").charValue(), 'a');
+    assertEquals(adapter.toJson('b'), "\"b\"");
 
     try {
       // Only a single character is allowed.
       adapter.fromJson("'ab'");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a char but was \"ab\" at path $");
+      assertTrue(expected.getMessage().contains("Expected a char but was \"ab\" at path "));
     }
 
     // Allow nulls for Character.class
-    assertThat(adapter.fromJson("null")).isEqualTo(null);
-    assertThat(adapter.toJson(null)).isEqualTo("null");
+    assertEquals(adapter.fromJson("null"), null);
+    assertEquals(adapter.toJson(null), "null");
   }
 
   @Test
   public void doubleAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Double> adapter = moshi.adapter(double.class).lenient();
-    assertThat(adapter.fromJson("1.0")).isEqualTo(1.0);
-    assertThat(adapter.fromJson("1")).isEqualTo(1.0);
-    assertThat(adapter.fromJson("1e0")).isEqualTo(1.0);
-    assertThat(adapter.toJson(-2.0)).isEqualTo("-2.0");
+    assertEquals(adapter.fromJson("1.0"), 1.0, 0);
+    assertEquals(adapter.fromJson("1"), 1.0, 0);
+    assertEquals(adapter.fromJson("1e0"), 1.0, 0);
+    assertEquals(adapter.toJson(-2.0), "-2.0");
 
     // Test min/max values.
-    assertThat(adapter.fromJson("-1.7976931348623157E308")).isEqualTo(-Double.MAX_VALUE);
-    assertThat(adapter.toJson(-Double.MAX_VALUE)).isEqualTo("-1.7976931348623157E308");
-    assertThat(adapter.fromJson("1.7976931348623157E308")).isEqualTo(Double.MAX_VALUE);
-    assertThat(adapter.toJson(Double.MAX_VALUE)).isEqualTo("1.7976931348623157E308");
+    assertEquals(adapter.fromJson("-1.7976931348623157E308"), -Double.MAX_VALUE, 0);
+    assertEquals(adapter.toJson(-Double.MAX_VALUE), "-1.7976931348623157E308");
+    assertEquals(adapter.fromJson("1.7976931348623157E308"), Double.MAX_VALUE, 0);
+    assertEquals(adapter.toJson(Double.MAX_VALUE), "1.7976931348623157E308");
 
     // Lenient reader converts too large values to infinities.
-    assertThat(adapter.fromJson("1E309")).isEqualTo(Double.POSITIVE_INFINITY);
-    assertThat(adapter.fromJson("-1E309")).isEqualTo(Double.NEGATIVE_INFINITY);
-    assertThat(adapter.fromJson("+Infinity")).isEqualTo(Double.POSITIVE_INFINITY);
-    assertThat(adapter.fromJson("Infinity")).isEqualTo(Double.POSITIVE_INFINITY);
-    assertThat(adapter.fromJson("-Infinity")).isEqualTo(Double.NEGATIVE_INFINITY);
+    assertEquals(adapter.fromJson("1E309"), Double.POSITIVE_INFINITY, 0);
+    assertEquals(adapter.fromJson("-1E309"), Double.NEGATIVE_INFINITY, 0);
+    assertEquals(adapter.fromJson("+Infinity"), Double.POSITIVE_INFINITY, 0);
+    assertEquals(adapter.fromJson("Infinity"), Double.POSITIVE_INFINITY, 0);
+    assertEquals(adapter.fromJson("-Infinity"), Double.NEGATIVE_INFINITY, 0);
 
     // Nulls not allowed for double.class
     try {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a double but was NULL at path $");
+      assertTrue(expected.getMessage().contains("Expected a double but was NULL at path "));
     }
 
     try {
@@ -291,9 +295,8 @@ public final class MoshiTest {
       adapter.fromJson(reader);
       fail();
     } catch (IOException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("JSON forbids NaN and infinities: Infinity at path $[0]");
+      assertTrue(
+          expected.getMessage().contains("JSON forbids NaN and infinities: Infinity at path $[0]"));
     }
 
     reader = newReader("[-1E309]");
@@ -302,9 +305,10 @@ public final class MoshiTest {
       adapter.fromJson(reader);
       fail();
     } catch (IOException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("JSON forbids NaN and infinities: -Infinity at path $[0]");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains("JSON forbids NaN and infinities: -Infinity at path $[0]"));
     }
   }
 
@@ -312,43 +316,43 @@ public final class MoshiTest {
   public void DoubleAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Double> adapter = moshi.adapter(Double.class).lenient();
-    assertThat(adapter.fromJson("1.0")).isEqualTo(1.0);
-    assertThat(adapter.fromJson("1")).isEqualTo(1.0);
-    assertThat(adapter.fromJson("1e0")).isEqualTo(1.0);
-    assertThat(adapter.toJson(-2.0)).isEqualTo("-2.0");
+    assertEquals(adapter.fromJson("1.0"), 1.0, 0);
+    assertEquals(adapter.fromJson("1"), 1.0, 0);
+    assertEquals(adapter.fromJson("1e0"), 1.0, 0);
+    assertEquals(adapter.toJson(-2.0), "-2.0");
     // Allow nulls for Double.class
-    assertThat(adapter.fromJson("null")).isEqualTo(null);
-    assertThat(adapter.toJson(null)).isEqualTo("null");
+    assertEquals(adapter.fromJson("null"), null);
+    assertEquals(adapter.toJson(null), "null");
   }
 
   @Test
   public void floatAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Float> adapter = moshi.adapter(float.class).lenient();
-    assertThat(adapter.fromJson("1.0")).isEqualTo(1.0f);
-    assertThat(adapter.fromJson("1")).isEqualTo(1.0f);
-    assertThat(adapter.fromJson("1e0")).isEqualTo(1.0f);
-    assertThat(adapter.toJson(-2.0f)).isEqualTo("-2.0");
+    assertEquals(adapter.fromJson("1.0"), 1.0f, 0);
+    assertEquals(adapter.fromJson("1"), 1.0f, 0);
+    assertEquals(adapter.fromJson("1e0"), 1.0f, 0);
+    assertEquals(adapter.toJson(-2.0f), "-2.0");
 
     // Test min/max values.
-    assertThat(adapter.fromJson("-3.4028235E38")).isEqualTo(-Float.MAX_VALUE);
-    assertThat(adapter.toJson(-Float.MAX_VALUE)).isEqualTo("-3.4028235E38");
-    assertThat(adapter.fromJson("3.4028235E38")).isEqualTo(Float.MAX_VALUE);
-    assertThat(adapter.toJson(Float.MAX_VALUE)).isEqualTo("3.4028235E38");
+    assertEquals(adapter.fromJson("-3.4028235E38"), -Float.MAX_VALUE, 0);
+    assertEquals(adapter.toJson(-Float.MAX_VALUE), "-3.4028235E38");
+    assertEquals(adapter.fromJson("3.4028235E38"), Float.MAX_VALUE, 0);
+    assertEquals(adapter.toJson(Float.MAX_VALUE), "3.4028235E38");
 
     // Lenient reader converts too large values to infinities.
-    assertThat(adapter.fromJson("1E39")).isEqualTo(Float.POSITIVE_INFINITY);
-    assertThat(adapter.fromJson("-1E39")).isEqualTo(Float.NEGATIVE_INFINITY);
-    assertThat(adapter.fromJson("+Infinity")).isEqualTo(Float.POSITIVE_INFINITY);
-    assertThat(adapter.fromJson("Infinity")).isEqualTo(Float.POSITIVE_INFINITY);
-    assertThat(adapter.fromJson("-Infinity")).isEqualTo(Float.NEGATIVE_INFINITY);
+    assertEquals(adapter.fromJson("1E39"), Float.POSITIVE_INFINITY, 0);
+    assertEquals(adapter.fromJson("-1E39"), Float.NEGATIVE_INFINITY, 0);
+    assertEquals(adapter.fromJson("+Infinity"), Float.POSITIVE_INFINITY, 0);
+    assertEquals(adapter.fromJson("Infinity"), Float.POSITIVE_INFINITY, 0);
+    assertEquals(adapter.fromJson("-Infinity"), Float.NEGATIVE_INFINITY, 0);
 
     // Nulls not allowed for float.class
     try {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a double but was NULL at path $");
+      assertTrue(expected.getMessage().contains("Expected a double but was NULL at path "));
     }
 
     try {
@@ -365,9 +369,8 @@ public final class MoshiTest {
       adapter.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("JSON forbids NaN and infinities: Infinity at path $[1]");
+      assertTrue(
+          expected.getMessage().contains("JSON forbids NaN and infinities: Infinity at path $[1]"));
     }
 
     reader = newReader("[-1E39]");
@@ -376,9 +379,10 @@ public final class MoshiTest {
       adapter.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("JSON forbids NaN and infinities: -Infinity at path $[1]");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains("JSON forbids NaN and infinities: -Infinity at path $[1]"));
     }
   }
 
@@ -386,44 +390,40 @@ public final class MoshiTest {
   public void FloatAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Float> adapter = moshi.adapter(Float.class).lenient();
-    assertThat(adapter.fromJson("1.0")).isEqualTo(1.0f);
-    assertThat(adapter.fromJson("1")).isEqualTo(1.0f);
-    assertThat(adapter.fromJson("1e0")).isEqualTo(1.0f);
-    assertThat(adapter.toJson(-2.0f)).isEqualTo("-2.0");
+    assertEquals(adapter.fromJson("1.0"), 1.0f, 0);
+    assertEquals(adapter.fromJson("1"), 1.0f, 0);
+    assertEquals(adapter.fromJson("1e0"), 1.0f, 0);
+    assertEquals(adapter.toJson(-2.0f), "-2.0");
     // Allow nulls for Float.class
-    assertThat(adapter.fromJson("null")).isEqualTo(null);
-    assertThat(adapter.toJson(null)).isEqualTo("null");
+    assertEquals(adapter.fromJson("null"), null);
+    assertEquals(adapter.toJson(null), "null");
   }
 
   @Test
   public void intAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Integer> adapter = moshi.adapter(int.class).lenient();
-    assertThat(adapter.fromJson("1")).isEqualTo(1);
-    assertThat(adapter.toJson(-2)).isEqualTo("-2");
+    assertEquals(adapter.fromJson("1"), 1, 0);
+    assertEquals(adapter.toJson(-2), "-2");
 
     // Test min/max values
-    assertThat(adapter.fromJson("-2147483648")).isEqualTo(Integer.MIN_VALUE);
-    assertThat(adapter.toJson(Integer.MIN_VALUE)).isEqualTo("-2147483648");
-    assertThat(adapter.fromJson("2147483647")).isEqualTo(Integer.MAX_VALUE);
-    assertThat(adapter.toJson(Integer.MAX_VALUE)).isEqualTo("2147483647");
+    assertEquals(adapter.fromJson("-2147483648"), Integer.MIN_VALUE, 0);
+    assertEquals(adapter.toJson(Integer.MIN_VALUE), "-2147483648");
+    assertEquals(adapter.fromJson("2147483647"), Integer.MAX_VALUE, 0);
+    assertEquals(adapter.toJson(Integer.MAX_VALUE), "2147483647");
 
     try {
       adapter.fromJson("2147483648");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected an int but was 2147483648 at path $");
+      assertTrue(expected.getMessage().contains("Expected an int but was 2147483648 at path "));
     }
 
     try {
       adapter.fromJson("-2147483649");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected an int but was -2147483649 at path $");
+      assertTrue(expected.getMessage().contains("Expected an int but was -2147483649 at path "));
     }
 
     // Nulls not allowed for int.class
@@ -431,7 +431,7 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected an int but was NULL at path $");
+      assertTrue(expected.getMessage().contains("Expected an int but was NULL at path "));
     }
 
     try {
@@ -445,42 +445,40 @@ public final class MoshiTest {
   public void IntegerAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Integer> adapter = moshi.adapter(Integer.class).lenient();
-    assertThat(adapter.fromJson("1")).isEqualTo(1);
-    assertThat(adapter.toJson(-2)).isEqualTo("-2");
+    assertEquals(adapter.fromJson("1"), 1, 0);
+    assertEquals(adapter.toJson(-2), "-2");
     // Allow nulls for Integer.class
-    assertThat(adapter.fromJson("null")).isEqualTo(null);
-    assertThat(adapter.toJson(null)).isEqualTo("null");
+    assertEquals(adapter.fromJson("null"), null);
+    assertEquals(adapter.toJson(null), "null");
   }
 
   @Test
   public void longAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Long> adapter = moshi.adapter(long.class).lenient();
-    assertThat(adapter.fromJson("1")).isEqualTo(1L);
-    assertThat(adapter.toJson(-2L)).isEqualTo("-2");
+    assertEquals(adapter.fromJson("1"), 1L, 0);
+    assertEquals(adapter.toJson(-2L), "-2");
 
     // Test min/max values
-    assertThat(adapter.fromJson("-9223372036854775808")).isEqualTo(Long.MIN_VALUE);
-    assertThat(adapter.toJson(Long.MIN_VALUE)).isEqualTo("-9223372036854775808");
-    assertThat(adapter.fromJson("9223372036854775807")).isEqualTo(Long.MAX_VALUE);
-    assertThat(adapter.toJson(Long.MAX_VALUE)).isEqualTo("9223372036854775807");
+    assertEquals(adapter.fromJson("-9223372036854775808"), Long.MIN_VALUE, 0);
+    assertEquals(adapter.toJson(Long.MIN_VALUE), "-9223372036854775808");
+    assertEquals(adapter.fromJson("9223372036854775807"), Long.MAX_VALUE, 0);
+    assertEquals(adapter.toJson(Long.MAX_VALUE), "9223372036854775807");
 
     try {
       adapter.fromJson("9223372036854775808");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected a long but was 9223372036854775808 at path $");
+      assertTrue(
+          expected.getMessage().contains("Expected a long but was 9223372036854775808 at path "));
     }
 
     try {
       adapter.fromJson("-9223372036854775809");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected a long but was -9223372036854775809 at path $");
+      assertTrue(
+          expected.getMessage().contains("Expected a long but was -9223372036854775809 at path "));
     }
 
     // Nulls not allowed for long.class
@@ -488,7 +486,7 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a long but was NULL at path $");
+      assertTrue(expected.getMessage().contains("Expected a long but was NULL at path "));
     }
 
     try {
@@ -502,38 +500,38 @@ public final class MoshiTest {
   public void LongAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Long> adapter = moshi.adapter(Long.class).lenient();
-    assertThat(adapter.fromJson("1")).isEqualTo(1L);
-    assertThat(adapter.toJson(-2L)).isEqualTo("-2");
+    assertEquals(adapter.fromJson("1"), 1L, 0);
+    assertEquals(adapter.toJson(-2L), "-2");
     // Allow nulls for Integer.class
-    assertThat(adapter.fromJson("null")).isEqualTo(null);
-    assertThat(adapter.toJson(null)).isEqualTo("null");
+    assertEquals(adapter.fromJson("null"), null);
+    assertEquals(adapter.toJson(null), "null");
   }
 
   @Test
   public void shortAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Short> adapter = moshi.adapter(short.class).lenient();
-    assertThat(adapter.fromJson("1")).isEqualTo((short) 1);
-    assertThat(adapter.toJson((short) -2)).isEqualTo("-2");
+    assertEquals(adapter.fromJson("1"), (short) 1, 0);
+    assertEquals(adapter.toJson((short) -2), "-2");
 
     // Test min/max values.
-    assertThat(adapter.fromJson("-32768")).isEqualTo(Short.MIN_VALUE);
-    assertThat(adapter.toJson(Short.MIN_VALUE)).isEqualTo("-32768");
-    assertThat(adapter.fromJson("32767")).isEqualTo(Short.MAX_VALUE);
-    assertThat(adapter.toJson(Short.MAX_VALUE)).isEqualTo("32767");
+    assertEquals(adapter.fromJson("-32768"), Short.MIN_VALUE, 0);
+    assertEquals(adapter.toJson(Short.MIN_VALUE), "-32768");
+    assertEquals(adapter.fromJson("32767"), Short.MAX_VALUE, 0);
+    assertEquals(adapter.toJson(Short.MAX_VALUE), "32767");
 
     try {
       adapter.fromJson("32768");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a short but was 32768 at path $");
+      assertTrue(expected.getMessage().contains("Expected a short but was 32768 at path "));
     }
 
     try {
       adapter.fromJson("-32769");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected a short but was -32769 at path $");
+      assertTrue(expected.getMessage().contains("Expected a short but was -32769 at path "));
     }
 
     // Nulls not allowed for short.class
@@ -541,7 +539,7 @@ public final class MoshiTest {
       adapter.fromJson("null");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Expected an int but was NULL at path $");
+      assertTrue(expected.getMessage().contains("Expected an int but was NULL at path "));
     }
 
     try {
@@ -555,31 +553,31 @@ public final class MoshiTest {
   public void ShortAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Short> adapter = moshi.adapter(Short.class).lenient();
-    assertThat(adapter.fromJson("1")).isEqualTo((short) 1);
-    assertThat(adapter.toJson((short) -2)).isEqualTo("-2");
+    assertEquals(adapter.fromJson("1"), (short) 1, 0);
+    assertEquals(adapter.toJson((short) -2), "-2");
     // Allow nulls for Byte.class
-    assertThat(adapter.fromJson("null")).isEqualTo(null);
-    assertThat(adapter.toJson(null)).isEqualTo("null");
+    assertEquals(adapter.fromJson("null"), null);
+    assertEquals(adapter.toJson(null), "null");
   }
 
   @Test
   public void stringAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<String> adapter = moshi.adapter(String.class).lenient();
-    assertThat(adapter.fromJson("\"a\"")).isEqualTo("a");
-    assertThat(adapter.toJson("b")).isEqualTo("\"b\"");
-    assertThat(adapter.fromJson("null")).isEqualTo(null);
-    assertThat(adapter.toJson(null)).isEqualTo("null");
+    assertEquals(adapter.fromJson("\"a\""), "a");
+    assertEquals(adapter.toJson("b"), "\"b\"");
+    assertNull(adapter.fromJson("null"));
+    assertEquals(adapter.toJson(null), "null");
   }
 
   @Test
   public void upperBoundedWildcardsAreHandled() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Object> adapter = moshi.adapter(Types.subtypeOf(String.class));
-    assertThat(adapter.fromJson("\"a\"")).isEqualTo("a");
-    assertThat(adapter.toJson("b")).isEqualTo("\"b\"");
-    assertThat(adapter.fromJson("null")).isEqualTo(null);
-    assertThat(adapter.toJson(null)).isEqualTo("null");
+    assertEquals(adapter.fromJson("\"a\""), "a");
+    assertEquals(adapter.toJson("b"), "\"b\"");
+    assertNull(adapter.fromJson("null"));
+    assertEquals(adapter.toJson(null), "null");
   }
 
   @Test
@@ -589,9 +587,9 @@ public final class MoshiTest {
       moshi.adapter(Types.supertypeOf(String.class));
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e)
-          .hasMessageThat()
-          .isEqualTo("No JsonAdapter for ? super java.lang.String (with no annotations)");
+      assertTrue(
+          e.getMessage()
+              .contains("No JsonAdapter for ? super java.lang.String (with no annotations)"));
     }
   }
 
@@ -604,43 +602,43 @@ public final class MoshiTest {
       builder.add((null));
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessageThat().contains("Parameter specified as non-null is null");
+      assertTrue(expected.getMessage().contains("Parameter specified as non-null is null"));
     }
     try {
       builder.add((Object) null);
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessageThat().contains("Parameter specified as non-null is null");
+      assertTrue(expected.getMessage().contains("Parameter specified as non-null is null"));
     }
     try {
       builder.add(null, null);
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessageThat().contains("Parameter specified as non-null is null");
+      assertTrue(expected.getMessage().contains("Parameter specified as non-null is null"));
     }
     try {
       builder.add(type, null);
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessageThat().contains("Parameter specified as non-null is null");
+      assertTrue(expected.getMessage().contains("Parameter specified as non-null is null"));
     }
     try {
       builder.add(null, null, null);
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessageThat().contains("Parameter specified as non-null is null");
+      assertTrue(expected.getMessage().contains("Parameter specified as non-null is null"));
     }
     try {
       builder.add(type, null, null);
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessageThat().contains("Parameter specified as non-null is null");
+      assertTrue(expected.getMessage().contains("Parameter specified as non-null is null"));
     }
     try {
       builder.add(type, annotation, null);
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessageThat().contains("Parameter specified as non-null is null");
+      assertTrue(expected.getMessage().contains("Parameter specified as non-null is null"));
     }
   }
 
@@ -649,10 +647,8 @@ public final class MoshiTest {
     Moshi moshi = new Moshi.Builder().add(Pizza.class, new PizzaAdapter()).build();
 
     JsonAdapter<Pizza> jsonAdapter = moshi.adapter(Pizza.class);
-    assertThat(jsonAdapter.toJson(new Pizza(15, true)))
-        .isEqualTo("{\"size\":15,\"extra cheese\":true}");
-    assertThat(jsonAdapter.fromJson("{\"extra cheese\":true,\"size\":18}"))
-        .isEqualTo(new Pizza(18, true));
+    assertEquals(jsonAdapter.toJson(new Pizza(15, true)), "{\"size\":15,\"extra cheese\":true}");
+    assertEquals(jsonAdapter.fromJson("{\"extra cheese\":true,\"size\":18}"), new Pizza(18, true));
   }
 
   @Test
@@ -666,8 +662,8 @@ public final class MoshiTest {
     pizzaObject.put("extraCheese", true);
 
     JsonAdapter<Pizza> jsonAdapter = moshi.adapter(Pizza.class);
-    assertThat(jsonAdapter.toJsonValue(pizza)).isEqualTo(pizzaObject);
-    assertThat(jsonAdapter.fromJsonValue(pizzaObject)).isEqualTo(pizza);
+    assertEquals(jsonAdapter.toJsonValue(pizza), pizzaObject);
+    assertEquals(jsonAdapter.fromJsonValue(pizzaObject), pizza);
   }
 
   @Test
@@ -681,8 +677,8 @@ public final class MoshiTest {
     pizzaObject.put("extra cheese", true);
 
     JsonAdapter<Pizza> jsonAdapter = moshi.adapter(Pizza.class);
-    assertThat(jsonAdapter.toJsonValue(pizza)).isEqualTo(pizzaObject);
-    assertThat(jsonAdapter.fromJsonValue(pizzaObject)).isEqualTo(pizza);
+    assertEquals(jsonAdapter.toJsonValue(pizza), pizzaObject);
+    assertEquals(jsonAdapter.fromJsonValue(pizzaObject), pizza);
   }
 
   @Test
@@ -691,8 +687,9 @@ public final class MoshiTest {
     JsonAdapter<Pizza> jsonAdapter = moshi.adapter(Pizza.class);
 
     Pizza pizza = new Pizza(15, true);
-    assertThat(jsonAdapter.indent("  ").toJson(pizza))
-        .isEqualTo("" + "{\n" + "  \"size\": 15,\n" + "  \"extra cheese\": true\n" + "}");
+    assertEquals(
+        jsonAdapter.indent("  ").toJson(pizza),
+        "" + "{\n" + "  \"size\": 15,\n" + "  \"extra cheese\": true\n" + "}");
   }
 
   @Test
@@ -709,12 +706,12 @@ public final class MoshiTest {
 
     // Calling JsonAdapter.indent("") can remove indentation.
     jsonAdapter.indent("").toJson(writer, pizza);
-    assertThat(buffer.readUtf8()).isEqualTo("{\"size\":15,\"extra cheese\":true}");
+    assertEquals(buffer.readUtf8(), "{\"size\":15,\"extra cheese\":true}");
 
     // Indentation changes only apply to their use.
     jsonAdapter.toJson(writer, pizza);
-    assertThat(buffer.readUtf8())
-        .isEqualTo("" + "{\n" + "  \"size\": 15,\n" + "  \"extra cheese\": true\n" + "}");
+    assertEquals(
+        buffer.readUtf8(), "" + "{\n" + "  \"size\": 15,\n" + "  \"extra cheese\": true\n" + "}");
   }
 
   @Test
@@ -726,10 +723,12 @@ public final class MoshiTest {
             .build();
 
     JsonAdapter<MealDeal> jsonAdapter = moshi.adapter(MealDeal.class);
-    assertThat(jsonAdapter.toJson(new MealDeal(new Pizza(15, true), "Pepsi")))
-        .isEqualTo("[{\"size\":15,\"extra cheese\":true},\"Pepsi\"]");
-    assertThat(jsonAdapter.fromJson("[{\"extra cheese\":true,\"size\":18},\"Coke\"]"))
-        .isEqualTo(new MealDeal(new Pizza(18, true), "Coke"));
+    assertEquals(
+        jsonAdapter.toJson(new MealDeal(new Pizza(15, true), "Pepsi")),
+        "[{\"size\":15,\"extra cheese\":true},\"Pepsi\"]");
+    assertEquals(
+        jsonAdapter.fromJson("[{\"extra cheese\":true,\"size\":18},\"Coke\"]"),
+        new MealDeal(new Pizza(18, true), "Coke"));
   }
 
   static class Message {
@@ -760,8 +759,7 @@ public final class MoshiTest {
     message.speak = "Yo dog";
     message.shout = "What's up";
 
-    assertThat(messageAdapter.toJson(message))
-        .isEqualTo("{\"shout\":\"WHAT'S UP\",\"speak\":\"Yo dog\"}");
+    assertEquals(messageAdapter.toJson(message), "{\"shout\":\"WHAT'S UP\",\"speak\":\"Yo dog\"}");
   }
 
   @Test
@@ -771,7 +769,7 @@ public final class MoshiTest {
       moshi.adapter(null, Collections.<Annotation>emptySet());
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessageThat().contains("Parameter specified as non-null is null");
+      assertTrue(expected.getMessage().contains("Parameter specified as non-null is null"));
     }
   }
 
@@ -782,13 +780,13 @@ public final class MoshiTest {
       moshi.adapter(String.class, (Class<? extends Annotation>) null);
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessageThat().contains("Parameter specified as non-null is null");
+      assertTrue(expected.getMessage().contains("Parameter specified as non-null is null"));
     }
     try {
       moshi.adapter(String.class, (Set<? extends Annotation>) null);
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessageThat().contains("Parameter specified as non-null is null");
+      assertTrue(expected.getMessage().contains("Parameter specified as non-null is null"));
     }
   }
 
@@ -808,7 +806,7 @@ public final class MoshiTest {
       moshi.adapter(Object.class);
       fail();
     } catch (NullPointerException expected) {
-      assertThat(expected).hasMessageThat().contains("Parameter specified as non-null is null");
+      assertTrue(expected.getMessage().contains("Parameter specified as non-null is null"));
     }
   }
 
@@ -821,8 +819,8 @@ public final class MoshiTest {
     Field uppercaseString = MoshiTest.class.getDeclaredField("uppercaseString");
     Set<? extends Annotation> annotations = Util.getJsonAnnotations(uppercaseString);
     JsonAdapter<String> adapter = moshi.<String>adapter(String.class, annotations).lenient();
-    assertThat(adapter.toJson("a")).isEqualTo("\"A\"");
-    assertThat(adapter.fromJson("\"b\"")).isEqualTo("B");
+    assertEquals(adapter.toJson("a"), "\"A\"");
+    assertEquals(adapter.fromJson("\"b\""), "B");
   }
 
   @Test
@@ -830,8 +828,8 @@ public final class MoshiTest {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<List<String>> adapter =
         moshi.adapter(Types.newParameterizedType(List.class, String.class));
-    assertThat(adapter.toJson(Arrays.asList("a", "b"))).isEqualTo("[\"a\",\"b\"]");
-    assertThat(adapter.fromJson("[\"a\",\"b\"]")).isEqualTo(Arrays.asList("a", "b"));
+    assertEquals(adapter.toJson(Arrays.asList("a", "b")), "[\"a\",\"b\"]");
+    assertEquals(adapter.fromJson("[\"a\",\"b\"]"), Arrays.asList("a", "b"));
   }
 
   @Test
@@ -843,8 +841,8 @@ public final class MoshiTest {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Set<String>> adapter =
         moshi.adapter(Types.newParameterizedType(Set.class, String.class));
-    assertThat(adapter.toJson(set)).isEqualTo("[\"a\",\"b\"]");
-    assertThat(adapter.fromJson("[\"a\",\"b\"]")).isEqualTo(set);
+    assertEquals(adapter.toJson(set), "[\"a\",\"b\"]");
+    assertEquals(adapter.fromJson("[\"a\",\"b\"]"), set);
   }
 
   @Test
@@ -856,8 +854,11 @@ public final class MoshiTest {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Collection<String>> adapter =
         moshi.adapter(Types.newParameterizedType(Collection.class, String.class));
-    assertThat(adapter.toJson(collection)).isEqualTo("[\"a\",\"b\"]");
-    assertThat(adapter.fromJson("[\"a\",\"b\"]")).containsExactly("a", "b");
+    Object[] values = adapter.fromJson("[\"a\",\"b\"]").toArray();
+    assertEquals(adapter.toJson(collection), "[\"a\",\"b\"]");
+    assertEquals(values.length, 2);
+    assertEquals(values[0], "a");
+    assertEquals(values[1], "b");
   }
 
   @Uppercase static List<String> uppercaseStrings;
@@ -872,11 +873,12 @@ public final class MoshiTest {
           uppercaseStringsField.getGenericType(), Util.getJsonAnnotations(uppercaseStringsField));
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "No JsonAdapter for java.util.List<java.lang.String> "
-                  + "annotated [@com.squareup.moshi.MoshiTest$Uppercase()]");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains(
+                  "No JsonAdapter for java.util.List<java.lang.String> "
+                      + "annotated [@com.squareup.moshi.MoshiTest$Uppercase()]"));
     }
   }
 
@@ -889,44 +891,51 @@ public final class MoshiTest {
           uppercaseStringField.getGenericType(), Util.getJsonAnnotations(uppercaseStringField));
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo(
-              "No JsonAdapter for class java.lang.String "
-                  + "annotated [@com.squareup.moshi.MoshiTest$Uppercase()]");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains(
+                  "No JsonAdapter for class java.lang.String "
+                      + "annotated [@com.squareup.moshi.MoshiTest$Uppercase()]"));
     }
   }
 
   @Test
-  public void objectArray() throws Exception {
+  public void objectArray() throws IOException {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<String[]> adapter = moshi.adapter(String[].class);
-    assertThat(adapter.toJson(new String[] {"a", "b"})).isEqualTo("[\"a\",\"b\"]");
-    assertThat(adapter.fromJson("[\"a\",\"b\"]")).asList().containsExactly("a", "b").inOrder();
+    assertEquals(adapter.toJson(new String[] {"a", "b"}), "[\"a\",\"b\"]");
+    String[] values = adapter.fromJson("[\"a\",\"b\"]");
+
+    assertEquals("a", values[0]);
+    assertEquals("b", values[1]);
   }
 
   @Test
   public void primitiveArray() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<int[]> adapter = moshi.adapter(int[].class);
-    assertThat(adapter.toJson(new int[] {1, 2})).isEqualTo("[1,2]");
-    assertThat(adapter.fromJson("[2,3]")).asList().containsExactly(2, 3).inOrder();
+    assertEquals(adapter.toJson(new int[] {1, 2}), "[1,2]");
+    int[] values = adapter.fromJson("[2,3]");
+
+    assertEquals(2, values[0]);
+    assertEquals(3, values[1]);
   }
 
   @Test
   public void enumAdapter() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Roshambo> adapter = moshi.adapter(Roshambo.class).lenient();
-    assertThat(adapter.fromJson("\"ROCK\"")).isEqualTo(Roshambo.ROCK);
-    assertThat(adapter.toJson(Roshambo.PAPER)).isEqualTo("\"PAPER\"");
+    assertEquals(adapter.fromJson("\"ROCK\""), Roshambo.ROCK);
+    assertEquals(adapter.toJson(Roshambo.PAPER), "\"PAPER\"");
   }
 
   @Test
   public void annotatedEnum() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Roshambo> adapter = moshi.adapter(Roshambo.class).lenient();
-    assertThat(adapter.fromJson("\"scr\"")).isEqualTo(Roshambo.SCISSORS);
-    assertThat(adapter.toJson(Roshambo.SCISSORS)).isEqualTo("\"scr\"");
+    assertEquals(adapter.fromJson("\"scr\""), Roshambo.SCISSORS);
+    assertEquals(adapter.toJson(Roshambo.SCISSORS), "\"scr\"");
   }
 
   @Test
@@ -937,9 +946,10 @@ public final class MoshiTest {
       adapter.fromJson("\"SPOCK\"");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected one of [ROCK, PAPER, scr] but was SPOCK at path $");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains("Expected one of [ROCK, PAPER, scr] but was SPOCK at path "));
     }
   }
 
@@ -953,20 +963,21 @@ public final class MoshiTest {
       adapter.fromJson(reader);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Expected one of [ROCK, PAPER, scr] but was SPOCK at path $[0]");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains("Expected one of [ROCK, PAPER, scr] but was SPOCK at path $[0]"));
     }
     reader.endArray();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+    assertEquals(reader.peek(), JsonReader.Token.END_DOCUMENT);
   }
 
   @Test
   public void nullEnum() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Roshambo> adapter = moshi.adapter(Roshambo.class).lenient();
-    assertThat(adapter.fromJson("null")).isNull();
-    assertThat(adapter.toJson(null)).isEqualTo("null");
+    assertNull(adapter.fromJson("null"));
+    assertEquals(adapter.toJson(null), "null");
   }
 
   @Test
@@ -974,8 +985,8 @@ public final class MoshiTest {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Pizza> adapter = moshi.adapter(Pizza.class);
     Pizza pizza = adapter.fromJson("{\"diameter\":5,\"crust\":\"thick\",\"extraCheese\":true}");
-    assertThat(pizza.diameter).isEqualTo(5);
-    assertThat(pizza.extraCheese).isEqualTo(true);
+    assertEquals(pizza.diameter, 5);
+    assertEquals(pizza.extraCheese, true);
   }
 
   @Test
@@ -986,7 +997,7 @@ public final class MoshiTest {
       adapter.fromJson("{\"diameter\":5,\"crust\":\"thick\",\"extraCheese\":true}");
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("Cannot skip unexpected NAME at $.crust");
+      assertTrue(expected.getMessage().contains("Cannot skip unexpected NAME at $.crust"));
     }
   }
 
@@ -997,28 +1008,29 @@ public final class MoshiTest {
       moshi.adapter(File.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e)
-          .hasMessageThat()
-          .isEqualTo("Platform class java.io.File requires explicit JsonAdapter to be registered");
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "Platform class java.io.File requires explicit JsonAdapter to be registered"));
     }
     try {
       moshi.adapter(KeyGenerator.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e)
-          .hasMessageThat()
-          .isEqualTo(
-              "Platform class javax.crypto.KeyGenerator requires explicit "
-                  + "JsonAdapter to be registered");
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "Platform class javax.crypto.KeyGenerator requires explicit "
+                      + "JsonAdapter to be registered"));
     }
     try {
       moshi.adapter(Pair.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e)
-          .hasMessageThat()
-          .isEqualTo(
-              "Platform class android.util.Pair requires explicit JsonAdapter to be registered");
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "Platform class android.util.Pair requires explicit JsonAdapter to be registered"));
     }
   }
 
@@ -1029,28 +1041,28 @@ public final class MoshiTest {
       moshi.adapter(Types.newParameterizedType(ArrayList.class, String.class));
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e)
-          .hasMessageThat()
-          .isEqualTo(
-              "No JsonAdapter for "
-                  + "java.util.ArrayList<java.lang.String>, "
-                  + "you should probably use List instead of ArrayList "
-                  + "(Moshi only supports the collection interfaces by default) "
-                  + "or else register a custom JsonAdapter.");
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "No JsonAdapter for "
+                      + "java.util.ArrayList<java.lang.String>, "
+                      + "you should probably use List instead of ArrayList "
+                      + "(Moshi only supports the collection interfaces by default) "
+                      + "or else register a custom JsonAdapter."));
     }
 
     try {
       moshi.adapter(Types.newParameterizedType(HashMap.class, String.class, String.class));
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e)
-          .hasMessageThat()
-          .isEqualTo(
-              "No JsonAdapter for "
-                  + "java.util.HashMap<java.lang.String, java.lang.String>, "
-                  + "you should probably use Map instead of HashMap "
-                  + "(Moshi only supports the collection interfaces by default) "
-                  + "or else register a custom JsonAdapter.");
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "No JsonAdapter for "
+                      + "java.util.HashMap<java.lang.String, java.lang.String>, "
+                      + "you should probably use Map instead of HashMap "
+                      + "(Moshi only supports the collection interfaces by default) "
+                      + "or else register a custom JsonAdapter."));
     }
   }
 
@@ -1070,7 +1082,7 @@ public final class MoshiTest {
 
     JsonAdapter<HashMap<String, String>> adapter =
         moshi.adapter(Types.newParameterizedType(HashMap.class, String.class, String.class));
-    assertThat(adapter).isInstanceOf(MapJsonAdapter.class);
+    assertTrue(adapter instanceof MapJsonAdapter);
   }
 
   static final class HasPlatformType {
@@ -1092,20 +1104,22 @@ public final class MoshiTest {
       moshi.adapter(Types.newParameterizedType(Map.class, String.class, HasPlatformType.class));
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e)
-          .hasMessageThat()
-          .isEqualTo(
-              "Platform class java.util.UUID requires explicit "
-                  + "JsonAdapter to be registered"
-                  + "\nfor class java.util.UUID uuid"
-                  + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType"
-                  + "\nfor java.util.Map<java.lang.String, "
-                  + "com.squareup.moshi.MoshiTest$HasPlatformType>");
-      assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
-      assertThat(e.getCause())
-          .hasMessageThat()
-          .isEqualTo(
-              "Platform class java.util.UUID " + "requires explicit JsonAdapter to be registered");
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "Platform class java.util.UUID requires explicit "
+                      + "JsonAdapter to be registered"
+                      + "\nfor class java.util.UUID uuid"
+                      + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType"
+                      + "\nfor java.util.Map<java.lang.String, "
+                      + "com.squareup.moshi.MoshiTest$HasPlatformType>"));
+      assertTrue(e.getCause() instanceof IllegalArgumentException);
+      assertTrue(
+          e.getCause()
+              .getMessage()
+              .contains(
+                  "Platform class java.util.UUID "
+                      + "requires explicit JsonAdapter to be registered"));
     }
   }
 
@@ -1116,19 +1130,21 @@ public final class MoshiTest {
       moshi.adapter(HasPlatformType.Wrapper.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e)
-          .hasMessageThat()
-          .isEqualTo(
-              "Platform class java.util.UUID requires explicit "
-                  + "JsonAdapter to be registered"
-                  + "\nfor class java.util.UUID uuid"
-                  + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType hasPlatformType"
-                  + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType$Wrapper");
-      assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
-      assertThat(e.getCause())
-          .hasMessageThat()
-          .isEqualTo(
-              "Platform class java.util.UUID " + "requires explicit JsonAdapter to be registered");
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "Platform class java.util.UUID requires explicit "
+                      + "JsonAdapter to be registered"
+                      + "\nfor class java.util.UUID uuid"
+                      + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType hasPlatformType"
+                      + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType$Wrapper"));
+      assertTrue(e.getCause() instanceof IllegalArgumentException);
+      assertTrue(
+          e.getCause()
+              .getMessage()
+              .contains(
+                  "Platform class java.util.UUID "
+                      + "requires explicit JsonAdapter to be registered"));
     }
   }
 
@@ -1139,20 +1155,22 @@ public final class MoshiTest {
       moshi.adapter(HasPlatformType.ListWrapper.class);
       fail();
     } catch (IllegalArgumentException e) {
-      assertThat(e)
-          .hasMessageThat()
-          .isEqualTo(
-              "Platform class java.util.UUID requires explicit "
-                  + "JsonAdapter to be registered"
-                  + "\nfor class java.util.UUID uuid"
-                  + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType"
-                  + "\nfor java.util.List<com.squareup.moshi.MoshiTest$HasPlatformType> platformTypes"
-                  + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType$ListWrapper");
-      assertThat(e).hasCauseThat().isInstanceOf(IllegalArgumentException.class);
-      assertThat(e.getCause())
-          .hasMessageThat()
-          .isEqualTo(
-              "Platform class java.util.UUID " + "requires explicit JsonAdapter to be registered");
+      assertTrue(
+          e.getMessage()
+              .contains(
+                  "Platform class java.util.UUID requires explicit "
+                      + "JsonAdapter to be registered"
+                      + "\nfor class java.util.UUID uuid"
+                      + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType"
+                      + "\nfor java.util.List<com.squareup.moshi.MoshiTest$HasPlatformType> platformTypes"
+                      + "\nfor class com.squareup.moshi.MoshiTest$HasPlatformType$ListWrapper"));
+      assertTrue(e.getCause() instanceof IllegalArgumentException);
+      assertTrue(
+          e.getCause()
+              .getMessage()
+              .contains(
+                  "Platform class java.util.UUID "
+                      + "requires explicit JsonAdapter to be registered"));
     }
   }
 
@@ -1166,9 +1184,8 @@ public final class MoshiTest {
               StandardJsonAdapters.INSTANCE.getBOOLEAN_JSON_ADAPTER());
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Use JsonAdapter.Factory for annotations with elements");
+      assertTrue(
+          expected.getMessage().contains("Use JsonAdapter.Factory for annotations with elements"));
     }
   }
 
@@ -1181,12 +1198,11 @@ public final class MoshiTest {
     baguette.withButter = true;
 
     JsonAdapter<Baguette> adapter = moshi.adapter(Baguette.class);
-    assertThat(adapter.toJson(baguette))
-        .isEqualTo("{\"avecBeurre\":\"oui\",\"withButter\":\"yes\"}");
+    assertEquals(adapter.toJson(baguette), "{\"avecBeurre\":\"oui\",\"withButter\":\"yes\"}");
 
     Baguette decoded = adapter.fromJson("{\"avecBeurre\":\"oui\",\"withButter\":\"yes\"}");
-    assertThat(decoded.avecBeurre).isTrue();
-    assertThat(decoded.withButter).isTrue();
+    assertTrue(decoded.avecBeurre);
+    assertTrue(decoded.withButter);
   }
 
   /** Note that this is the opposite of Gson's behavior, where later adapters are preferred. */
@@ -1221,25 +1237,26 @@ public final class MoshiTest {
     Moshi moshi =
         new Moshi.Builder().add(String.class, adapter1).add(String.class, adapter2).build();
     JsonAdapter<String> adapter = moshi.adapter(String.class).lenient();
-    assertThat(adapter.toJson("a")).isEqualTo("\"one!\"");
+    assertEquals(adapter.toJson("a"), "\"one!\"");
   }
 
   @Test
-  public void cachingJsonAdapters() throws Exception {
+  public void cachingJsonAdapters() {
     Moshi moshi = new Moshi.Builder().build();
 
     JsonAdapter<MealDeal> adapter1 = moshi.adapter(MealDeal.class);
     JsonAdapter<MealDeal> adapter2 = moshi.adapter(MealDeal.class);
-    assertThat(adapter1).isSameInstanceAs(adapter2);
+    assertEquals(adapter1.getClass().getName(), adapter2.getClass().getName());
+    assertEquals(adapter1.getClass(), adapter2.getClass());
   }
 
   @Test
-  public void newBuilder() throws Exception {
+  public void newBuilder() {
     Moshi moshi = new Moshi.Builder().add(Pizza.class, new PizzaAdapter()).build();
     Moshi.Builder newBuilder = moshi.newBuilder();
     for (JsonAdapter.Factory factory : Moshi.BUILT_IN_FACTORIES) {
       // Awkward but java sources don't know about the internal-ness of this
-      assertThat(factory).isNotIn(newBuilder.getFactories$moshi());
+      assertFalse(newBuilder.getFactories$moshi().contains(factory));
     }
   }
 
@@ -1252,14 +1269,15 @@ public final class MoshiTest {
       moshi.adapter(Object.class).toJson(map);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Nesting too deep at $" + repeat(".a", 255) + ": circular reference?");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains("Nesting too deep at $" + repeat(".a", 255) + ": circular reference?"));
     }
   }
 
   @Test
-  public void referenceCyclesOnObjects() throws Exception {
+  public void referenceCyclesOnObjects() {
     Moshi moshi = new Moshi.Builder().build();
     List<Object> list = new ArrayList<>();
     list.add(list);
@@ -1267,9 +1285,10 @@ public final class MoshiTest {
       moshi.adapter(Object.class).toJson(list);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Nesting too deep at $" + repeat("[0]", 255) + ": circular reference?");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains("Nesting too deep at $" + repeat("[0]", 255) + ": circular reference?"));
     }
   }
 
@@ -1284,9 +1303,11 @@ public final class MoshiTest {
       moshi.adapter(Object.class).toJson(list);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Nesting too deep at $[0]" + repeat(".a[0]", 127) + ": circular reference?");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains(
+                  "Nesting too deep at $[0]" + repeat(".a[0]", 127) + ": circular reference?"));
     }
   }
 
@@ -1299,9 +1320,10 @@ public final class MoshiTest {
       adapter.fromJson(json);
       fail();
     } catch (JsonDataException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("Map key 'diameter' has multiple values at path $.diameter: 5.0 and 5.0");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains("Map key 'diameter' has multiple values at path $.diameter: 5.0 and 5.0"));
     }
   }
 
@@ -1310,7 +1332,7 @@ public final class MoshiTest {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Pizza> adapter = moshi.adapter(Pizza.class);
     String json = "{\"diameter\":5,\"diameter\":5,\"extraCheese\":true}";
-    assertThat(adapter.fromJson(json)).isEqualTo(new Pizza(5, true));
+    assertEquals(adapter.fromJson(json), new Pizza(5, true));
   }
 
   @Test
@@ -1323,7 +1345,7 @@ public final class MoshiTest {
             .addLast(new AppendingAdapterFactory(" z"))
             .build();
     JsonAdapter<String> adapter = moshi.adapter(String.class).lenient();
-    assertThat(adapter.toJson("hello")).isEqualTo("\"hello a b y z\"");
+    assertEquals(adapter.toJson("hello"), "\"hello a b y z\"");
   }
 
   @Test
@@ -1345,7 +1367,7 @@ public final class MoshiTest {
             .build();
 
     JsonAdapter<String> adapter = moshi2.adapter(String.class).lenient();
-    assertThat(adapter.toJson("hello")).isEqualTo("\"hello a b c d w x y z\"");
+    assertEquals(adapter.toJson("hello"), "\"hello a b c d w x y z\"");
   }
 
   /** Adds a suffix to a string before emitting it. */

--- a/moshi/src/test/java/com/squareup/moshi/ObjectAdapterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/ObjectAdapterTest.java
@@ -15,9 +15,9 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -52,22 +52,22 @@ public final class ObjectAdapterTest {
 
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Object> adapter = moshi.adapter(Object.class);
-    assertThat(adapter.toJson(delivery))
-        .isEqualTo(
-            "{"
-                + "\"address\":\"1455 Market St.\","
-                + "\"items\":["
-                + "{\"diameter\":12,\"extraCheese\":true},"
-                + "\"Pepsi\""
-                + "]"
-                + "}");
+    assertEquals(
+        adapter.toJson(delivery),
+        "{"
+            + "\"address\":\"1455 Market St.\","
+            + "\"items\":["
+            + "{\"diameter\":12,\"extraCheese\":true},"
+            + "\"Pepsi\""
+            + "]"
+            + "}");
   }
 
   @Test
   public void toJsonJavaLangObject() {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Object> adapter = moshi.adapter(Object.class);
-    assertThat(adapter.toJson(new Object())).isEqualTo("{}");
+    assertEquals(adapter.toJson(new Object()), "{}");
   }
 
   @Test
@@ -81,23 +81,23 @@ public final class ObjectAdapterTest {
 
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Object> adapter = moshi.adapter(Object.class);
-    assertThat(
-            adapter.fromJson(
-                "{"
-                    + "\"address\":\"1455 Market St.\","
-                    + "\"items\":["
-                    + "{\"diameter\":12,\"extraCheese\":true},"
-                    + "\"Pepsi\""
-                    + "]"
-                    + "}"))
-        .isEqualTo(delivery);
+    assertEquals(
+        adapter.fromJson(
+            "{"
+                + "\"address\":\"1455 Market St.\","
+                + "\"items\":["
+                + "{\"diameter\":12,\"extraCheese\":true},"
+                + "\"Pepsi\""
+                + "]"
+                + "}"),
+        delivery);
   }
 
   @Test
   public void fromJsonUsesDoublesForNumbers() throws Exception {
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Object> adapter = moshi.adapter(Object.class);
-    assertThat(adapter.fromJson("[0, 1]")).isEqualTo(Arrays.asList(0d, 1d));
+    assertEquals(adapter.fromJson("[0, 1]"), Arrays.asList(0d, 1d));
   }
 
   @Test
@@ -108,7 +108,7 @@ public final class ObjectAdapterTest {
 
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Object> adapter = moshi.adapter(Object.class);
-    assertThat(adapter.fromJson("{\"address\":null, \"items\":null}")).isEqualTo(emptyDelivery);
+    assertEquals(adapter.fromJson("{\"address\":null, \"items\":null}"), emptyDelivery);
   }
 
   @Test
@@ -128,7 +128,7 @@ public final class ObjectAdapterTest {
 
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Object> adapter = moshi.adapter(Object.class);
-    assertThat(adapter.toJson(collection)).isEqualTo("[\"A\"]");
+    assertEquals(adapter.toJson(collection), "[\"A\"]");
   }
 
   @Test
@@ -148,7 +148,7 @@ public final class ObjectAdapterTest {
 
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Object> adapter = moshi.adapter(Object.class);
-    assertThat(adapter.toJson(list)).isEqualTo("[\"A\"]");
+    assertEquals(adapter.toJson(list), "[\"A\"]");
   }
 
   @Test
@@ -168,7 +168,7 @@ public final class ObjectAdapterTest {
 
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Object> adapter = moshi.adapter(Object.class);
-    assertThat(adapter.toJson(set)).isEqualTo("[\"A\"]");
+    assertEquals(adapter.toJson(set), "[\"A\"]");
   }
 
   @Test
@@ -183,7 +183,7 @@ public final class ObjectAdapterTest {
 
     Moshi moshi = new Moshi.Builder().build();
     JsonAdapter<Object> adapter = moshi.adapter(Object.class);
-    assertThat(adapter.toJson(map)).isEqualTo("{\"A\":true}");
+    assertEquals(adapter.toJson(map), "{\"A\":true}");
   }
 
   @Test
@@ -202,7 +202,7 @@ public final class ObjectAdapterTest {
         };
     Moshi moshi = new Moshi.Builder().add(dateAdapter).build();
     JsonAdapter<Object> adapter = moshi.adapter(Object.class);
-    assertThat(adapter.toJson(Arrays.asList(new Date(1), new Date(2)))).isEqualTo("[1,2]");
+    assertEquals(adapter.toJson(Arrays.asList(new Date(1), new Date(2))), "[1,2]");
   }
 
   /**
@@ -228,7 +228,14 @@ public final class ObjectAdapterTest {
     JsonAdapter<Object> objectAdapter = moshi.adapter(Object.class);
     Map<String, String> value =
         (Map<String, String>) objectAdapter.fromJson("{\"a\":\"b\", \"c\":\"d\"}");
-    assertThat(value).containsExactly("A", "B", "C", "D");
+    Object[] keys = value.keySet().toArray();
+    Object[] values = value.values().toArray();
+    assertEquals(keys[0], "A");
+    assertEquals(keys[1], "C");
+    assertEquals(values[0], "B");
+    assertEquals(values[1], "D");
+    assertEquals(value.get("A"), "B");
+    assertEquals(value.get("C"), "D");
   }
 
   /**
@@ -266,13 +273,13 @@ public final class ObjectAdapterTest {
     Moshi moshi = new Moshi.Builder().add(objectFactory).build();
     JsonAdapter<Object> objectAdapter = moshi.adapter(Object.class);
     List<?> value = (List<?>) objectAdapter.fromJson("[0, 1, 2.0, 3.14]");
-    assertThat(value)
-        .isEqualTo(
-            Arrays.asList(
-                new BigDecimal("0"),
-                new BigDecimal("1"),
-                new BigDecimal("2.0"),
-                new BigDecimal("3.14")));
+    assertEquals(
+        value,
+        Arrays.asList(
+            new BigDecimal("0"),
+            new BigDecimal("1"),
+            new BigDecimal("2.0"),
+            new BigDecimal("3.14")));
   }
 
   /** Confirm that the built-in adapter for Object delegates to user-supplied adapters for lists. */
@@ -295,7 +302,7 @@ public final class ObjectAdapterTest {
     Moshi moshi = new Moshi.Builder().add(List.class, listAdapter).build();
     JsonAdapter<Object> objectAdapter = moshi.adapter(Object.class);
     Map<?, ?> mapOfList = (Map<?, ?>) objectAdapter.fromJson("{\"a\":[\"b\"]}");
-    assertThat(mapOfList).isEqualTo(singletonMap("a", singletonList("z")));
+    assertEquals(mapOfList, singletonMap("a", singletonList("z")));
   }
 
   /** Confirm that the built-in adapter for Object delegates to user-supplied adapters for maps. */
@@ -318,7 +325,7 @@ public final class ObjectAdapterTest {
     Moshi moshi = new Moshi.Builder().add(Map.class, mapAdapter).build();
     JsonAdapter<Object> objectAdapter = moshi.adapter(Object.class);
     List<?> listOfMap = (List<?>) objectAdapter.fromJson("[{\"b\":\"c\"}]");
-    assertThat(listOfMap).isEqualTo(singletonList(singletonMap("x", "y")));
+    assertEquals(listOfMap, singletonList(singletonMap("x", "y")));
   }
 
   static class Delivery {

--- a/moshi/src/test/java/com/squareup/moshi/PromoteNameToValueTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/PromoteNameToValueTest.java
@@ -15,7 +15,11 @@
  */
 package com.squareup.moshi;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.List;
@@ -40,14 +44,14 @@ public final class PromoteNameToValueTest {
     JsonReader reader = factory.newReader("{\"a\":1}");
     reader.beginObject();
     reader.promoteNameToValue();
-    assertThat(reader.getPath()).isEqualTo("$.a");
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.STRING);
-    assertThat(reader.nextString()).isEqualTo("a");
-    assertThat(reader.getPath()).isEqualTo("$.a");
-    assertThat(reader.nextInt()).isEqualTo(1);
-    assertThat(reader.getPath()).isEqualTo("$.a");
+    assertEquals(reader.getPath(), "$.a");
+    assertEquals(reader.peek(), JsonReader.Token.STRING);
+    assertEquals(reader.nextString(), "a");
+    assertEquals(reader.getPath(), "$.a");
+    assertEquals(reader.nextInt(), 1);
+    assertEquals(reader.getPath(), "$.a");
     reader.endObject();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
   }
 
   @Test
@@ -55,14 +59,14 @@ public final class PromoteNameToValueTest {
     JsonReader reader = factory.newReader("{\"5\":1}");
     reader.beginObject();
     reader.promoteNameToValue();
-    assertThat(reader.getPath()).isEqualTo("$.5");
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.STRING);
-    assertThat(reader.nextInt()).isEqualTo(5);
-    assertThat(reader.getPath()).isEqualTo("$.5");
-    assertThat(reader.nextInt()).isEqualTo(1);
-    assertThat(reader.getPath()).isEqualTo("$.5");
+    assertEquals(reader.getPath(), "$.5");
+    assertEquals(reader.peek(), JsonReader.Token.STRING);
+    assertEquals(reader.nextInt(), 5);
+    assertEquals(reader.getPath(), "$.5");
+    assertEquals(reader.nextInt(), 1);
+    assertEquals(reader.getPath(), "$.5");
     reader.endObject();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
   }
 
   @Test
@@ -70,14 +74,14 @@ public final class PromoteNameToValueTest {
     JsonReader reader = factory.newReader("{\"5.5\":1}");
     reader.beginObject();
     reader.promoteNameToValue();
-    assertThat(reader.getPath()).isEqualTo("$.5.5");
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.STRING);
-    assertThat(reader.nextDouble()).isEqualTo(5.5d);
-    assertThat(reader.getPath()).isEqualTo("$.5.5");
-    assertThat(reader.nextInt()).isEqualTo(1);
-    assertThat(reader.getPath()).isEqualTo("$.5.5");
+    assertEquals(reader.getPath(), "$.5.5");
+    assertEquals(reader.peek(), JsonReader.Token.STRING);
+    assertEquals(5.5d, reader.nextDouble(), 0);
+    assertEquals(reader.getPath(), "$.5.5");
+    assertEquals(reader.nextInt(), 1);
+    assertEquals(reader.getPath(), "$.5.5");
     reader.endObject();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
   }
 
   @Test
@@ -85,24 +89,24 @@ public final class PromoteNameToValueTest {
     JsonReader reader = factory.newReader("{\"true\":1}");
     reader.beginObject();
     reader.promoteNameToValue();
-    assertThat(reader.getPath()).isEqualTo("$.true");
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.STRING);
+    assertEquals(reader.getPath(), "$.true");
+    assertEquals(reader.peek(), JsonReader.Token.STRING);
     try {
       reader.nextBoolean();
       fail();
     } catch (JsonDataException e) {
-      assertThat(e)
-          .hasMessageThat()
-          .isAnyOf(
-              "Expected BOOLEAN but was true, a java.lang.String, at path $.true",
-              "Expected a boolean but was STRING at path $.true");
+      assertThat(
+          e.getMessage(),
+          anyOf(
+              containsString("Expected BOOLEAN but was true, a java.lang.String, at path $.true"),
+              containsString("Expected a boolean but was STRING at path $.true")));
     }
-    assertThat(reader.getPath()).isEqualTo("$.true");
-    assertThat(reader.nextString()).isEqualTo("true");
-    assertThat(reader.getPath()).isEqualTo("$.true");
-    assertThat(reader.nextInt()).isEqualTo(1);
+    assertEquals(reader.getPath(), "$.true");
+    assertEquals(reader.nextString(), "true");
+    assertEquals(reader.getPath(), "$.true");
+    assertEquals(reader.nextInt(), 1);
     reader.endObject();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
   }
 
   @Test
@@ -110,14 +114,14 @@ public final class PromoteNameToValueTest {
     JsonReader reader = factory.newReader("{\"5\":1}");
     reader.beginObject();
     reader.promoteNameToValue();
-    assertThat(reader.getPath()).isEqualTo("$.5");
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.STRING);
-    assertThat(reader.nextLong()).isEqualTo(5L);
-    assertThat(reader.getPath()).isEqualTo("$.5");
-    assertThat(reader.nextInt()).isEqualTo(1);
-    assertThat(reader.getPath()).isEqualTo("$.5");
+    assertEquals(reader.getPath(), "$.5");
+    assertEquals(reader.peek(), JsonReader.Token.STRING);
+    assertEquals(reader.nextLong(), 5L);
+    assertEquals(reader.getPath(), "$.5");
+    assertEquals(reader.nextInt(), 1);
+    assertEquals(reader.getPath(), "$.5");
     reader.endObject();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
   }
 
   @Test
@@ -125,52 +129,52 @@ public final class PromoteNameToValueTest {
     JsonReader reader = factory.newReader("{\"null\":1}");
     reader.beginObject();
     reader.promoteNameToValue();
-    assertThat(reader.getPath()).isEqualTo("$.null");
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.STRING);
+    assertEquals(reader.getPath(), "$.null");
+    assertEquals(reader.peek(), JsonReader.Token.STRING);
     try {
       reader.nextNull();
       fail();
     } catch (JsonDataException e) {
-      assertThat(e)
-          .hasMessageThat()
-          .isAnyOf(
-              "Expected NULL but was null, a java.lang.String, at path $.null",
-              "Expected null but was STRING at path $.null");
+      assertThat(
+          e.getMessage(),
+          anyOf(
+              containsString("Expected NULL but was null, a java.lang.String, at path $.null"),
+              containsString("Expected null but was STRING at path $.null")));
     }
-    assertThat(reader.nextString()).isEqualTo("null");
-    assertThat(reader.getPath()).isEqualTo("$.null");
-    assertThat(reader.nextInt()).isEqualTo(1);
-    assertThat(reader.getPath()).isEqualTo("$.null");
+    assertEquals(reader.nextString(), "null");
+    assertEquals(reader.getPath(), "$.null");
+    assertEquals(reader.nextInt(), 1);
+    assertEquals(reader.getPath(), "$.null");
     reader.endObject();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
   }
 
   @Test
   public void readerMultipleValueObject() throws Exception {
     JsonReader reader = factory.newReader("{\"a\":1,\"b\":2}");
     reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.nextInt()).isEqualTo(1);
+    assertEquals(reader.nextName(), "a");
+    assertEquals(reader.nextInt(), 1);
     reader.promoteNameToValue();
-    assertThat(reader.getPath()).isEqualTo("$.b");
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.STRING);
-    assertThat(reader.nextString()).isEqualTo("b");
-    assertThat(reader.getPath()).isEqualTo("$.b");
-    assertThat(reader.nextInt()).isEqualTo(2);
-    assertThat(reader.getPath()).isEqualTo("$.b");
+    assertEquals(reader.getPath(), "$.b");
+    assertEquals(reader.peek(), JsonReader.Token.STRING);
+    assertEquals(reader.nextString(), "b");
+    assertEquals(reader.getPath(), "$.b");
+    assertEquals(reader.nextInt(), 2);
+    assertEquals(reader.getPath(), "$.b");
     reader.endObject();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
   }
 
   @Test
   public void readerEmptyValueObject() throws Exception {
     JsonReader reader = factory.newReader("{}");
     reader.beginObject();
-    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_OBJECT);
+    assertEquals(reader.peek(), JsonReader.Token.END_OBJECT);
     reader.promoteNameToValue();
-    assertThat(reader.getPath()).isEqualTo("$.");
+    assertEquals(reader.getPath(), "$.");
     reader.endObject();
-    assertThat(reader.getPath()).isEqualTo("$");
+    assertEquals(reader.getPath(), "$");
   }
 
   @Test
@@ -186,7 +190,7 @@ public final class PromoteNameToValueTest {
       fail();
     } catch (JsonDataException expected) {
     }
-    assertThat(reader.nextName()).isEqualTo("a");
+    assertEquals(reader.nextName(), "a");
   }
 
   @Test
@@ -195,8 +199,8 @@ public final class PromoteNameToValueTest {
     reader.setLenient(true);
     reader.beginObject();
     reader.promoteNameToValue();
-    assertThat(reader.nextInt()).isEqualTo(5);
-    assertThat(reader.nextInt()).isEqualTo(1);
+    assertEquals(reader.nextInt(), 5);
+    assertEquals(reader.nextInt(), 1);
     reader.endObject();
   }
 
@@ -206,8 +210,8 @@ public final class PromoteNameToValueTest {
     reader.setLenient(true);
     reader.beginObject();
     reader.promoteNameToValue();
-    assertThat(reader.nextLong()).isEqualTo(5L);
-    assertThat(reader.nextInt()).isEqualTo(1);
+    assertEquals(reader.nextLong(), 5L);
+    assertEquals(reader.nextInt(), 1);
     reader.endObject();
   }
 
@@ -217,8 +221,8 @@ public final class PromoteNameToValueTest {
     reader.setLenient(true);
     reader.beginObject();
     reader.promoteNameToValue();
-    assertThat(reader.nextDouble()).isEqualTo(5d);
-    assertThat(reader.nextInt()).isEqualTo(1);
+    assertEquals(5d, reader.nextDouble(), 0);
+    assertEquals(reader.nextInt(), 1);
     reader.endObject();
   }
 
@@ -228,12 +232,12 @@ public final class PromoteNameToValueTest {
     writer.beginObject();
     writer.promoteValueToName();
     writer.value("a");
-    assertThat(writer.getPath()).isEqualTo("$.a");
+    assertEquals(writer.getPath(), "$.a");
     writer.value(1);
-    assertThat(writer.getPath()).isEqualTo("$.a");
+    assertEquals(writer.getPath(), "$.a");
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$");
-    assertThat(factory.json()).isEqualTo("{\"a\":1}");
+    assertEquals(writer.getPath(), "$");
+    assertEquals(factory.json(), "{\"a\":1}");
   }
 
   @Test
@@ -242,12 +246,12 @@ public final class PromoteNameToValueTest {
     writer.beginObject();
     writer.promoteValueToName();
     writer.value(5);
-    assertThat(writer.getPath()).isEqualTo("$.5");
+    assertEquals(writer.getPath(), "$.5");
     writer.value(1);
-    assertThat(writer.getPath()).isEqualTo("$.5");
+    assertEquals(writer.getPath(), "$.5");
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$");
-    assertThat(factory.json()).isEqualTo("{\"5\":1}");
+    assertEquals(writer.getPath(), "$");
+    assertEquals(factory.json(), "{\"5\":1}");
   }
 
   @Test
@@ -256,12 +260,12 @@ public final class PromoteNameToValueTest {
     writer.beginObject();
     writer.promoteValueToName();
     writer.value(5.5d);
-    assertThat(writer.getPath()).isEqualTo("$.5.5");
+    assertEquals(writer.getPath(), "$.5.5");
     writer.value(1);
-    assertThat(writer.getPath()).isEqualTo("$.5.5");
+    assertEquals(writer.getPath(), "$.5.5");
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$");
-    assertThat(factory.json()).isEqualTo("{\"5.5\":1}");
+    assertEquals(writer.getPath(), "$");
+    assertEquals(factory.json(), "{\"5.5\":1}");
   }
 
   @Test
@@ -273,16 +277,14 @@ public final class PromoteNameToValueTest {
       writer.value(true);
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e)
-          .hasMessageThat()
-          .isEqualTo("Boolean cannot be used as a map key in JSON at path $.");
+      assertTrue(e.getMessage().contains("Boolean cannot be used as a map key in JSON at path $."));
     }
     writer.value("true");
-    assertThat(writer.getPath()).isEqualTo("$.true");
+    assertEquals(writer.getPath(), "$.true");
     writer.value(1);
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$");
-    assertThat(factory.json()).isEqualTo("{\"true\":1}");
+    assertEquals(writer.getPath(), "$");
+    assertEquals(factory.json(), "{\"true\":1}");
   }
 
   @Test
@@ -291,12 +293,12 @@ public final class PromoteNameToValueTest {
     writer.beginObject();
     writer.promoteValueToName();
     writer.value(5L);
-    assertThat(writer.getPath()).isEqualTo("$.5");
+    assertEquals(writer.getPath(), "$.5");
     writer.value(1);
-    assertThat(writer.getPath()).isEqualTo("$.5");
+    assertEquals(writer.getPath(), "$.5");
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$");
-    assertThat(factory.json()).isEqualTo("{\"5\":1}");
+    assertEquals(writer.getPath(), "$");
+    assertEquals(factory.json(), "{\"5\":1}");
   }
 
   @Test
@@ -308,17 +310,15 @@ public final class PromoteNameToValueTest {
       writer.nullValue();
       fail();
     } catch (IllegalStateException e) {
-      assertThat(e)
-          .hasMessageThat()
-          .isEqualTo("null cannot be used as a map key in JSON at path $.");
+      assertTrue(e.getMessage().contains("null cannot be used as a map key in JSON at path $."));
     }
     writer.value("null");
-    assertThat(writer.getPath()).isEqualTo("$.null");
+    assertEquals(writer.getPath(), "$.null");
     writer.value(1);
-    assertThat(writer.getPath()).isEqualTo("$.null");
+    assertEquals(writer.getPath(), "$.null");
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$");
-    assertThat(factory.json()).isEqualTo("{\"null\":1}");
+    assertEquals(writer.getPath(), "$");
+    assertEquals(factory.json(), "{\"null\":1}");
   }
 
   @Test
@@ -329,12 +329,12 @@ public final class PromoteNameToValueTest {
     writer.value(1);
     writer.promoteValueToName();
     writer.value("b");
-    assertThat(writer.getPath()).isEqualTo("$.b");
+    assertEquals(writer.getPath(), "$.b");
     writer.value(2);
-    assertThat(writer.getPath()).isEqualTo("$.b");
+    assertEquals(writer.getPath(), "$.b");
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$");
-    assertThat(factory.json()).isEqualTo("{\"a\":1,\"b\":2}");
+    assertEquals(writer.getPath(), "$");
+    assertEquals(factory.json(), "{\"a\":1,\"b\":2}");
   }
 
   @Test
@@ -342,10 +342,10 @@ public final class PromoteNameToValueTest {
     JsonWriter writer = factory.newWriter();
     writer.beginObject();
     writer.promoteValueToName();
-    assertThat(writer.getPath()).isEqualTo("$.");
+    assertEquals(writer.getPath(), "$.");
     writer.endObject();
-    assertThat(writer.getPath()).isEqualTo("$");
-    assertThat(factory.json()).isEqualTo("{}");
+    assertEquals(writer.getPath(), "$");
+    assertEquals(factory.json(), "{}");
   }
 
   @Test
@@ -373,14 +373,15 @@ public final class PromoteNameToValueTest {
       writer.value(new Buffer().writeUtf8("\"a\""));
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("BufferedSource cannot be used as a map key in JSON at path $.");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains("BufferedSource cannot be used as a map key in JSON at path $."));
     }
     writer.value("a");
     writer.value("a value");
     writer.endObject();
-    assertThat(factory.json()).isEqualTo("{\"a\":\"a value\"}");
+    assertEquals(factory.json(), "{\"a\":\"a value\"}");
   }
 
   @Test
@@ -392,13 +393,14 @@ public final class PromoteNameToValueTest {
       writer.valueSink();
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected)
-          .hasMessageThat()
-          .isEqualTo("BufferedSink cannot be used as a map key in JSON at path $.");
+      assertTrue(
+          expected
+              .getMessage()
+              .contains("BufferedSink cannot be used as a map key in JSON at path $."));
     }
     writer.value("a");
     writer.value("a value");
     writer.endObject();
-    assertThat(factory.json()).isEqualTo("{\"a\":\"a value\"}");
+    assertEquals(factory.json(), "{\"a\":\"a value\"}");
   }
 }


### PR DESCRIPTION
Motivation:
Is there any specific reason to use the truth testing library? I checked the whole code base and generally, you had used isEqual of type methods. I changed with JUnit assertion methods and I've not changed any test semantics. If there is a good reason then you can decline PR.

Changes:
Remove -> com.google.truth:truth:1.1.3 dependency
Remove -> import static com.google.common.truth.Truth.assertThat in classes
