### PR TITLE
1.15.0 preperations

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,14 +16,14 @@
 autoService = "1.0"
 gjf = "1.11.0"
 jvmTarget = "1.8"
-kotlin = "1.7.0"
-kotlinCompileTesting = "1.4.9"
-kotlinpoet = "1.12.0"
-ksp = "1.7.0-1.0.6"
+kotlin = "1.8.21"
+kotlinCompileTesting = "0.2.1"
+kotlinpoet = "1.13.2"
+ksp = "1.8.21-1.0.11"
 ktlint = "0.41.0"
 
 [plugins]
-dokka = { id = "org.jetbrains.dokka", version = "1.7.0" }
+dokka = { id = "org.jetbrains.dokka", version = "1.8.10" }
 japicmp = { id = "me.champeau.gradle.japicmp", version = "0.2.9" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.21.0" }
@@ -42,7 +42,7 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref =
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 kotlinpoet-metadata = { module = "com.squareup:kotlinpoet-metadata", version.ref = "kotlinpoet" }
 kotlinpoet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinpoet" }
-kotlinxMetadata = "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.5.0"
+kotlinxMetadata = "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.6.0"
 ksp = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 okio = "com.squareup.okio:okio:2.10.0"
@@ -50,6 +50,6 @@ okio = "com.squareup.okio:okio:2.10.0"
 # Test libs
 assertj = "org.assertj:assertj-core:3.11.1"
 junit = "junit:junit:4.13.2"
-kotlinCompileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version.ref = "kotlinCompileTesting" }
-kotlinCompileTesting-ksp = { module = "com.github.tschuchortdev:kotlin-compile-testing-ksp", version.ref ="kotlinCompileTesting" }
+kotlinCompileTesting = { module = "dev.zacsweers.kctfork:core", version.ref = "kotlinCompileTesting" }
+kotlinCompileTesting-ksp = { module = "dev.zacsweers.kctfork:ksp", version.ref ="kotlinCompileTesting" }
 truth = "com.google.truth:truth:1.1.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,8 @@ autoService = { module = "com.google.auto.service:auto-service-annotations", ver
 autoService-ksp = "dev.zacsweers.autoservice:auto-service-ksp:1.0.0"
 guava = "com.google.guava:guava:30.1.1-jre"
 jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
+kotlin-annotationProcessingEmbeddable = { module = "org.jetbrains.kotlin:kotlin-annotation-processing-embeddable", version.ref = "kotlin" }
+kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }

--- a/kotlin/codegen/build.gradle.kts
+++ b/kotlin/codegen/build.gradle.kts
@@ -32,6 +32,9 @@ tasks.withType<KotlinCompile>().configureEach {
       "-opt-in=com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview",
       "-opt-in=com.squareup.moshi.kotlin.codegen.api.InternalMoshiCodegenApi",
     )
+    if (this@configureEach.name == "compileTestKotlin") {
+      freeCompilerArgs += "-opt-in=org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi"
+    }
   }
 }
 

--- a/kotlin/codegen/build.gradle.kts
+++ b/kotlin/codegen/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
   implementation(libs.kotlinpoet.ksp)
   implementation(libs.guava)
   implementation(libs.asm)
+  implementation(platform(libs.kotlin.bom))
 
   implementation(libs.autoService)
   ksp(libs.autoService.ksp)
