### PR TITLE
updated read me documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ List<Card> cards = adapter.fromJson(cardsJsonResponse);
 
 ```kotlin
 val cardsJsonResponse: String = ...
-// We can just use a reified extension!
+// We can just use a reified extension! (Available with Kotlin ExperimentalStdlibApi)
 val adapter = moshi.adapter<List<Card>>()
 val cards: List<Card> = adapter.fromJson(cardsJsonResponse)
 ```


### PR DESCRIPTION
Updated comment in the READ ME file for moshi.

Below line of code can be used if we opt in ExperimentalStdlibApi in Kotlin. Adding specific details to the READ ME file.

`val adapter = moshi.adapter<List<Card>>()`