### PR TITLE
fix PolymorphicJsonAdapterFactory with FallbackJsonAdapter deserialize empty object error.

### DIFF
--- a/moshi-adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.kt
+++ b/moshi-adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.kt
@@ -202,6 +202,11 @@ public class PolymorphicJsonAdapterFactory<T> internal constructor(
 
     private fun labelIndex(reader: JsonReader): Int {
       reader.beginObject()
+
+      if (!reader.hasNext()) {
+        return -1
+      }
+
       while (reader.hasNext()) {
         if (reader.selectName(labelKeyOptions) == -1) {
           reader.skipName()


### PR DESCRIPTION
well，when PolymorphicJsonAdapterFactory deserialize json array contains empty object like below,  the origin logic will throw `JsonDataException("Missing label for $labelKey")` instead of using fallbackJsonAdapter，this PR will use fallbackJsonAdapter deserialize empty json to object other than throw  `JsonDataException`。

```json
"[{\"type\":\"success\",\"value\":\"this is success message\"},{}]"
``` 