### PR TITLE
Work-around for missing fqn on default args to annotations

### DIFF
--- a/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/ksp/KspUtil.kt
+++ b/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/ksp/KspUtil.kt
@@ -59,20 +59,20 @@ internal fun KSAnnotation.toAnnotationSpec(resolver: Resolver): AnnotationSpec {
     val member = CodeBlock.builder()
     val name = argument.name!!.getShortName()
     member.add("%L = ", name)
-    addValueToBlock(argument.value!!, resolver, member)
+    addValueToBlock(argument.value!!, resolver, member, element)
     builder.addMember(member.build())
   }
   return builder.build()
 }
 
-private fun addValueToBlock(value: Any, resolver: Resolver, member: CodeBlock.Builder) {
+private fun addValueToBlock(value: Any, resolver: Resolver, member: CodeBlock.Builder, annotationContext: KSClassDeclaration? = null) {
   when (value) {
     is List<*> -> {
       // Array type
       member.add("arrayOf(⇥⇥")
       value.forEachIndexed { index, innerValue ->
         if (index > 0) member.add(", ")
-        addValueToBlock(innerValue!!, resolver, member)
+        addValueToBlock(innerValue!!, resolver, member, annotationContext)
       }
       member.add("⇤⇤)")
     }
@@ -89,12 +89,56 @@ private fun addValueToBlock(value: Any, resolver: Resolver, member: CodeBlock.Bu
       }
     }
 
-    is KSName ->
-      member.add(
-        "%T.%L",
-        ClassName.bestGuess(value.getQualifier()),
-        value.getShortName(),
-      )
+    is KSName -> {
+      // Try to resolve enum names using annotation context first
+      val qualifier = value.getQualifier()
+      val shortName = value.getShortName()
+
+      if (qualifier != null) {
+        // Try direct resolution first
+        val resolvedClass = resolver.getClassDeclarationByName(resolver.getKSNameFromString(qualifier))
+        when {
+          resolvedClass?.classKind == ClassKind.ENUM_CLASS -> {
+            member.add("%T.%L", resolvedClass.toClassName(), shortName)
+          }
+          annotationContext != null -> {
+            // Look for nested enum in annotation context
+            val nestedEnum = annotationContext.declarations
+              .filterIsInstance<KSClassDeclaration>()
+              .find { it.simpleName.getShortName() == qualifier && it.classKind == ClassKind.ENUM_CLASS }
+
+            if (nestedEnum != null) {
+              member.add("%T.%L", nestedEnum.toClassName(), shortName)
+            } else {
+              // Fallback to best guess
+              member.add("%T.%L", ClassName.bestGuess(qualifier), shortName)
+            }
+          }
+          else -> {
+            // Fallback to best guess
+            member.add("%T.%L", ClassName.bestGuess(qualifier), shortName)
+          }
+        }
+      } else {
+        member.add("%L", shortName)
+      }
+    }
+
+    is KSClassDeclaration -> {
+      // Handle enum entries that come directly as KSClassDeclaration
+      if (value.classKind == ClassKind.ENUM_ENTRY) {
+        val enumEntry = value.simpleName.getShortName()
+        val parentClass = value.parentDeclaration as? KSClassDeclaration
+
+        if (parentClass != null && parentClass.classKind == ClassKind.ENUM_CLASS) {
+          member.add("%T.%L", parentClass.toClassName(), enumEntry)
+        } else {
+          member.add("%L", enumEntry)
+        }
+      } else {
+        member.add("%T::class", value.toClassName())
+      }
+    }
 
     is KSAnnotation -> member.add("%L", value.toAnnotationSpec(resolver))
 

--- a/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -1196,7 +1196,12 @@ class GeneratedAdaptersTest {
   }
 
   @JsonQualifier
-  annotation class Uppercase(val inFrench: Boolean, val onSundays: Boolean = false)
+  annotation class Uppercase(val inFrench: Boolean, val onSundays: Boolean = false, val temperature: Temperature = Temperature.COLD) {
+    enum class Temperature {
+      WARM,
+      COLD,
+    }
+  }
 
   class UppercaseJsonAdapter {
     @ToJson


### PR DESCRIPTION
Fix for https://github.com/square/moshi/issues/1995

If you have an annotation applied to your  POJOs and that annotation has a default parameter in its list, the new adapter generator would fail to produce a fully qualified name for the type.

This is my best-attempt, I'm not familiar with all the intricacies of resolving the type information here.
I'd be glad to improve on this if someone points me in the right direction.