### PR TITLE
Adding support for inline classes and unsigned integers

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,9 @@ kotlinCompileTesting = "1.4.9-alpha01"
 kotlinpoet = "1.12.0"
 ksp = "1.7.0-1.0.6"
 ktlint = "0.45.2"
+assertk = "0.25"
+junitJupiter = "5.9.1"
+#"org.junit.jupiter:junit-jupiter:5.9.1"
 
 [plugins]
 dokka = { id = "org.jetbrains.dokka", version = "1.6.21" }
@@ -36,7 +39,9 @@ okio = "com.squareup.okio:okio:3.1.0"
 
 # Test libs
 assertj = "org.assertj:assertj-core:3.11.1"
+assertk = { module = "com.willowtreeapps.assertk:assertk-jvm", version.ref = "assertk"}
 junit = "junit:junit:4.13.2"
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junitJupiter" }
 kotlinCompileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version.ref = "kotlinCompileTesting" }
 kotlinCompileTesting-ksp = { module = "com.github.tschuchortdev:kotlin-compile-testing-ksp", version.ref ="kotlinCompileTesting" }
 truth = "com.google.truth:truth:1.1.3"

--- a/moshi-kotlin/build.gradle.kts
+++ b/moshi-kotlin/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
   testImplementation(kotlin("test"))
   testImplementation(libs.junit)
   testImplementation(libs.truth)
