### PR TITLE
Don't replace nullable absent properties with null

### DIFF
--- a/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -510,7 +510,7 @@ public class AdapterGenerator(
           property.localName,
           property.localName,
           property.jsonName,
-          readerParam
+          readerParam,
         )
       }
     }

--- a/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/PropertyGenerator.kt
+++ b/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/PropertyGenerator.kt
@@ -33,21 +33,19 @@ public class PropertyGenerator(
   public lateinit var localName: String
   public lateinit var localIsPresentName: String
 
-  public val isRequired: Boolean get() = !delegateKey.nullable && !hasDefault
+  public val isRequired: Boolean get() = !hasDefault
 
   public val hasConstructorParameter: Boolean get() = target.parameterIndex != -1
 
   /**
    * IsPresent is required if the following conditions are met:
-   * - Is not transient
+   * - Is not ignored
    * - Has a default
-   * - Is not a constructor parameter (for constructors we use a defaults mask)
-   * - Is nullable (because we differentiate absent from null)
    *
    * This is used to indicate that presence should be checked first before possible assigning null
    * to an absent value
    */
-  public val hasLocalIsPresentName: Boolean = !isTransient && hasDefault && !hasConstructorParameter && delegateKey.nullable
+  public val hasLocalIsPresentName: Boolean = !isTransient && isRequired
   public val hasConstructorDefault: Boolean = hasDefault && hasConstructorParameter
 
   internal fun allocateNames(nameAllocator: NameAllocator) {

--- a/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -301,6 +301,7 @@ class GeneratedAdaptersTest {
   @Test
   fun nullableTypeParams() {
     val adapter = moshi.adapter<NullableTypeParams<Int>>()
+      .serializeNulls()
     val nullSerializing = adapter.serializeNulls()
 
     val nullableTypeParams = NullableTypeParams(
@@ -314,7 +315,7 @@ class GeneratedAdaptersTest {
     val noNullsTypeParams = NullableTypeParams(
       nullableTypeParams.nullableList,
       nullableTypeParams.nullableSet,
-      nullableTypeParams.nullableMap.filterValues { it != null },
+      nullableTypeParams.nullableMap,
       null,
       1,
     )
@@ -484,9 +485,12 @@ class GeneratedAdaptersTest {
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
     assertThat(jsonAdapter.serializeNulls().toJson(encoded)).isEqualTo("""{"a":null,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"b":6}""")!!
-    assertThat(decoded.a).isNull()
-    assertThat(decoded.b).isEqualTo(6)
+    try {
+      jsonAdapter.fromJson("""{"b":6}""")!!
+      fail()
+    } catch (expected: JsonDataException) {
+      assertThat(expected).hasMessageThat().isEqualTo("Required value 'a' missing at $")
+    }
   }
 
   @JsonClass(generateAdapter = true)

--- a/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -766,7 +766,7 @@ class DualKotlinTest {
       {
         "a": "hello"
       }
-      """.trimIndent()
+      """.trimIndent(),
     )
 
     // Explicit null is ok
@@ -775,7 +775,7 @@ class DualKotlinTest {
       {
         "a": null
       }
-      """.trimIndent()
+      """.trimIndent(),
     )
 
     // Absent is not

--- a/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -187,9 +187,12 @@ class KotlinJsonAdapterTest {
     assertThat(jsonAdapter.toJson(encoded)).isEqualTo("""{"b":5}""")
     assertThat(jsonAdapter.serializeNulls().toJson(encoded)).isEqualTo("""{"a":null,"b":5}""")
 
-    val decoded = jsonAdapter.fromJson("""{"b":6}""")!!
-    assertThat(decoded.a).isNull()
-    assertThat(decoded.b).isEqualTo(6)
+    try {
+      jsonAdapter.fromJson("""{"b":6}""")!!
+      fail()
+    } catch (expected: JsonDataException) {
+      assertThat(expected).hasMessageThat().isEqualTo("Required value 'a' missing at $")
+    }
   }
 
   class AbsentNull(var a: Int?, var b: Int?)

--- a/moshi-kotlin/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterFactory.kt
+++ b/moshi-kotlin/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterFactory.kt
@@ -104,10 +104,6 @@ internal class KotlinJsonAdapter<T>(
       if (values[i] === ABSENT_VALUE) {
         when {
           constructor.parameters[i].isOptional -> isFullInitialized = false
-
-          // Replace absent with null.
-          constructor.parameters[i].type.isMarkedNullable -> values[i] = null
-
           else -> throw missingProperty(
             constructor.parameters[i].name,
             allBindings[i]?.jsonName,


### PR DESCRIPTION
This was always supposed to be a feature of moshi but not actually enforced in kotlin reflect or code gen. This fixes that in both with a regression test. Now nullable properties either need to explicitly declare a default value or explicitly have a null present in the JSON.

This uses a couple clever tricks with kotlin contracts to avoid the extra runtime intrinsic checks.

It's worth mentioning that while this was always how this was advertised to work, this is likely going to be a fairly invasive change to people that were implicitly relying on the old behavior.