### PR TITLE
Add a simple AST model and Adapter

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/AstAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/AstAdapter.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.moshi
+
+import com.squareup.moshi.ast.JArray
+import com.squareup.moshi.ast.JBoolean
+import com.squareup.moshi.ast.JDouble
+import com.squareup.moshi.ast.JField
+import com.squareup.moshi.ast.JInt
+import com.squareup.moshi.ast.JNothing
+import com.squareup.moshi.ast.JNull
+import com.squareup.moshi.ast.JObject
+import com.squareup.moshi.ast.JString
+import com.squareup.moshi.ast.JValue
+
+internal class AstAdapter : JsonAdapter<JValue<*>>() {
+  override fun fromJson(reader: JsonReader): JValue<*> {
+    try {
+      return when (reader.peek()) {
+        JsonReader.Token.BEGIN_ARRAY -> parseArray(reader)
+        // parseArray should have consumed this token, invalid document
+        JsonReader.Token.END_ARRAY -> JNothing
+        JsonReader.Token.BEGIN_OBJECT -> parseObject(reader)
+        // parseObject should have consumed this token, invalid document
+        JsonReader.Token.END_OBJECT -> JNothing
+        // parseObject should have consumed this token, invalid document
+        JsonReader.Token.NAME -> JNothing
+        JsonReader.Token.STRING -> parseString(reader)
+        JsonReader.Token.NUMBER -> parseNumber(reader)
+        JsonReader.Token.BOOLEAN -> parseBoolean(reader)
+        JsonReader.Token.NULL -> JNull
+        // reader.hasNext() should have returned false, invalid document
+        JsonReader.Token.END_DOCUMENT -> JNothing
+      }
+    } catch (e: Exception) {
+      return JNothing
+    }
+  }
+
+  private fun parseArray(reader: JsonReader): JArray {
+    val values = mutableListOf<JValue<*>>()
+    reader.beginArray()
+    while (reader.hasNext()) {
+      values.add(fromJson(reader))
+    }
+    reader.endArray()
+    return JArray(values)
+  }
+
+  private fun parseObject(reader: JsonReader): JObject {
+    val fields = mutableListOf<JField>()
+    reader.beginObject()
+    while (reader.hasNext()) {
+      val name = reader.nextName()
+      val value = fromJson(reader)
+      fields.add(JField(name, value))
+    }
+    reader.endObject()
+    return JObject(fields)
+  }
+
+  private fun parseString(reader: JsonReader): JString {
+    return JString(reader.nextString())
+  }
+
+  private fun parseNumber(reader: JsonReader): JValue<*> {
+    val value = reader.nextString()
+    return if (value.contains('.')) {
+      JDouble(value.toBigDecimal())
+    } else {
+      JInt(value.toBigInteger())
+    }
+  }
+
+  private fun parseBoolean(reader: JsonReader): JBoolean {
+    return JBoolean(reader.nextBoolean())
+  }
+
+  override fun toJson(writer: JsonWriter, value: JValue<*>?) {
+    when (value) {
+      // not writing anything since this value is invalid by definition
+      is JNothing -> {}
+      is JNull, null -> writer.nullValue()
+      is JString -> writer.value(value.value)
+      is JDouble -> writer.value(value.value)
+      is JInt -> writer.value(value.value)
+      is JBoolean -> writer.value(value.value)
+      is JArray -> {
+        writer.beginArray()
+        value.values.forEach {
+          toJson(writer, it)
+        }
+        writer.endArray()
+      }
+      is JObject -> {
+        writer.beginObject()
+        value.fields.forEach {
+          writer.name(it.name)
+          toJson(writer, it.value)
+        }
+        writer.endObject()
+      }
+    }
+  }
+
+  override fun toString(): String = "AstAdapter"
+}