+  testImplementation(libs.junit.jupiter)
+  testImplementation(libs.assertk)
 }
 
 tasks.withType<Jar>().configureEach {

--- a/moshi-kotlin/src/main/java/com/squareup/moshi/kotlin/inline/UnsignedNumberJsonAdapter.kt
+++ b/moshi-kotlin/src/main/java/com/squareup/moshi/kotlin/inline/UnsignedNumberJsonAdapter.kt
@@ -1,0 +1,67 @@
+package com.squareup.moshi.kotlin.inline
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonReader.Token
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.rawType
+import java.lang.reflect.Type
+
+internal class UnsignedNumberJsonAdapter<UnsignedT : Any> private constructor(
+  private val toUnsignedT: ULong.() -> UnsignedT,
+) : JsonAdapter<UnsignedT>() {
+  override fun toJson(writer: JsonWriter, value: UnsignedT?) {
+    when (value) {
+      null -> writer.nullValue()
+      else -> writer.valueSink().use { it.writeUtf8(value.toString()) }
+    }
+  }
+
+  override fun fromJson(reader: JsonReader): UnsignedT? = when (val next = reader.peek()) {
+    Token.NUMBER -> {
+      try {
+        reader.nextString().toULong().toUnsignedT()
+      } catch (numberFormatException: NumberFormatException) {
+        throw JsonDataException(
+          "${numberFormatException.message} for unsigned number at ${reader.path}"
+        )
+      }
+    }
+
+    Token.NULL -> reader.nextNull()
+    else -> throw JsonDataException(
+      "Expected an unsigned number but was ${reader.readJsonValue()}, " +
+        "a $next, at path ${reader.path}",
+      IllegalArgumentException(next.name)
+    )
+  }
+
+  object Factory : JsonAdapter.Factory {
+    private val unsignedTypesMapperMap: Map<Class<*>, ULong.() -> Any> = mapOf(
+      ULong::class.java to { this },
+      UInt::class.java to {
+        if (this > UInt.MAX_VALUE) throw NumberFormatException("Invalid number format: '$this'") else toUInt()
+      },
+      UShort::class.java to {
+        if (this > UShort.MAX_VALUE) throw NumberFormatException("Invalid number format: '$this'") else toUShort()
+      },
+      UByte::class.java to {
+        if (this > UByte.MAX_VALUE) throw NumberFormatException("Invalid number format: '$this'") else toUByte()
+      }
+    )
+
+    private val Type.isUnsignedType: Boolean
+      get() = unsignedTypesMapperMap.keys.contains(rawType)
+
+    private val Type.mapper: ULong.() -> Any
+      get() = unsignedTypesMapperMap[rawType]!!
+
+    override fun create(
+      type: Type,
+      annotations: Set<Annotation>,
+      moshi: Moshi,
+    ): JsonAdapter<*>? = if (type.isUnsignedType) UnsignedNumberJsonAdapter(type.mapper) else null
+  }
+}

--- a/moshi-kotlin/src/main/java/com/squareup/moshi/kotlin/inline/ValueClassJsonAdapter.kt
+++ b/moshi-kotlin/src/main/java/com/squareup/moshi/kotlin/inline/ValueClassJsonAdapter.kt
@@ -1,0 +1,51 @@
+package com.squareup.moshi.kotlin.inline
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.rawType
+import java.lang.reflect.Constructor
+import java.lang.reflect.Type
+
+internal class ValueClassJsonAdapter<InlineT : Any, ValueT : Any> private constructor(
+  private val constructor: Constructor<out InlineT>,
+  private val adapter: JsonAdapter<ValueT>,
+) : JsonAdapter<InlineT>() {
+  @Suppress("UNCHECKED_CAST")
+  private fun <T : Any, ValueT> T.declaredProperty(): ValueT = with(this::class.java.declaredFields.first()) {
+    isAccessible = true
+    get(this@declaredProperty) as ValueT
+  }
+
+  override fun toJson(
+    writer: JsonWriter,
+    value: InlineT?,
+  ) {
+    value?.let { writer.jsonValue(adapter.toJsonValue(it.declaredProperty())) }
+  }
+
+  @Suppress("TooGenericExceptionCaught")
+  override fun fromJson(reader: JsonReader): InlineT =
+    reader.readJsonValue().let { jsonValue -> constructor.newInstance(adapter.fromJsonValue(jsonValue)) }
+
+  object Factory : JsonAdapter.Factory {
+    private val unsignedTypes = listOf(
+      ULong::class.java,
+      UInt::class.java,
+      UShort::class.java,
+      UByte::class.java,
+    )
+
+    override fun create(
+      type: Type,
+      annotations: Set<Annotation>,
+      moshi: Moshi,
+    ): JsonAdapter<Any>? = if (type.rawType.kotlin.isValue && !unsignedTypes.contains(type)) {
+      val constructor = (type.rawType.declaredConstructors.first { it.parameterCount == 1 } as Constructor<*>)
+        .also { it.isAccessible = true }
+      val valueType = type.rawType.declaredFields[0].genericType
+      ValueClassJsonAdapter(constructor = constructor, adapter = moshi.adapter(valueType))
+    } else null
+  }
+}

--- a/moshi-kotlin/src/test/java/com/squareup/moshi/kotlin/inline/TestModels.kt
+++ b/moshi-kotlin/src/test/java/com/squareup/moshi/kotlin/inline/TestModels.kt
@@ -1,0 +1,68 @@
+package com.squareup.moshi.kotlin.inline
+
+@JvmInline
+value class JvmInlineNullableString(val value: String?)
+
+@JvmInline
+value class JvmInlineString(val value: String) {
+  constructor(
+    baseString: String,
+    appendedString: String,
+  ) : this(baseString + appendedString)
+
+  val secondValue: Char
+    get() = value.first()
+}
+
+@JvmInline
+value class JvmInlineInt(val value: Int)
+
+@JvmInline
+value class JvmInlineUInt(val unsignedValue: UInt)
+
+data class DataClassWithUIntAndString(
+  val stringValue: String,
+  val unsignedValue: UInt,
+)
+
+@JvmInline
+value class JvmInlineDouble(val value: Double)
+
+@JvmInline
+value class JvmInlineComplexClass(
+  val value: ExampleNestedClass,
+) {
+  data class ExampleNestedClass(
+    val stringValue: String,
+    val intValue: Int,
+  )
+}
+
+@JvmInline
+value class JvmInlineListInt(val list: List<Int>)
+
+@JvmInline
+value class JvmInlineMapStringNullableInt(val map: Map<String, Int?>)
+
+@JvmInline
+value class JvmInlineMapComplexClass(val parameterizedValue: Map<String, JvmInlineComplexClass>)
+
+@JvmInline
+value class JvmInlineComplexClassWithParameterizedField(
+  val value: ExampleNestedClassWithParameterizedField,
+) {
+  data class ExampleNestedClassWithParameterizedField(
+    val strings: List<String>,
+    val ints: List<Int>,
+  )
+}
+
+data class DataClassWithUInt(val uInt: UInt)
+
+data class DataClassWithULong(val uLong: ULong)
+
+data class DataClassWithUShort(val uShort: UShort)
+
+data class DataClassWithUByte(val uByte: UByte)
+
+data class DataClassWithNullableULong(val nullableULong: ULong?)

--- a/moshi-kotlin/src/test/java/com/squareup/moshi/kotlin/inline/TestUtil.kt
+++ b/moshi-kotlin/src/test/java/com/squareup/moshi/kotlin/inline/TestUtil.kt
@@ -1,0 +1,7 @@
+package com.squareup.moshi.kotlin.inline
+
+import com.squareup.moshi.Moshi
+
+inline fun <reified T : Any> Moshi.serialize(value: T): String = adapter(T::class.java).toJson(value)
+
+fun <T : Any> Moshi.deserialize(value: String, type: Class<T>): T = adapter(type).fromJson(value)!!

--- a/moshi-kotlin/src/test/java/com/squareup/moshi/kotlin/inline/TestValues.kt
+++ b/moshi-kotlin/src/test/java/com/squareup/moshi/kotlin/inline/TestValues.kt
@@ -1,0 +1,63 @@
+package com.squareup.moshi.kotlin.inline
+
+import org.intellij.lang.annotations.Language
+
+val jvmInlineString = JvmInlineString("exampleValue")
+val jvmInlineInt = JvmInlineInt(10)
+val jvmInlineDouble = JvmInlineDouble(0.5)
+val exampleNestedClass = JvmInlineComplexClass.ExampleNestedClass(
+  stringValue = "a string",
+  intValue = 10
+)
+val jvmInlineComplexClass = JvmInlineComplexClass(value = exampleNestedClass)
+val jvmInlineListInt = JvmInlineListInt(list = listOf(0, 2, 99))
+val jvmInlineMapStringNullableInt = JvmInlineMapStringNullableInt(mapOf("first" to 1, "missing" to null))
+val jvmInlineMapComplexClass = JvmInlineMapComplexClass(mapOf("key" to jvmInlineComplexClass))
+val jvmInlineComplexClassWithParameterizedField = JvmInlineComplexClassWithParameterizedField(
+  value = JvmInlineComplexClassWithParameterizedField.ExampleNestedClassWithParameterizedField(
+    strings = listOf("i", "have", "strings"),
+    ints = listOf(5, 10)
+  )
+)
+
+val jvmInlineStringMultipleConstructorUsage = JvmInlineString("base", "Appended")
+val jvmInlineNotNullNullableString = JvmInlineNullableString("notNull")
+val jvmInlineNullNullableString = JvmInlineNullableString(null)
+val jvmInlineUInt = JvmInlineUInt(unsignedValue = 99u)
+val dataClassWithUInt = DataClassWithUInt(Int.MAX_VALUE.toUInt() + Short.MAX_VALUE.toUInt())
+val dataClassWithULong = DataClassWithULong(Long.MAX_VALUE.toULong() + Int.MAX_VALUE.toUInt())
+val dataClassWithUShort = DataClassWithUShort(
+  (Short.MAX_VALUE.toUShort() + Byte.MAX_VALUE.toUShort()).toUShort()
+)
+val dataClassWithUByte = DataClassWithUByte((Byte.MAX_VALUE.toUByte() + 10u).toUByte())
+val dataClassWithUIntAndString = DataClassWithUIntAndString(
+  stringValue = "foo",
+  unsignedValue = dataClassWithUInt.uInt
+)
+
+@Language("JSON")
+val instanceToJsonStringMap: MutableMap<Any, String> = mutableMapOf(
+  jvmInlineString to """"${jvmInlineString.value}"""",
+  jvmInlineInt to "${jvmInlineInt.value}",
+  jvmInlineDouble to "${jvmInlineDouble.value}",
+  jvmInlineComplexClass to
+    """{"stringValue":"${jvmInlineComplexClass.value.stringValue}",""" +
+    """"intValue":${jvmInlineComplexClass.value.intValue}}""",
+  jvmInlineListInt to """[0,2,99]""",
+  jvmInlineMapStringNullableInt to """{"first":${jvmInlineMapStringNullableInt.map["first"]},"missing":null}""",
+  jvmInlineMapComplexClass to
+    """{"key":{"stringValue":"${jvmInlineComplexClass.value.stringValue}",""" +
+    """"intValue":${jvmInlineComplexClass.value.intValue}}}""",
+  jvmInlineStringMultipleConstructorUsage to """"${jvmInlineStringMultipleConstructorUsage.value}"""",
+  jvmInlineNotNullNullableString to """"${jvmInlineNotNullNullableString.value}"""",
+  jvmInlineNullNullableString to """null""",
+  jvmInlineComplexClassWithParameterizedField to """{"strings":["i","have","strings"],"ints":[5,10]}""",
+  jvmInlineUInt to """${jvmInlineUInt.unsignedValue}""",
+  dataClassWithULong to """{"uLong":${dataClassWithULong.uLong}}""",
+  dataClassWithUInt to """{"uInt":${dataClassWithUInt.uInt}}""",
+  dataClassWithUShort to """{"uShort":${dataClassWithUShort.uShort}}""",
+  dataClassWithUByte to """{"uByte":${dataClassWithUByte.uByte}}""",
+  dataClassWithUIntAndString to
+    """{"stringValue":"${dataClassWithUIntAndString.stringValue}",""" +
+    """"unsignedValue":${dataClassWithUIntAndString.unsignedValue}}"""
+)

--- a/moshi-kotlin/src/test/java/com/squareup/moshi/kotlin/inline/UnsignedNumberJsonAdapterTest.kt
+++ b/moshi-kotlin/src/test/java/com/squareup/moshi/kotlin/inline/UnsignedNumberJsonAdapterTest.kt
@@ -1,0 +1,159 @@
+package com.squareup.moshi.kotlin.inline
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import assertk.assertions.startsWith
+import assertk.fail
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+private val moshi: Moshi = Moshi.Builder()
+  .add(UnsignedNumberJsonAdapter.Factory)
+  .addLast(KotlinJsonAdapterFactory())
+  .build()
+
+@Language("JSON")
+private val unsignedToStringRepresentation: Map<Any, String> = mapOf(
+  dataClassWithULong to """{"uLong":${dataClassWithULong.uLong}}""",
+  dataClassWithUInt to """{"uInt":${dataClassWithUInt.uInt}}""",
+  dataClassWithUShort to """{"uShort":${dataClassWithUShort.uShort}}""",
+  dataClassWithUByte to """{"uByte":${dataClassWithUByte.uByte}}""",
+)
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class UnsignedNumberJsonAdapterTest {
+  private fun assertSerializedDeserialized(original: Any) =
+    when (val stringRepresentation = unsignedToStringRepresentation[original]) {
+      null -> fail("Missing string representation of $original")
+      else -> {
+        val actual = moshi.adapter(original::class.java).fromJson(stringRepresentation)!!
+        assertThat(actual).isEqualTo(original)
+        actual::class.java.declaredFields.map { field ->
+          assertThat(field.genericType).isEqualTo(
+            original::class.java.declaredFields
+              .find { it.name == field.name }?.genericType
+          )
+        }
+      }
+    }
+
+  @Suppress("unused")
+  private fun unsignedNumbers(): Stream<Arguments> = Stream.of(
+    Arguments.of(dataClassWithULong),
+    Arguments.of(dataClassWithUInt),
+    Arguments.of(dataClassWithUShort),
+    Arguments.of(dataClassWithUByte),
+  )
+
+  @Suppress("unused")
+  private fun dataClassPropertyNames(): Stream<Arguments> = Stream.of(
+    Arguments.of(DataClassWithULong::class.java, "uLong"),
+    Arguments.of(DataClassWithUInt::class.java, "uInt"),
+    Arguments.of(DataClassWithUShort::class.java, "uShort"),
+    Arguments.of(DataClassWithUByte::class.java, "uByte"),
+  )
+
+  @ParameterizedTest
+  @MethodSource("unsignedNumbers")
+  fun `When an unsigned value would be negative if it was signed, then it's positivity is properly retained`(
+    value: Any,
+  ) {
+    assertSerializedDeserialized(value)
+  }
+
+  @ParameterizedTest
+  @MethodSource("dataClassPropertyNames")
+  fun `When a negative value as attempted to be deserialized, then an exception is thrown`(
+    type: Class<*>,
+    propertyName: String,
+  ) {
+    val negativeValue = -1
+
+    @Language("JSON")
+    val stringRepresentation = """{"$propertyName":$negativeValue}"""
+    assertThat(
+      requireNotNull(
+        assertThrows<JsonDataException> {
+          moshi.adapter(type).fromJson(stringRepresentation)
+        }.message
+      )
+    ).startsWith("Invalid number format: '-1' for unsigned number at $.")
+  }
+
+  @Test
+  fun `When a unsigned value is larger than it's max, then an exception is thrown`() {
+    @Language("JSON")
+    val overflowingMap = mapOf(
+      DataClassWithULong::class.java to """{"uLong": 18446744100000000000}""",
+      DataClassWithUInt::class.java to """{"uInt": 4295032828}""",
+      DataClassWithUShort::class.java to """{"uShort": 65788}""",
+      DataClassWithUByte::class.java to """{"uByte": 274}"""
+    )
+
+    overflowingMap.forEach { (type, string) ->
+      assertThat(
+        requireNotNull(
+          assertThrows<JsonDataException> {
+            moshi.deserialize(string, type)
+          }.message
+        )
+      ).startsWith("Invalid number format:")
+    }
+  }
+
+  @Test
+  fun `When a unsigned field is not null nullable, and the value is null, then an exception is thrown`() {
+    @Language("JSON")
+    val stringRepresentation = """{"uLong": "10"}"""
+    assertThat(
+      requireNotNull(
+        assertThrows<JsonDataException> {
+          moshi.deserialize(stringRepresentation, DataClassWithULong::class.java)
+        }.message
+      )
+    ).isEqualTo("Expected an unsigned number but was 10, a STRING, at path $.uLong")
+  }
+
+  @Test
+  fun `When a unsigned field gets a not null not number token, then an exception is thrown`() {
+    @Language("JSON")
+    val stringRepresentation = """{"uLong": null}"""
+    assertThat(
+      requireNotNull(
+        assertThrows<JsonDataException> {
+          moshi.deserialize(stringRepresentation, DataClassWithULong::class.java)
+        }.message
+      )
+    ).isEqualTo("Non-null value 'uLong' was null at $.uLong")
+  }
+
+  @Test
+  fun `When a unsigned field is nullable, and the value is not null, it is deserialized properly`() {
+    @Language("JSON")
+    val stringRepresentation = """{"nullableULong": ${dataClassWithULong.uLong}}"""
+    assertThat(
+      moshi.deserialize(stringRepresentation, DataClassWithNullableULong::class.java)
+        .nullableULong
+    ).isEqualTo(dataClassWithULong.uLong)
+  }
+
+  @Test
+  fun `When a unsigned field is nullable, and the value is null, it is deserialized properly`() {
+    @Language("JSON")
+    val stringRepresentation = """{"nullableULong": null}"""
+    assertThat(
+      moshi.deserialize(stringRepresentation, DataClassWithNullableULong::class.java)
+        .nullableULong
+    ).isNull()
+  }
+}

--- a/moshi-kotlin/src/test/java/com/squareup/moshi/kotlin/inline/ValueClassJsonAdapterTest.kt
+++ b/moshi-kotlin/src/test/java/com/squareup/moshi/kotlin/inline/ValueClassJsonAdapterTest.kt
@@ -1,0 +1,119 @@
+package com.squareup.moshi.kotlin.inline
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.fail
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+private val moshi: Moshi = Moshi.Builder()
+  .add(ValueClassJsonAdapter.Factory)
+  .add(UnsignedNumberJsonAdapter.Factory)
+  .addLast(KotlinJsonAdapterFactory())
+  .build()
+
+@Suppress("MaxLineLength")
+internal class ValueClassJsonAdapterTest {
+  fun assertSerializedDeserialized(original: Any) =
+    when (val stringRepresentation = instanceToJsonStringMap[original]) {
+      null -> fail("Missing string representation of $original")
+      else -> {
+        val actual = requireNotNull(moshi.adapter(original::class.java).fromJson(stringRepresentation))
+        assertThat(actual).isEqualTo(original)
+        actual::class.java.declaredFields.map { field ->
+          assertThat(field.genericType).isEqualTo(
+            original::class.java.declaredFields
+              .find { it.name == field.name }?.genericType
+          )
+        }
+      }
+    }
+
+  @Nested
+  @TestInstance(PER_CLASS)
+  inner class JsonTypeConversionTests {
+    @Suppress("unused")
+    private fun inlineInstances(): Stream<Arguments> = instanceToJsonStringMap.keys.map { Arguments.of(it) }.stream()
+
+    @ParameterizedTest
+    @MethodSource("inlineInstances")
+    fun `Validate result of serialization is equal`(
+      value: Any,
+    ) {
+      // This check is here as we don't serialize key with null values by default
+      if (value is JvmInlineMapStringNullableInt) {
+        assertThat(moshi.serialize(value)).isEqualTo("""{"first":1}""")
+      } else {
+        assertThat(moshi.serialize(value)).isEqualTo(instanceToJsonStringMap[value])
+      }
+    }
+
+    @ParameterizedTest
+    @MethodSource("inlineInstances")
+    fun `Validate result of serialization and subsequent deserialization is equal`(inline: Any) {
+      assertSerializedDeserialized(inline)
+    }
+
+    @Test
+    fun `When a class has multiple constructors, and can be created using a secondary constructor, then it is still serialized and deserialized`() {
+      assertSerializedDeserialized(jvmInlineStringMultipleConstructorUsage)
+    }
+
+    @Test
+    fun `When a class is deserialized from an invalid representation, then an exception is thrown`() {
+      @Language("JSON")
+      val invalidJson = """{"stringValue":"someString", "malformedIntKey": 100}"""
+      assertThat(
+        requireNotNull(
+          assertThrows<JsonDataException> {
+            moshi.deserialize(invalidJson, JvmInlineComplexClass::class.java)
+          }.message
+        )
+      ).isEqualTo("Required value 'intValue' missing at $")
+    }
+  }
+
+  @Nested
+  inner class NullabilityScenarios {
+    @Test
+    fun `When a value class field is not nullable, and the serialized value is null, then an exception is thrown`() {
+      val illegallyNullFieldString = """null"""
+      assertThrows<JsonDataException> {
+        moshi.deserialize(illegallyNullFieldString, JvmInlineInt::class.java)
+      }
+    }
+
+    @Test
+    fun `When a value class field is nullable, and the serialized value is not null, then the deserialized field is not null`() {
+      assertSerializedDeserialized(jvmInlineNotNullNullableString)
+      assertNotNull(jvmInlineNotNullNullableString.value)
+    }
+
+    @Test
+    fun `When a value class field is nullable, and the serialized value is null, then the deserialized field is null`() {
+      assertSerializedDeserialized(jvmInlineNullNullableString)
+      assertNull(jvmInlineNullNullableString.value)
+    }
+  }
+
+  @Nested
+  inner class TypeValidationScenarios {
+    @Test
+    fun `When a value class has a backing field of a complex type containing a field with a type parameter, then it is deserialized as expected`() {
+      assertSerializedDeserialized(jvmInlineComplexClassWithParameterizedField)
+    }
+  }
+}


### PR DESCRIPTION
The intention of this pull request is to address the issues outlined in #1170.

This would also cover the unsigned types `[ULong, UInt, UShort, UByte]`.

I've outlined the thought process and approach for this solution in [this repository](https://github.com/amichne/moshi-value-classes), including the expected behavior, the current behavior (as of version `1.14.0`) and the behavior after this addition of the included adapters.

Any & all feedback is highly appreciated!