### PR TITLE
Remove redundant preconditions from generated ProGuard rules

### DIFF
--- a/moshi-kotlin-codegen/src/test/java/com/squareup/moshi/kotlin/codegen/ksp/JsonClassSymbolProcessorTest.kt
+++ b/moshi-kotlin-codegen/src/test/java/com/squareup/moshi/kotlin/codegen/ksp/JsonClassSymbolProcessorTest.kt
@@ -727,7 +727,6 @@ class JsonClassSymbolProcessorTest(private val useKSP2: Boolean) {
       when (generatedFile.nameWithoutExtension) {
         "moshi-testPackage.Aliases" -> assertThat(generatedFile.readText()).contains(
           """
-          -if class testPackage.Aliases
           -keepnames class testPackage.Aliases
           -if class testPackage.Aliases
           -keep class testPackage.AliasesJsonAdapter {
@@ -738,7 +737,6 @@ class JsonClassSymbolProcessorTest(private val useKSP2: Boolean) {
 
         "moshi-testPackage.Simple" -> assertThat(generatedFile.readText()).contains(
           """
-          -if class testPackage.Simple
           -keepnames class testPackage.Simple
           -if class testPackage.Simple
           -keep class testPackage.SimpleJsonAdapter {
@@ -749,7 +747,6 @@ class JsonClassSymbolProcessorTest(private val useKSP2: Boolean) {
 
         "moshi-testPackage.Generic" -> assertThat(generatedFile.readText()).contains(
           """
-          -if class testPackage.Generic
           -keepnames class testPackage.Generic
           -if class testPackage.Generic
           -keep class testPackage.GenericJsonAdapter {
@@ -761,7 +758,6 @@ class JsonClassSymbolProcessorTest(private val useKSP2: Boolean) {
         "moshi-testPackage.UsingQualifiers" -> {
           assertThat(generatedFile.readText()).contains(
             """
-            -if class testPackage.UsingQualifiers
             -keepnames class testPackage.UsingQualifiers
             -if class testPackage.UsingQualifiers
             -keep class testPackage.UsingQualifiersJsonAdapter {
@@ -773,7 +769,6 @@ class JsonClassSymbolProcessorTest(private val useKSP2: Boolean) {
 
         "moshi-testPackage.MixedTypes" -> assertThat(generatedFile.readText()).contains(
           """
-          -if class testPackage.MixedTypes
           -keepnames class testPackage.MixedTypes
           -if class testPackage.MixedTypes
           -keep class testPackage.MixedTypesJsonAdapter {
@@ -784,7 +779,6 @@ class JsonClassSymbolProcessorTest(private val useKSP2: Boolean) {
 
         "moshi-testPackage.DefaultParams" -> assertThat(generatedFile.readText()).contains(
           """
-          -if class testPackage.DefaultParams
           -keepnames class testPackage.DefaultParams
           -if class testPackage.DefaultParams
           -keep class testPackage.DefaultParamsJsonAdapter {
@@ -792,7 +786,6 @@ class JsonClassSymbolProcessorTest(private val useKSP2: Boolean) {
           }
           -if class testPackage.DefaultParams
           -keepnames class kotlin.jvm.internal.DefaultConstructorMarker
-          -if class testPackage.DefaultParams
           -keepclassmembers class testPackage.DefaultParams {
               public synthetic <init>(java.lang.String,int,kotlin.jvm.internal.DefaultConstructorMarker);
           }
@@ -802,7 +795,6 @@ class JsonClassSymbolProcessorTest(private val useKSP2: Boolean) {
         "moshi-testPackage.Complex" -> {
           assertThat(generatedFile.readText()).contains(
             """
-            -if class testPackage.Complex
             -keepnames class testPackage.Complex
             -if class testPackage.Complex
             -keep class testPackage.ComplexJsonAdapter {
@@ -810,7 +802,6 @@ class JsonClassSymbolProcessorTest(private val useKSP2: Boolean) {
             }
             -if class testPackage.Complex
             -keepnames class kotlin.jvm.internal.DefaultConstructorMarker
-            -if class testPackage.Complex
             -keepclassmembers class testPackage.Complex {
                 public synthetic <init>(java.lang.String,java.util.List,java.lang.Object,int,kotlin.jvm.internal.DefaultConstructorMarker);
             }
@@ -820,7 +811,6 @@ class JsonClassSymbolProcessorTest(private val useKSP2: Boolean) {
 
         "moshi-testPackage.MultipleMasks" -> assertThat(generatedFile.readText()).contains(
           """
-          -if class testPackage.MultipleMasks
           -keepnames class testPackage.MultipleMasks
           -if class testPackage.MultipleMasks
           -keep class testPackage.MultipleMasksJsonAdapter {
@@ -828,7 +818,6 @@ class JsonClassSymbolProcessorTest(private val useKSP2: Boolean) {
           }
           -if class testPackage.MultipleMasks
           -keepnames class kotlin.jvm.internal.DefaultConstructorMarker
-          -if class testPackage.MultipleMasks
           -keepclassmembers class testPackage.MultipleMasks {
               public synthetic <init>(long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,long,int,int,int,kotlin.jvm.internal.DefaultConstructorMarker);
           }
@@ -838,7 +827,6 @@ class JsonClassSymbolProcessorTest(private val useKSP2: Boolean) {
         "moshi-testPackage.NestedType.NestedSimple" -> {
           assertThat(generatedFile.readText()).contains(
             """
-            -if class testPackage.NestedType${'$'}NestedSimple
             -keepnames class testPackage.NestedType${'$'}NestedSimple
             -if class testPackage.NestedType${'$'}NestedSimple
             -keep class testPackage.NestedType_NestedSimpleJsonAdapter {


### PR DESCRIPTION
Fixes #1911.

@christofferqa (who works on R8 at Google) was looking into Monzo's slow R8 builds. One thing he found was removing redundant `-if` rules generated by Moshi reduced the time we spend in R8 by about 8% (we have ~2.8k classes  annotated with `@JsonClass`).