### PR TITLE
Allow PolymorphicJsonAdapterFactory's fallback adapter to handle case…

### DIFF
--- a/moshi-adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.kt
+++ b/moshi-adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.kt
@@ -216,7 +216,7 @@ public class PolymorphicJsonAdapterFactory<T> internal constructor(
         }
         return labelIndex
       }
-      throw JsonDataException("Missing label for $labelKey")
+      return -1
     }
 
     @Throws(IOException::class)


### PR DESCRIPTION
[Allow PolymorphicJsonAdapterFactory's fallback adapter to handle case when label key doesn't appear in json string]
even if the lable key doesn't appear in json string,the better solution is still execute `PolymorphicJsonAdapter#fromJson`
#1512 