### PR TITLE
remove obvious comment

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/LinkedHashTreeMap.kt
+++ b/moshi/src/main/java/com/squareup/moshi/LinkedHashTreeMap.kt
@@ -449,7 +449,6 @@ constructor(
     }
     replaceInParent(root, pivot)
 
-    // move the root to the pivot's left
     pivot.left = root
     root.parent = pivot
 


### PR DESCRIPTION
This PR removes an obvious comment (i.e. comment that restates what the code does in an obvious manner). The code itself is understandable that the root is being moved to pivot's left.