--- a/moshi/src/main/java/com/squareup/moshi/ast/JsonAst.kt
+++ b/moshi/src/main/java/com/squareup/moshi/ast/JsonAst.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.moshi.ast
+
+import java.math.BigDecimal
+import java.math.BigInteger
+
+public sealed class JValue<T> {
+  public abstract val value: T
+}
+
+/**
+ * Represents an invalid JSON value or an empty document
+ */
+public data object JNothing : JValue<Nothing>() {
+  override val value: Nothing get() = throw UnsupportedOperationException("JNothing has no value")
+  override fun toString(): String = ""
+}
+
+/**
+ * Represents a JSON `null` value.
+ */
+public data object JNull : JValue<Nothing?>() {
+  override val value: Nothing? get() = null
+  override fun toString(): String = "null"
+}
+
+/**
+ * Represents a JSON string value.
+ */
+public data class JString(override val value: String) : JValue<String>() {
+  override fun toString(): String = "\"$value\""
+}
+
+/**
+ * Represents a JSON number value, if the value is a decimal.
+ */
+public data class JDouble(override val value: BigDecimal) : JValue<BigDecimal>() {
+  override fun toString(): String = value.toString()
+}
+
+/**
+ * Represents a JSON number value, if the value is an integer.
+ */
+public data class JInt(override val value: BigInteger) : JValue<BigInteger>() {
+  override fun toString(): String = value.toString()
+}
+
+/**
+ * Represents a JSON boolean value.
+ */
+public data class JBoolean(override val value: Boolean) : JValue<Boolean>() {
+  override fun toString(): String = value.toString()
+}
+
+/**
+ * Represents a JSON array value.
+ */
+public data class JArray(val values: List<JValue<*>>) : JValue<List<*>>() {
+  public constructor(vararg fs: JValue<*>) : this(fs.toList())
+
+  override val value: List<*> get() = values.map { it.value }
+  override fun toString(): String = values.joinToString(prefix = "[", postfix = "]")
+}
+
+/**
+ * Represents a JSON object value.
+ */
+public data class JObject(val fields: List<JField>) : JValue<Map<String, *>>() {
+
+  public constructor(vararg fs: JField) : this(fs.toList())
+
+  override val value: Map<String, *> get() = fields.associate { it.name to it.value.value }
+  override fun toString(): String = fields.joinToString(prefix = "{", postfix = "}")
+}
+
+/**
+ * Represents a JSON object field.
+ */
+public data class JField(val name: String, val value: JValue<*>) {
+  override fun toString(): String = "$name: $value"
+}

--- a/moshi/src/test/java/com/squareup/moshi/AstAdapterTests.java
+++ b/moshi/src/test/java/com/squareup/moshi/AstAdapterTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.moshi;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.squareup.moshi.ast.*;
+import java.io.IOException;
+import org.intellij.lang.annotations.Language;
+import org.junit.Test;
+
+@SuppressWarnings({"KotlinInternalInJava", "rawtypes"})
+public class AstAdapterTests {
+
+  @Test
+  public void toAndFromJson() throws IOException {
+    Moshi moshi = new Moshi.Builder().add(JValue.class, new AstAdapter()).build();
+    JsonAdapter<JValue> astAdapter = moshi.adapter(JValue.class);
+
+    JObject subject =
+        new JObject(
+            new JField("alpha", new JString("apple")),
+            new JField(
+                "beta",
+                new JObject(
+                    new JField("alpha", new JString("bacon")),
+                    new JField("charlie", new JString("i'm a masseuse")))));
+
+    @Language("JSON")
+    String jsonValue =
+        "{\"alpha\":\"apple\",\"beta\":{\"alpha\":\"bacon\",\"charlie\":\"i'm a masseuse\"}}";
+
+    assertThat(astAdapter.toJson(subject)).isEqualTo(jsonValue);
+
+    JValue<?> fromJson = astAdapter.fromJson(jsonValue);
+    assertThat(fromJson).isEqualTo(subject);
+  }
+
+  @Test
+  public void invalidDocumentTests() throws IOException {
+    Moshi moshi = new Moshi.Builder().add(JValue.class, new AstAdapter()).build();
+    JsonAdapter<JValue> astAdapter = moshi.adapter(JValue.class).lenient();
+
+    assertThat(astAdapter.fromJson(",.")).isEqualTo(JNothing.INSTANCE);
+    assertThat(astAdapter.fromJson("null")).isEqualTo(JNull.INSTANCE);
+    assertThat(astAdapter.fromJson("true")).isInstanceOf(JBoolean.class);
+    assertThat(astAdapter.fromJson("false")).isInstanceOf(JBoolean.class);
+    assertThat(astAdapter.fromJson("0")).isInstanceOf(JInt.class);
+    assertThat(astAdapter.fromJson("1")).isInstanceOf(JInt.class);
+    assertThat(astAdapter.fromJson("1.0")).isInstanceOf(JDouble.class);
+    assertThat(astAdapter.fromJson("\"\"")).isInstanceOf(JString.class);
+    assertThat(astAdapter.fromJson("[]")).isInstanceOf(JArray.class);
+    assertThat(astAdapter.fromJson("{}")).isInstanceOf(JObject.class);
+  }
+}


### PR DESCRIPTION
This adapter provides a similar functionality to Gson's `JsonElement`, but it's just another option and not a central part of the API.