### PR TITLE
Replace deprecated `indentWithSpaces` with `leadingTabsToSpaces`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ spotless {
   format("misc") {
     target("*.md", ".gitignore")
     trimTrailingWhitespace()
-    indentWithSpaces(2)
+    leadingTabsToSpaces(2)
     endWithNewline()
   }
   val configureCommonJavaFormat: JavaExtension.() -> Unit = {


### PR DESCRIPTION
Replaces the deprecated `indentWithSpace` with `leadingTabsToSpace` as discussed in [spotless#794](https://github.com/diffplug/spotless/issues/794).

Since `leadingTabsToSpace` has been available since spotless Gradle plugin `7.0.0`, and moshi currently uses `7.0.3`, it's safe to adopt the new API.