### PR TITLE
Ignore JSON object trailing comma in lenient JsonUtf8Reader.

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/JsonUtf8Reader.kt
+++ b/moshi/src/main/java/com/squareup/moshi/JsonUtf8Reader.kt
@@ -197,11 +197,14 @@ internal class JsonUtf8Reader : JsonReader {
             PEEKED_SINGLE_QUOTED_NAME
           }
 
-          '}' -> if (peekStack != JsonScope.NONEMPTY_OBJECT) {
+          '}' -> {
+            if (peekStack == JsonScope.NONEMPTY_OBJECT && !lenient) {
+              throw syntaxError(
+                "Expected name. Use JsonReader.setLenient(true) to accept malformed JSON"
+              )
+            }
             buffer.readByte() // consume the '}'.
             PEEKED_END_OBJECT
-          } else {
-            throw syntaxError("Expected name")
           }
 
           else -> {
@@ -213,8 +216,7 @@ internal class JsonUtf8Reader : JsonReader {
             }
           }
         }
-        peeked = next
-        return next
+        return setPeeked(next)
       }
 
       JsonScope.DANGLING_NAME -> {

--- a/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonUtf8ReaderTest.java
@@ -1261,20 +1261,6 @@ public final class JsonUtf8ReaderTest {
   }
 
   @Test
-  public void lenientExtraCommasInMaps() throws IOException {
-    JsonReader reader = newReader("{\"a\":\"b\",}");
-    reader.setLenient(true);
-    reader.beginObject();
-    assertThat(reader.nextName()).isEqualTo("a");
-    assertThat(reader.nextString()).isEqualTo("b");
-    try {
-      reader.peek();
-      fail();
-    } catch (JsonEncodingException expected) {
-    }
-  }
-
-  @Test
   public void malformedDocuments() throws IOException {
     assertDocument("{]", BEGIN_OBJECT, JsonEncodingException.class);
     assertDocument("{,", BEGIN_OBJECT, JsonEncodingException.class);
@@ -1354,6 +1340,49 @@ public final class JsonUtf8ReaderTest {
     reader.setLenient(true);
     reader.beginArray();
     assertThat(reader.nextString()).isEqualTo("string");
+  }
+
+  @Test
+  public void trailingCommaInJsonObject() throws Exception {
+    JsonReader reader = newReader("{\"a\":1,}");
+    reader.beginObject();
+    assertThat(reader.nextName()).isEqualTo("a");
+    assertThat(reader.nextInt()).isEqualTo(1);
+    try {
+      reader.endObject();
+      fail();
+    } catch (JsonEncodingException expected) {
+      assertThat(expected.getMessage()).isEqualTo(
+        "Expected name. Use JsonReader.setLenient(true) to accept malformed JSON at path $.a");
+    }
+    reader = newReader("{\"a\": 1, }");
+    reader.beginObject();
+    assertThat(reader.nextName()).isEqualTo("a");
+    assertThat(reader.nextInt()).isEqualTo(1);
+    reader.setLenient(true);
+    reader.endObject();
+    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
+  }
+
+  @Test
+  public void trailingCommaInJsonArray() throws Exception {
+    JsonReader reader = newReader("[1, ]");
+    reader.beginArray();
+    assertThat(reader.nextInt()).isEqualTo(1);
+    try {
+      reader.endArray();
+      fail();
+    } catch (JsonEncodingException expected) {
+      assertThat(expected.getMessage())
+        .isEqualTo("Use JsonReader.setLenient(true) to accept malformed JSON at path $[1]");
+    }
+    reader = newReader("[1,]");
+    reader.beginArray();
+    assertThat(reader.nextInt()).isEqualTo(1);
+    reader.setLenient(true);
+    reader.nextNull();
+    reader.endArray();
+    assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
   }
 
   private void assertDocument(String document, Object... expectations) throws IOException {


### PR DESCRIPTION
Unchanged behavior: Lenient readers treat empty values in JSON arrays as the null value.

References #802 