### PR TITLE
Fix #1891. Remove invalid and operation inside Byte Adapter

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.kt
+++ b/moshi/src/main/java/com/squareup/moshi/StandardJsonAdapters.kt
@@ -82,7 +82,7 @@ internal object StandardJsonAdapters : JsonAdapter.Factory {
     }
 
     override fun toJson(writer: JsonWriter, value: Byte?) {
-      writer.value((knownNotNull(value).toInt() and 0xff).toLong())
+      writer.value(knownNotNull(value).toLong())
     }
 
     override fun toString() = "JsonAdapter(Byte)"


### PR DESCRIPTION
The and operation creates invalid results for negative Byte values as mentioned in #1891