### PR TITLE
Remove @Synchronized annotation from `Rfc3339DateJsonAdapter`.

### DIFF
--- a/moshi-adapters/src/main/java/com/squareup/moshi/adapters/Iso8601Utils.kt
+++ b/moshi-adapters/src/main/java/com/squareup/moshi/adapters/Iso8601Utils.kt
@@ -47,7 +47,7 @@ private val TIMEZONE_Z: TimeZone = TimeZone.getTimeZone(GMT_ID)
 /** Returns `date` formatted as yyyy-MM-ddThh:mm:ss.sssZ  */
 internal fun Date.formatIsoDate(): String {
   val calendar: Calendar = GregorianCalendar(TIMEZONE_Z, Locale.US)
-  calendar.time = this
+  calendar.time = Date(this.time)
 
   // estimate capacity of buffer as close as we can (yeah, that's pedantic ;)
   val capacity = "yyyy-MM-ddThh:mm:ss.sssZ".length

--- a/moshi-adapters/src/main/java/com/squareup/moshi/adapters/Iso8601Utils.kt
+++ b/moshi-adapters/src/main/java/com/squareup/moshi/adapters/Iso8601Utils.kt
@@ -47,7 +47,7 @@ private val TIMEZONE_Z: TimeZone = TimeZone.getTimeZone(GMT_ID)
 /** Returns `date` formatted as yyyy-MM-ddThh:mm:ss.sssZ  */
 internal fun Date.formatIsoDate(): String {
   val calendar: Calendar = GregorianCalendar(TIMEZONE_Z, Locale.US)
-  calendar.time = Date(this.time)
+  calendar.time = this
 
   // estimate capacity of buffer as close as we can (yeah, that's pedantic ;)
   val capacity = "yyyy-MM-ddThh:mm:ss.sssZ".length

--- a/moshi-adapters/src/main/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapter.kt
+++ b/moshi-adapters/src/main/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapter.kt
@@ -48,7 +48,7 @@ public class Rfc3339DateJsonAdapter : JsonAdapter<Date>() {
     if (value == null) {
       writer.nullValue()
     } else {
-      val string = Date(value.time).formatIsoDate()
+      val string = value.formatIsoDate()
       writer.value(string)
     }
   }

--- a/moshi-adapters/src/main/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapter.kt
+++ b/moshi-adapters/src/main/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapter.kt
@@ -34,7 +34,6 @@ import java.util.Date
  * ```
  */
 public class Rfc3339DateJsonAdapter : JsonAdapter<Date>() {
-  @Synchronized
   @Throws(IOException::class)
   override fun fromJson(reader: JsonReader): Date? {
     if (reader.peek() == NULL) {
@@ -44,7 +43,6 @@ public class Rfc3339DateJsonAdapter : JsonAdapter<Date>() {
     return string.parseIsoDate()
   }
 
-  @Synchronized
   @Throws(IOException::class)
   override fun toJson(writer: JsonWriter, value: Date?) {
     if (value == null) {

--- a/moshi-adapters/src/main/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapter.kt
+++ b/moshi-adapters/src/main/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapter.kt
@@ -48,7 +48,7 @@ public class Rfc3339DateJsonAdapter : JsonAdapter<Date>() {
     if (value == null) {
       writer.nullValue()
     } else {
-      val string = value.formatIsoDate()
+      val string = Date(value.time).formatIsoDate()
       writer.value(string)
     }
   }

--- a/moshi-adapters/src/main/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapter.kt
+++ b/moshi-adapters/src/main/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapter.kt
@@ -34,6 +34,8 @@ import java.util.Date
  * ```
  */
 public class Rfc3339DateJsonAdapter : JsonAdapter<Date>() {
+
+  /** The underlying deserialization logic is thread-safe and does not require synchronization. **/
   @Throws(IOException::class)
   override fun fromJson(reader: JsonReader): Date? {
     if (reader.peek() == NULL) {
@@ -43,6 +45,7 @@ public class Rfc3339DateJsonAdapter : JsonAdapter<Date>() {
     return string.parseIsoDate()
   }
 
+  /*** The underlying serialization logic is thread-safe and does not require synchronization. **/
   @Throws(IOException::class)
   override fun toJson(writer: JsonWriter, value: Date?) {
     if (value == null) {


### PR DESCRIPTION
### Motivation
`Rfc3339DateJsonAdapter` can convert a nullable `Date` object to a JSON string and vice versa.

If a system attempts to concurrently serialize or deserialize large objects containing many `Date` objects or collections of those large objects, there could be contention across threads and delays due to synchronization.

![Screenshot 2024-05-10 at 6 04 23 PM](https://github.com/square/moshi/assets/114962894/bf3610b2-0432-4cb1-92a2-a6a1c57cea53)


### Synchronization evaluation
#### 1. fromJson
`fromJson` constructs and uses a local `Calendar` instance and does not use any shared `DateFormat`, thus it should not need to be synchronized.

#### 2. toJson
`toJson` calls `Date.formatIsoDate` extension method, which provides a (mutable) `Date` object to local `Calendar` instance.
```kotlin
internal fun Date.formatIsoDate(): String {
  val calendar: Calendar = GregorianCalendar(TIMEZONE_Z, Locale.US)
  calendar.time = this
  // ...
}
```

The underlying code for `calendar.time = this` simply gets the `Long` time value from the `Date` object which is a thread-safe operation.

```java
  public final void setTime(Date date) {
     Objects.requireNonNull(date, "date must not be null");
     setTimeInMillis(date.getTime());
  }
```

Therefore, synchronized execution shouldn't be needed for `toJson`.

### Changes
- Remove `@Synchronized` annotation from `fromJson` and `toJson` in `Rfc3339DateJsonAdapter` to make it usable concurrently.

### Outcome
Lower contention across threads & synchronization overhead can improve efficiency and compute resource utilization in multi-threaded environments such as in backend servers.

### Benchmark
**Setup**
- M1 Max MBP
- 100 fixed threads
- 1000 serialization and deserialization tasks
   - Each object with a collection of 100 objects with date property.

**Outcome**
```
Benchmark                         Mode  Cnt   Score    Error  Units
BenchmarkDate.synchronized       thrpt    5  10.707  ± 0.052  ops/s   // before
BenchmarkDate.non-synchronized   thrpt    5  77.978  ± 5.109  ops/s   // after
```