@@ -78,12 +79,16 @@ dependencies {
   // KSP deps
   compileOnly(libs.ksp)
   compileOnly(libs.ksp.api)
+  compileOnly(libs.kotlin.annotationProcessingEmbeddable)
   compileOnly(libs.kotlin.compilerEmbeddable)
+  compileOnly(platform(libs.kotlin.bom))
   // Always force the latest KSP version to match the one we're compiling against
   testImplementation(libs.ksp)
   testImplementation(libs.ksp.api)
+  testImplementation(libs.kotlin.annotationProcessingEmbeddable)
   testImplementation(libs.kotlin.compilerEmbeddable)
   testImplementation(libs.kotlinCompileTesting.ksp)
+  testImplementation(platform(libs.kotlin.bom))
 
   // Copy these again as they're not automatically included since they're shaded
   testImplementation(project(":moshi"))

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -258,8 +258,12 @@ public class AdapterGenerator(
 
     val typeRenderer: TypeRenderer = object : TypeRenderer() {
       override fun renderTypeVariable(typeVariable: TypeVariableName): CodeBlock {
-        val index = typeVariables.indexOfFirst { it == typeVariable }
-        check(index != -1) { "Unexpected type variable $typeVariable" }
+        // Match only by name because equality checks for more things than just the name. For example, a base class
+        // may declare "T" but the subclass declares "T : Number", which is legal but will fail an equals() test.
+        val index = typeVariables.indexOfFirst { it.name == typeVariable.name }
+        check(index != -1) {
+          "Unexpected type variable $typeVariable"
+        }
         return CodeBlock.of("%N[%L]", typesParam, index)
       }
     }

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -72,6 +72,7 @@ public class AdapterGenerator(
       "DEPRECATION",
       // Because we look it up reflectively
       "unused",
+      "UNUSED_PARAMETER",
       // Because we include underscores
       "ClassName",
       // Because we generate redundant `out` variance for some generics and there's no way

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/apt/JsonClassCodegenProcessor.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/apt/JsonClassCodegenProcessor.kt
@@ -70,6 +70,7 @@ public class JsonClassCodegenProcessor : AbstractProcessor() {
 
   override fun init(processingEnv: ProcessingEnvironment) {
     super.init(processingEnv)
+    processingEnv.messager.printMessage(Diagnostic.Kind.WARNING, "Kapt support in Moshi Kotlin Code Gen is deprecated and will be removed in 2.0. Please migrate to KSP. https://github.com/square/moshi#codegen")
     generatedType = processingEnv.options[OPTION_GENERATED]?.let {
       POSSIBLE_GENERATED_NAMES[it] ?: error(
         "Invalid option value for $OPTION_GENERATED. Found $it, " +

--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/ksp/JsonClassSymbolProcessorProvider.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/ksp/JsonClassSymbolProcessorProvider.kt
@@ -87,9 +87,9 @@ private class JsonClassSymbolProcessor(
 
       if (!jsonClassAnnotation.generateAdapter) continue
 
-      val originatingFile = type.containingFile!!
-      val adapterGenerator = adapterGenerator(logger, resolver, type) ?: return emptyList()
       try {
+        val originatingFile = type.containingFile!!
+        val adapterGenerator = adapterGenerator(logger, resolver, type) ?: return emptyList()
         val preparedAdapter = adapterGenerator
           .prepare(generateProguardRules) { spec ->
             spec.toBuilder()

--- a/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/ksp/JsonClassSymbolProcessorTest.kt
+++ b/kotlin/codegen/src/test/java/com/squareup/moshi/kotlin/codegen/ksp/JsonClassSymbolProcessorTest.kt
@@ -538,6 +538,24 @@ class JsonClassSymbolProcessorTest {
   }
 
   @Test
+  fun invalidGenericSyntaxErrorMessaging() {
+    val result = compile(
+      kotlin(
+        "source.kt",
+        """
+          package test
+          import com.squareup.moshi.JsonClass
+
+          @JsonClass(generateAdapter = true)
+          data class ElementEnvelope(val elements: List)
+          """,
+      ),
+    )
+    assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+    assertThat(result.messages).contains("Error preparing ElementEnvelope")
+  }
+
+  @Test
   fun `TypeAliases with the same backing type should share the same adapter`() {
     val result = compile(
       kotlin(

--- a/moshi/build.gradle.kts
+++ b/moshi/build.gradle.kts
@@ -29,6 +29,10 @@ val java16 by sourceSets.creating {
 }
 
 tasks.named<JavaCompile>("compileJava16Java") {
+  options.release.set(16)
+}
+
+tasks.named<JavaCompile>("compileJava16Java") {
   // We use JDK 17 for latest but target 16 for maximum compatibility
   javaCompiler.set(
     javaToolchains.compilerFor {


### PR DESCRIPTION
- Upgrade to Kotlin `1.8.21`
- Upgrade to KSP `1.8.21-1.0.11`
- Upgrade to kotlinx-metadata `0.6.0`
- Upgrade to KotlinPoet `1.13.2`
- Support Kotlin language version `1.9.0` in Kapt
- Backport 076ee610759c077b7e84d2ba3ac603017a5c26e4
- Backport 000ce304187a6f655f5359ad14df5b5981916607
- Deprecate kapt code gen support w/ a noisy warning message in its processor init