### PR TITLE
Update README.md dependency version 1.15.0 to 1.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1063,12 +1063,12 @@ The reflection adapter requires the following additional dependency:
 <dependency>
   <groupId>com.squareup.moshi</groupId>
   <artifactId>moshi-kotlin</artifactId>
-  <version>1.15.0</version>
+  <version>1.15.1</version>
 </dependency>
 ```
 
 ```kotlin
-implementation("com.squareup.moshi:moshi-kotlin:1.15.0")
+implementation("com.squareup.moshi:moshi-kotlin:1.15.1")
 ```
 
 Note that the reflection adapter transitively depends on the `kotlin-reflect` library which is a
@@ -1103,7 +1103,7 @@ plugins {
 }
 
 dependencies {
-  ksp("com.squareup.moshi:moshi-kotlin-codegen:1.15.0")
+  ksp("com.squareup.moshi:moshi-kotlin-codegen:1.15.1")
 }
 
 ```
@@ -1116,13 +1116,13 @@ dependencies {
 <dependency>
   <groupId>com.squareup.moshi</groupId>
   <artifactId>moshi-kotlin-codegen</artifactId>
-  <version>1.15.0</version>
+  <version>1.15.1</version>
   <scope>provided</scope>
 </dependency>
 ```
 
 ```kotlin
-kapt("com.squareup.moshi:moshi-kotlin-codegen:1.15.0")
+kapt("com.squareup.moshi:moshi-kotlin-codegen:1.15.1")
 ```
 </details>
 
@@ -1146,12 +1146,12 @@ Download [the latest JAR][dl] or depend via Maven:
 <dependency>
   <groupId>com.squareup.moshi</groupId>
   <artifactId>moshi</artifactId>
-  <version>1.15.0</version>
+  <version>1.15.1</version>
 </dependency>
 ```
 or Gradle:
 ```kotlin
-implementation("com.squareup.moshi:moshi:1.15.0")
+implementation("com.squareup.moshi:moshi:1.15.1")
 ```
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].


### PR DESCRIPTION
Mostly due to [CVE-2023-3635](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-3635)