### PR TITLE
Update CI/build infra

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,15 +16,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v3
-
       - name: Configure JDK
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '20'
+          java-version: '21'
           cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Test
         run: ./gradlew build check --stacktrace -PkotlinTestMode=${{ matrix.kotlin-test-mode }}

--- a/.github/workflows/gradle-wrapper.yml
+++ b/.github/workflows/gradle-wrapper.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'gradlew'
       - 'gradlew.bat'
-      - 'gradle/wrapper/'
+      - 'gradle/wrapper/**'
 
 jobs:
   validate:

--- a/.github/workflows/gradle-wrapper.yml
+++ b/.github/workflows/gradle-wrapper.yml
@@ -1,0 +1,15 @@
+name: gradle-wrapper
+
+on:
+  pull_request:
+    paths:
+      - 'gradlew'
+      - 'gradlew.bat'
+      - 'gradle/wrapper/'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gradle/actions/wrapper-validation@v3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,7 @@ subprojects {
   pluginManager.withPlugin("java") {
     configure<JavaPluginExtension> {
       toolchain {
-        languageVersion.set(JavaLanguageVersion.of(20))
+        languageVersion.set(libs.versions.jdk.map(JavaLanguageVersion::of))
       }
     }
     if (project.name != "records-tests") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 autoService = "1.1.1"
+jdk = "21"
 jvmTarget = "1.8"
 kotlin = "2.0.0"
 # No 0.5.0 full release yet due to KSP's 1.0.21 release being busted for CLI/programmatic use

--- a/moshi/build.gradle.kts
+++ b/moshi/build.gradle.kts
@@ -19,11 +19,11 @@ val java16: SourceSet by sourceSets.creating {
   }
 }
 
-// We use JDK 17 for latest but target 16 for maximum compatibility
+// We use newer JDKs but target 16 for maximum compatibility
 val service = project.extensions.getByType<JavaToolchainService>()
 val customLauncher =
   service.launcherFor {
-    languageVersion.set(JavaLanguageVersion.of(17))
+    languageVersion.set(libs.versions.jdk.map(JavaLanguageVersion::of))
   }
 
 tasks.named<JavaCompile>("compileJava16Java") {


### PR DESCRIPTION
- Gradle caching on CI
- JDK 21
- Move gradle wrapper validation to a separate workflow that only runs on changes to those files