### PR TITLE
[CI] Bump JDK from `18` to `19`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '18'
+          java-version: '19'
           cache: 'gradle'
 
       - name: Test


### PR DESCRIPTION
JDK 18 is reached EOL.