### PR TITLE
fix kotlin 2.1 aliases nullability

### DIFF
--- a/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/ksp/TargetTypes.kt
+++ b/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/ksp/TargetTypes.kt
@@ -30,8 +30,10 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.google.devtools.ksp.symbol.KSTypeParameter
 import com.google.devtools.ksp.symbol.Modifier
+import com.google.devtools.ksp.symbol.Nullability
 import com.google.devtools.ksp.symbol.Origin
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
@@ -258,7 +260,8 @@ private fun KSPropertyDeclaration.toPropertySpec(
 ): PropertySpec {
   return PropertySpec.builder(
     name = simpleName.getShortName(),
-    type = resolvedType.toTypeName(typeParameterResolver).unwrapTypeAlias(),
+    type = resolvedType.toTypeName(typeParameterResolver).unwrapTypeAlias()
+      .fixTypeAliasNullability(resolvedType),
   )
     .mutable(isMutable)
     .addModifiers(modifiers.map { KModifier.valueOf(it.name) })
@@ -277,4 +280,14 @@ private fun KSPropertyDeclaration.toPropertySpec(
       )
     }
     .build()
+}
+
+private fun TypeName.fixTypeAliasNullability(resolvedType: KSType): TypeName {
+  return if (resolvedType.declaration is KSTypeAlias) {
+    copy(
+      nullable = resolvedType.nullability == Nullability.NULLABLE,
+    )
+  } else {
+    this
+  }
 }

--- a/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -487,7 +487,7 @@ class DualKotlinTest {
     val parameterized: GenericClass<TypeAlias>,
     val wildcardIn: GenericClass<in TypeAlias>,
     val wildcardOut: GenericClass<out TypeAlias>,
-    val complex: GenericClass<GenericTypeAlias>?,
+    val complex: GenericClass<GenericTypeAlias?>?,
   )
 
   // Regression test for https://github.com/square/moshi/issues/991


### PR DESCRIPTION
This PR addresses #1966 issue with nullability on type aliases.

The `kotlinpoet` extension `toTypeName` returns wrong nullability info on aliases, saying that they are not null.

For ex., on `TypeAliasNullability`, the generated JSON adapter will generate this `toJson` method:

```kotlin

  override fun toJson(writer: JsonWriter, `value`: DualKotlinTest.TypeAliasNullability?) {
    //...
    writer.name("aShouldBeNonNull")
    intAdapter.toJson(writer, `value`.aShouldBeNonNull)
    writer.name("nullableAShouldBeNullable")
    intAdapter.toJson(writer, `value`.nullableAShouldBeNullable)
    writer.name("redundantNullableAShouldBeNullable")
    nullableIntAdapter.toJson(writer, `value`.redundantNullableAShouldBeNullable)
    writer.name("manuallyNullableAShouldBeNullable")
    nullableIntAdapter.toJson(writer, `value`.manuallyNullableAShouldBeNullable)
    writer.name("convolutedMultiNullableShouldBeNullable")
    nullableIntAdapter.toJson(writer, `value`.convolutedMultiNullableShouldBeNullable)
    writer.name("deepNestedNullableShouldBeNullable")
    intAdapter.toJson(writer, `value`.deepNestedNullableShouldBeNullable)
    writer.endObject()
  }
```

Whereas it should have used `nullableIntAdapter` instead of `intAdapter` on nullable fields:
```kotlin
  override fun toJson(writer: JsonWriter, `value`: DualKotlinTest.TypeAliasNullability?) {
    //...
    writer.name("aShouldBeNonNull")
    intAdapter.toJson(writer, `value`.aShouldBeNonNull)
    writer.name("nullableAShouldBeNullable")
    nullableIntAdapter.toJson(writer, `value`.nullableAShouldBeNullable)
    writer.name("redundantNullableAShouldBeNullable")
    nullableIntAdapter.toJson(writer, `value`.redundantNullableAShouldBeNullable)
    writer.name("manuallyNullableAShouldBeNullable")
    nullableIntAdapter.toJson(writer, `value`.manuallyNullableAShouldBeNullable)
    writer.name("convolutedMultiNullableShouldBeNullable")
    nullableIntAdapter.toJson(writer, `value`.convolutedMultiNullableShouldBeNullable)
    writer.name("deepNestedNullableShouldBeNullable")
    nullableIntAdapter.toJson(writer, `value`.deepNestedNullableShouldBeNullable)
  }
```


Using `resolvedType.nullability` from KSP correctly returns that the type is nullable.
I think this is something that should be fixed directly in kotlinpoet, but I wanted to test the fix here first and see if it's a suitable solution.

However, it won't work for inner types like with the `GenericClass` class. We need to specify if the inner type is nullable or not, whereas `GenericTypeAlias` is already marked as nullable
.