### PR TITLE
Update moshi-kotlin to use kotlin-metadata instead

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ autoService-ksp = "dev.zacsweers.autoservice:auto-service-ksp:1.2.0"
 jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 kotlin-annotationProcessingEmbeddable = { module = "org.jetbrains.kotlin:kotlin-annotation-processing-embeddable", version.ref = "kotlin" }
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
-kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+kotlin-metadata = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlin" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 kotlinpoet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinpoet" }
 ksp = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }

--- a/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -268,6 +268,7 @@ class DualKotlinTest {
   @JsonClass(generateAdapter = true)
   data class InlineConsumer(val inline: ValueClass)
 
+  // TODO this produces {"inline":23} now
   @Test fun inlineClassConsumer() {
     val adapter = moshi.adapter<InlineConsumer>()
 

--- a/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -243,6 +243,8 @@ class DualKotlinTest {
     assertThat(decoded.a).isEqualTo(null)
   }
 
+  // TODO CR ValueClass enables generateAdapter but it's not present in reflect-only.
+  //  We previously allowed reflect to do this
   @Test fun valueClass() {
     val adapter = moshi.adapter<ValueClass>()
 

--- a/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -288,9 +288,8 @@ class KotlinJsonAdapterTest {
       fail()
     } catch (expected: IllegalArgumentException) {
       assertThat(expected).hasMessageThat().isEqualTo(
-        "No default value for transient constructor parameter #0 " +
-          "a of fun `<init>`(kotlin.Int): " +
-          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest.RequiredTransientConstructorParameter",
+        "No default value for transient/ignored constructor parameter 'a' on type " +
+          "'com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest.RequiredTransientConstructorParameter'",
       )
     }
   }
@@ -304,9 +303,8 @@ class KotlinJsonAdapterTest {
       fail()
     } catch (expected: IllegalArgumentException) {
       assertThat(expected).hasMessageThat().isEqualTo(
-        "No default value for ignored constructor parameter #0 " +
-          "a of fun `<init>`(kotlin.Int): " +
-          "com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest.RequiredIgnoredConstructorParameter",
+        "No default value for transient/ignored constructor parameter 'a' on type " +
+          "'com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterTest.RequiredIgnoredConstructorParameter'",
       )
     }
   }
@@ -551,8 +549,8 @@ class KotlinJsonAdapterTest {
       fail()
     } catch (expected: IllegalArgumentException) {
       assertThat(expected).hasMessageThat().isEqualTo(
-        "No property for required constructor parameter #0 a of fun `<init>`(" +
-          "kotlin.Int, kotlin.Int): ${NonPropertyConstructorParameter::class.qualifiedName}",
+        "No property for required constructor parameter 'a' on type " +
+          "'${NonPropertyConstructorParameter::class.qualifiedName}'",
       )
     }
   }

--- a/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
+++ b/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterTest.kt
@@ -380,6 +380,7 @@ class KotlinJsonAdapterTest {
 
   internal class ExtendsPlatformClassWithPrivateField(var a: Int) : SimpleTimeZone(0, "C")
 
+  // TODO in code review - this now only produces {"a":3}. Do we want this?
   @Test fun extendsPlatformClassWithProtectedField() {
     val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
     val jsonAdapter = moshi.adapter<ExtendsPlatformClassWithProtectedField>()

--- a/moshi-kotlin/build.gradle.kts
+++ b/moshi-kotlin/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 dependencies {
   api(project(":moshi"))
-  api(kotlin("reflect"))
+  implementation(libs.kotlin.metadata)
 
   testImplementation(kotlin("test"))
   testImplementation(libs.junit)

--- a/moshi-kotlin/src/main/java/com/squareup/moshi/kotlin/reflect/JvmDescriptors.kt
+++ b/moshi-kotlin/src/main/java/com/squareup/moshi/kotlin/reflect/JvmDescriptors.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.moshi.kotlin.reflect
+
+import java.lang.reflect.Constructor
+import kotlin.metadata.jvm.JvmMethodSignature
+
+private val PRIMITIVE_CLASS_TO_SYMBOL =
+  buildMap(capacity = 9) {
+    put(Byte::class.javaPrimitiveType, 'B')
+    put(Char::class.javaPrimitiveType, 'C')
+    put(Double::class.javaPrimitiveType, 'D')
+    put(Float::class.javaPrimitiveType, 'F')
+    put(Int::class.javaPrimitiveType, 'I')
+    put(Long::class.javaPrimitiveType, 'J')
+    put(Short::class.javaPrimitiveType, 'S')
+    put(Boolean::class.javaPrimitiveType, 'Z')
+    put(Void::class.javaPrimitiveType, 'V')
+  }
+
+internal val Class<*>.descriptor: String
+  get() {
+    return when {
+      isPrimitive ->
+        PRIMITIVE_CLASS_TO_SYMBOL[this]?.toString()
+          ?: throw RuntimeException("Unrecognized primitive $this")
+      isArray -> "[${componentType.descriptor}"
+      else -> "L$name;".replace('.', '/')
+    }
+  }
+
+private class State(var index: Int)
+
+private fun readType(state: State, desc: String): Class<*> {
+  return when (val c = desc[state.index]) {
+    '[' -> {
+      // It's an array
+      state.index++
+      val start = state.index
+      readType(state, desc)
+      // We ignore the read class because we just want to reuse the descriptor name in the string
+      // since that's how array component lookups work
+      val descriptorName = buildString {
+        for (i in start until state.index) {
+          var subc = desc[i]
+          if (subc == '/') {
+            subc = '.'
+          }
+          append(subc)
+        }
+      }
+      Class.forName("[$descriptorName")
+    }
+    'B' -> {
+      state.index++
+      Byte::class.javaPrimitiveType!!
+    }
+    'C' -> {
+      state.index++
+      Char::class.javaPrimitiveType!!
+    }
+    'D' -> {
+      state.index++
+      Double::class.javaPrimitiveType!!
+    }
+    'F' -> {
+      state.index++
+      Float::class.javaPrimitiveType!!
+    }
+    'I' -> {
+      state.index++
+      Int::class.javaPrimitiveType!!
+    }
+    'J' -> {
+      state.index++
+      Long::class.javaPrimitiveType!!
+    }
+    'S' -> {
+      state.index++
+      Short::class.javaPrimitiveType!!
+    }
+    'Z' -> {
+      state.index++
+      Boolean::class.javaPrimitiveType!!
+    }
+    'V' -> {
+      state.index++
+      Void::class.javaPrimitiveType!!
+    }
+    'L' -> {
+      // It's a ClassName, read it until ';'
+      state.index++
+      var c2 = desc[state.index]
+      val className = buildString {
+        while (c2 != ';') {
+          if (c2 == '/') {
+            // convert package splits to '.'
+            c2 = '.'
+          }
+          append(c2)
+          state.index++
+          c2 = desc[state.index]
+        }
+      }
+
+      state.index++ // Read off the ';'
+      Class.forName(className)
+    }
+    else -> error("Unknown character $c")
+  }
+}
+
+internal fun JvmMethodSignature.decodeParameterTypes(): List<Class<*>> {
+  val classList = mutableListOf<Class<*>>()
+  val state = State(0)
+  while (state.index < descriptor.length) {
+    when (descriptor[state.index]) {
+      '(' -> {
+        state.index++
+        continue
+      }
+      ')' -> break
+    }
+    classList += readType(state, descriptor)
+  }
+  return classList
+}
+
+/**
+ * Returns the JVM signature in the form "<init>$MethodDescriptor", for example:
+ * `"<init>(Ljava/lang/Object;)V")`.
+ *
+ * Useful for comparing with [JvmMethodSignature].
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.3">JVM specification, section 4.3</a>
+ */
+internal val Constructor<*>.jvmMethodSignature: String
+  get() = buildString {
+    append("<init>")
+    parameterTypes.joinTo(buffer = this, separator = "", prefix = "(", postfix = ")V") { it.descriptor }
+  }

--- a/moshi-kotlin/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterFactory.kt
+++ b/moshi-kotlin/src/main/java/com/squareup/moshi/kotlin/reflect/KotlinJsonAdapterFactory.kt
@@ -21,7 +21,6 @@ import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.Types
 import com.squareup.moshi.internal.generatedAdapter
 import com.squareup.moshi.internal.isPlatformType
 import com.squareup.moshi.internal.jsonAnnotations
@@ -29,20 +28,32 @@ import com.squareup.moshi.internal.missingProperty
 import com.squareup.moshi.internal.resolve
 import com.squareup.moshi.internal.unexpectedNull
 import com.squareup.moshi.rawType
+import java.lang.reflect.Field
+import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.lang.reflect.Type
-import kotlin.reflect.KClass
-import kotlin.reflect.KFunction
-import kotlin.reflect.KMutableProperty1
-import kotlin.reflect.KParameter
-import kotlin.reflect.KProperty1
-import kotlin.reflect.KTypeParameter
-import kotlin.reflect.full.findAnnotation
-import kotlin.reflect.full.memberProperties
-import kotlin.reflect.full.primaryConstructor
-import kotlin.reflect.jvm.isAccessible
-import kotlin.reflect.jvm.javaField
-import kotlin.reflect.jvm.javaType
+import kotlin.metadata.ClassKind
+import kotlin.metadata.KmClass
+import kotlin.metadata.KmFlexibleTypeUpperBound
+import kotlin.metadata.KmProperty
+import kotlin.metadata.KmType
+import kotlin.metadata.KmTypeProjection
+import kotlin.metadata.Modality
+import kotlin.metadata.Visibility
+import kotlin.metadata.isInner
+import kotlin.metadata.isNullable
+import kotlin.metadata.isVar
+import kotlin.metadata.jvm.JvmFieldSignature
+import kotlin.metadata.jvm.JvmMethodSignature
+import kotlin.metadata.jvm.KotlinClassMetadata
+import kotlin.metadata.jvm.Metadata
+import kotlin.metadata.jvm.fieldSignature
+import kotlin.metadata.jvm.getterSignature
+import kotlin.metadata.jvm.setterSignature
+import kotlin.metadata.jvm.syntheticMethodForAnnotations
+import kotlin.metadata.kind
+import kotlin.metadata.modality
+import kotlin.metadata.visibility
 
 /** Classes annotated with this are eligible for this adapter. */
 private val KOTLIN_METADATA = Metadata::class.java
@@ -58,10 +69,10 @@ private val ABSENT_VALUE = Any()
  * constructor, and then by setting any additional properties that exist, if any.
  */
 internal class KotlinJsonAdapter<T>(
-  val constructor: KFunction<T>,
-  val allBindings: List<Binding<T, Any?>?>,
-  val nonIgnoredBindings: List<Binding<T, Any?>>,
-  val options: JsonReader.Options,
+  private val constructor: KtConstructor,
+  private val allBindings: List<Binding<T, Any?>?>,
+  private val nonIgnoredBindings: List<Binding<T, Any?>>,
+  private val options: JsonReader.Options,
 ) : JsonAdapter<T>() {
 
   override fun fromJson(reader: JsonReader): T {
@@ -81,48 +92,36 @@ internal class KotlinJsonAdapter<T>(
 
       val propertyIndex = binding.propertyIndex
       if (values[propertyIndex] !== ABSENT_VALUE) {
-        throw JsonDataException(
-          "Multiple values for '${binding.property.name}' at ${reader.path}",
-        )
+        throw JsonDataException("Multiple values for '${binding.property.name}' at ${reader.path}")
       }
 
       values[propertyIndex] = binding.adapter.fromJson(reader)
 
-      if (values[propertyIndex] == null && !binding.property.returnType.isMarkedNullable) {
-        throw unexpectedNull(
-          binding.property.name,
-          binding.jsonName,
-          reader,
-        )
+      if (values[propertyIndex] == null && !binding.property.km.returnType.isNullable) {
+        throw unexpectedNull(binding.property.name, binding.jsonName, reader)
       }
     }
     reader.endObject()
 
     // Confirm all parameters are present, optional, or nullable.
-    var isFullInitialized = allBindings.size == constructorSize
     for (i in 0 until constructorSize) {
       if (values[i] === ABSENT_VALUE) {
-        when {
-          constructor.parameters[i].isOptional -> isFullInitialized = false
-
-          // Replace absent with null.
-          constructor.parameters[i].type.isMarkedNullable -> values[i] = null
-
-          else -> throw missingProperty(
-            constructor.parameters[i].name,
-            allBindings[i]?.jsonName,
-            reader,
-          )
+        val param = constructor.parameters[i]
+        if (!param.declaresDefaultValue) {
+          if (!param.isNullable) {
+            throw missingProperty(
+              constructor.parameters[i].name,
+              allBindings[i]?.jsonName,
+              reader,
+            )
+          }
+          values[i] = null // Replace absent with null.
         }
       }
     }
 
     // Call the constructor using a Map so that absent optionals get defaults.
-    val result = if (isFullInitialized) {
-      constructor.call(*values)
-    } else {
-      constructor.callBy(IndexedParameterMap(constructor.parameters, values))
-    }
+    val result = constructor.callBy<T>(IndexedParameterMap(constructor.parameters, values))
 
     // Set remaining properties.
     for (i in constructorSize until allBindings.size) {
@@ -141,51 +140,64 @@ internal class KotlinJsonAdapter<T>(
     for (binding in allBindings) {
       if (binding == null) continue // Skip constructor parameters that aren't properties.
 
-      writer.name(binding.jsonName)
+      writer.name(binding.name)
       binding.adapter.toJson(writer, binding.get(value))
     }
     writer.endObject()
   }
 
-  override fun toString() = "KotlinJsonAdapter(${constructor.returnType})"
+  override fun toString() = "KotlinJsonAdapter(${constructor.type.canonicalName})"
 
   data class Binding<K, P>(
+    val name: String,
     val jsonName: String,
     val adapter: JsonAdapter<P>,
-    val property: KProperty1<K, P>,
-    val parameter: KParameter?,
-    val propertyIndex: Int,
+    val property: KtProperty,
+    val propertyIndex: Int = property.parameter?.index ?: -1,
   ) {
-    fun get(value: K) = property.get(value)
+
+    fun get(value: K): Any? {
+      property.jvmGetter?.let { getter ->
+        return getter.invoke(value)
+      }
+      property.jvmField?.let {
+        return it.get(value)
+      }
+
+      error("Could not get JVM field or invoke JVM getter for property '$name'")
+    }
 
     fun set(result: K, value: P) {
       if (value !== ABSENT_VALUE) {
-        (property as KMutableProperty1<K, P>).set(result, value)
+        property.jvmSetter?.let { setter ->
+          setter.invoke(result, value)
+          return
+        }
+        property.jvmField?.set(result, value)
       }
     }
   }
 
   /** A simple [Map] that uses parameter indexes instead of sorting or hashing. */
   class IndexedParameterMap(
-    private val parameterKeys: List<KParameter>,
+    private val parameterKeys: List<KtParameter>,
     private val parameterValues: Array<Any?>,
-  ) : AbstractMutableMap<KParameter, Any?>() {
+  ) : AbstractMutableMap<KtParameter, Any?>() {
 
-    override fun put(key: KParameter, value: Any?): Any? = null
+    override fun put(key: KtParameter, value: Any?): Any? = null
 
-    override val entries: MutableSet<MutableMap.MutableEntry<KParameter, Any?>>
+    override val entries: MutableSet<MutableMap.MutableEntry<KtParameter, Any?>>
       get() {
-        val allPossibleEntries = parameterKeys.mapIndexed { index, value ->
-          SimpleEntry<KParameter, Any?>(value, parameterValues[index])
-        }
-        return allPossibleEntries.filterTo(mutableSetOf()) {
-          it.value !== ABSENT_VALUE
-        }
+        val allPossibleEntries =
+          parameterKeys.mapIndexed { index, value ->
+            SimpleEntry<KtParameter, Any?>(value, parameterValues[index])
+          }
+        return allPossibleEntries.filterTo(mutableSetOf()) { it.value !== ABSENT_VALUE }
       }
 
-    override fun containsKey(key: KParameter) = parameterValues[key.index] !== ABSENT_VALUE
+    override fun containsKey(key: KtParameter) = parameterValues[key.index] !== ABSENT_VALUE
 
-    override fun get(key: KParameter): Any? {
+    override fun get(key: KtParameter): Any? {
       val value = parameterValues[key.index]
       return if (value !== ABSENT_VALUE) value else null
     }
@@ -213,111 +225,102 @@ public class KotlinJsonAdapterFactory : JsonAdapter.Factory {
       // Fall back to a reflective adapter when the generated adapter is not found.
     }
 
-    require(!rawType.isLocalClass) {
-      "Cannot serialize local class or object expression ${rawType.name}"
-    }
-    val rawTypeKotlin = rawType.kotlin
-    require(!rawTypeKotlin.isAbstract) {
+    require(!rawType.isLocalClass) { "Cannot serialize local class or object expression ${rawType.name}" }
+
+    require(!rawType.isAnonymousClass) { "Cannot serialize anonymous class ${rawType.name}" }
+
+    val kmClass = rawType.header()?.toKmClass() ?: return null
+
+    require(kmClass.modality != Modality.ABSTRACT) {
       "Cannot serialize abstract class ${rawType.name}"
     }
-    require(!rawTypeKotlin.isInner) {
-      "Cannot serialize inner class ${rawType.name}"
-    }
-    require(rawTypeKotlin.objectInstance == null) {
+    require(!kmClass.isInner) { "Cannot serialize inner class ${rawType.name}" }
+    require(kmClass.kind != ClassKind.OBJECT) {
       "Cannot serialize object declaration ${rawType.name}"
     }
-    require(!rawTypeKotlin.isSealed) {
+    require(kmClass.kind != ClassKind.COMPANION_OBJECT) {
+      "Cannot serialize companion object declaration ${rawType.name}"
+    }
+    require(kmClass.modality != Modality.SEALED) {
       "Cannot reflectively serialize sealed class ${rawType.name}. Please register an adapter."
     }
 
-    val constructor = rawTypeKotlin.primaryConstructor ?: return null
-    val parametersByName = constructor.parameters.associateBy { it.name }
-    constructor.isAccessible = true
+    val ktConstructor = KtConstructor.primary(rawType, kmClass) ?: return null
 
+    // TODO CR this doesn't cover platform types
+    val allPropertiesSequence =
+      kmClass.properties.asSequence() +
+        generateSequence(rawType) { it.superclass }
+          .mapNotNull { it.header()?.toKmClass() }
+          .flatMap { it.properties.asSequence() }
+          .filterNot {
+            it.visibility == Visibility.PRIVATE || it.visibility == Visibility.PRIVATE_TO_THIS
+          }
+          .filter { it.isVar }
+
+    val signatureSearcher = JvmSignatureSearcher(rawType)
     val bindingsByName = LinkedHashMap<String, KotlinJsonAdapter.Binding<Any, Any?>>()
+    val parametersByName = ktConstructor.parameters.associateBy { it.name }
 
-    for (property in rawTypeKotlin.memberProperties) {
-      val parameter = parametersByName[property.name]
+    for (property in allPropertiesSequence.distinctBy { it.name }) {
+      val propertyField = signatureSearcher.field(property)
+      val ktParameter = parametersByName[property.name]
 
-      property.isAccessible = true
-      var jsonAnnotation = property.findAnnotation<Json>()
-      val allAnnotations = property.annotations.toMutableList()
-
-      if (parameter != null) {
-        allAnnotations += parameter.annotations
-        if (jsonAnnotation == null) {
-          jsonAnnotation = parameter.findAnnotation()
+      if (ktParameter != null) {
+        require(ktParameter.km.type valueEquals property.returnType) {
+          "'${property.name}' has a constructor parameter of type ${ktParameter.km.type.canonicalName} but a property of type ${property.returnType.canonicalName}."
         }
       }
 
-      if (Modifier.isTransient(property.javaField?.modifiers ?: 0)) {
-        require(parameter == null || parameter.isOptional) {
-          "No default value for transient constructor $parameter"
-        }
-        continue
-      } else if (jsonAnnotation?.ignore == true) {
-        require(parameter == null || parameter.isOptional) {
-          "No default value for ignored constructor $parameter"
-        }
-        continue
-      }
+      if (!property.isVar && ktParameter == null) continue
 
-      require(parameter == null || parameter.type == property.returnType) {
-        "'${property.name}' has a constructor parameter of type ${parameter!!.type} but a property of type ${property.returnType}."
-      }
+      val getterMethod = signatureSearcher.getter(property)
+      val setterMethod = signatureSearcher.setter(property)
+      val annotationsMethod = signatureSearcher.syntheticMethodForAnnotations(property)
 
-      if (property !is KMutableProperty1 && parameter == null) continue
+      val ktProperty =
+        KtProperty(
+          km = property,
+          jvmField = propertyField,
+          jvmGetter = getterMethod,
+          jvmSetter = setterMethod,
+          jvmAnnotationsMethod = annotationsMethod,
+          parameter = ktParameter,
+        )
+      val allAnnotations = ktProperty.annotations.toMutableList()
+      val jsonAnnotation = allAnnotations.filterIsInstance<Json>().firstOrNull()
 
-      val jsonName = jsonAnnotation?.name?.takeUnless { it == Json.UNSET_NAME } ?: property.name
-      val propertyType = when (val propertyTypeClassifier = property.returnType.classifier) {
-        is KClass<*> -> {
-          if (propertyTypeClassifier.isValue) {
-            // When it's a value class, we need to resolve the type ourselves because the javaType
-            // function will return its inlined type
-            val rawClassifierType = propertyTypeClassifier.java
-            if (property.returnType.arguments.isEmpty()) {
-              rawClassifierType
-            } else {
-              Types.newParameterizedType(
-                rawClassifierType,
-                *property.returnType.arguments.mapNotNull { it.type?.javaType }.toTypedArray(),
-              )
-            }
-          } else {
-            // This is safe when it's not a value class!
-            property.returnType.javaType
+      val isIgnored =
+        Modifier.isTransient(propertyField?.modifiers ?: 0) || jsonAnnotation?.ignore == true
+
+      if (isIgnored) {
+        ktParameter?.run {
+          require(declaresDefaultValue) {
+            "No default value for transient/ignored constructor parameter '$name' on type '${rawType.canonicalName}'"
           }
         }
-
-        is KTypeParameter -> {
-          property.returnType.javaType
-        }
-
-        else -> error("Not possible!")
+        continue
       }
-      val resolvedPropertyType = propertyType.resolve(type, rawType)
-      val adapter = moshi.adapter<Any?>(
-        resolvedPropertyType,
-        allAnnotations.toTypedArray().jsonAnnotations,
-        property.name,
-      )
 
-      @Suppress("UNCHECKED_CAST")
-      bindingsByName[property.name] = KotlinJsonAdapter.Binding(
-        jsonName,
-        adapter,
-        property as KProperty1<Any, Any?>,
-        parameter,
-        parameter?.index ?: -1,
-      )
+      val name = jsonAnnotation?.name ?: property.name
+      val resolvedPropertyType = ktProperty.javaType.resolve(type, rawType)
+      val adapter =
+        moshi.adapter<Any?>(
+          resolvedPropertyType,
+          allAnnotations.toTypedArray().jsonAnnotations,
+          property.name,
+        )
+
+      bindingsByName[property.name] =
+        KotlinJsonAdapter.Binding(name, jsonAnnotation?.name ?: name, adapter, ktProperty)
     }
 
     val bindings = ArrayList<KotlinJsonAdapter.Binding<Any, Any?>?>()
 
-    for (parameter in constructor.parameters) {
+    for (parameter in ktConstructor.parameters) {
       val binding = bindingsByName.remove(parameter.name)
-      require(binding != null || parameter.isOptional) {
-        "No property for required constructor $parameter"
+      require(binding != null || parameter.declaresDefaultValue) {
+        "No property for required constructor parameter '${parameter.name}' on type '${rawType.canonicalName}'"
       }
       bindings += binding
     }
@@ -328,7 +331,133 @@ public class KotlinJsonAdapterFactory : JsonAdapter.Factory {
     }
 
     val nonIgnoredBindings = bindings.filterNotNull()
-    val options = JsonReader.Options.of(*nonIgnoredBindings.map { it.jsonName }.toTypedArray())
-    return KotlinJsonAdapter(constructor, bindings, nonIgnoredBindings, options).nullSafe()
+    val options = JsonReader.Options.of(*nonIgnoredBindings.map { it.name }.toTypedArray())
+    return KotlinJsonAdapter(ktConstructor, bindings, nonIgnoredBindings, options).nullSafe()
+  }
+
+  private infix fun KmType?.valueEquals(other: KmType?): Boolean {
+    return when {
+      this === other -> true
+      this != null && other != null -> {
+        // Note we don't check abbreviatedType because typealiases and their backing types are equal
+        // for our purposes.
+        arguments valueEquals other.arguments &&
+          classifier == other.classifier &&
+          isNullable == other.isNullable &&
+          flexibleTypeUpperBound valueEquals other.flexibleTypeUpperBound &&
+          outerType valueEquals other.outerType
+      }
+      else -> false
+    }
+  }
+
+  private infix fun List<KmTypeProjection>.valueEquals(other: List<KmTypeProjection>): Boolean {
+    // check collections aren't same
+    if (this !== other) {
+      // fast check of sizes
+      if (this.size != other.size) return false
+
+      // check this and other contains same elements at position
+      for (i in indices) {
+        if (!(get(i) valueEquals other[i])) {
+          return false
+        }
+      }
+    }
+    // collections are same or they contain same elements with same order
+    return true
+  }
+
+  private infix fun KmTypeProjection?.valueEquals(other: KmTypeProjection?): Boolean {
+    return when {
+      this === other -> true
+      this != null && other != null -> {
+        variance == other.variance && type valueEquals other.type
+      }
+      else -> false
+    }
+  }
+
+  private infix fun KmFlexibleTypeUpperBound?.valueEquals(
+    other: KmFlexibleTypeUpperBound?,
+  ): Boolean {
+    return when {
+      this === other -> true
+      this != null && other != null -> {
+        typeFlexibilityId == other.typeFlexibilityId && type valueEquals other.type
+      }
+      else -> false
+    }
+  }
+  private fun Class<*>.header(): Metadata? {
+    val metadata = getAnnotation(KOTLIN_METADATA) ?: return null
+    return with(metadata) {
+      Metadata(
+        kind = kind,
+        metadataVersion = metadataVersion,
+        data1 = data1,
+        data2 = data2,
+        extraString = extraString,
+        packageName = packageName,
+        extraInt = extraInt,
+      )
+    }
+  }
+
+  private fun Metadata.toKmClass(): KmClass? {
+    val classMetadata = KotlinClassMetadata.readLenient(this)
+    if (classMetadata !is KotlinClassMetadata.Class) {
+      return null
+    }
+
+    return classMetadata.kmClass
+  }
+
+  private class JvmSignatureSearcher(private val clazz: Class<*>) {
+    fun syntheticMethodForAnnotations(kmProperty: KmProperty): Method? =
+      kmProperty.syntheticMethodForAnnotations?.let { signature -> findMethod(clazz, signature) }
+
+    fun getter(kmProperty: KmProperty): Method? =
+      kmProperty.getterSignature?.let { signature -> findMethod(clazz, signature) }
+
+    fun setter(kmProperty: KmProperty): Method? =
+      kmProperty.setterSignature?.let { signature -> findMethod(clazz, signature) }
+
+    fun field(kmProperty: KmProperty): Field? =
+      kmProperty.fieldSignature?.let { signature -> findField(clazz, signature) }
+
+    private fun findMethod(sourceClass: Class<*>, signature: JvmMethodSignature): Method {
+      val parameterTypes = signature.decodeParameterTypes()
+      return try {
+        if (parameterTypes.isEmpty()) {
+          // Save the empty copy
+          sourceClass.getDeclaredMethod(signature.name)
+        } else {
+          sourceClass.getDeclaredMethod(signature.name, *parameterTypes.toTypedArray())
+        }
+      } catch (e: NoSuchMethodException) {
+        // Try finding the superclass method
+        val superClass = sourceClass.superclass
+        if (superClass != Any::class.java) {
+          return findMethod(superClass, signature)
+        } else {
+          throw e
+        }
+      }
+    }
+
+    private fun findField(sourceClass: Class<*>, signature: JvmFieldSignature): Field {
+      return try {
+        sourceClass.getDeclaredField(signature.name)
+      } catch (e: NoSuchFieldException) {
+        // Try finding the superclass field
+        val superClass = sourceClass.superclass
+        if (superClass != Any::class.java) {
+          return findField(superClass, signature)
+        } else {
+          throw e
+        }
+      }
+    }
   }
 }

--- a/moshi-kotlin/src/main/java/com/squareup/moshi/kotlin/reflect/KtTypes.kt
+++ b/moshi-kotlin/src/main/java/com/squareup/moshi/kotlin/reflect/KtTypes.kt
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.moshi.kotlin.reflect
+
+import com.squareup.moshi.internal.DEFAULT_CONSTRUCTOR_MARKER
+import java.lang.reflect.Constructor
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.lang.reflect.Type
+import kotlin.metadata.KmClass
+import kotlin.metadata.KmClassifier
+import kotlin.metadata.KmClassifier.TypeAlias
+import kotlin.metadata.KmClassifier.TypeParameter
+import kotlin.metadata.KmConstructor
+import kotlin.metadata.KmProperty
+import kotlin.metadata.KmType
+import kotlin.metadata.KmValueParameter
+import kotlin.metadata.declaresDefaultValue
+import kotlin.metadata.isLocalClassName
+import kotlin.metadata.isNullable
+import kotlin.metadata.isSecondary
+import kotlin.metadata.jvm.signature
+
+private val DEFAULT_CONSTRUCTOR_SIGNATURE by lazy(LazyThreadSafetyMode.NONE) {
+  DEFAULT_CONSTRUCTOR_MARKER!!.descriptor
+}
+
+private fun defaultPrimitiveValue(type: Type): Any? =
+  if (type is Class<*> && type.isPrimitive) {
+    when (type) {
+      Boolean::class.java -> false
+      Char::class.java -> 0.toChar()
+      Byte::class.java -> 0.toByte()
+      Short::class.java -> 0.toShort()
+      Int::class.java -> 0
+      Float::class.java -> 0f
+      Long::class.java -> 0L
+      Double::class.java -> 0.0
+      Void.TYPE -> throw IllegalStateException("Parameter with void type is illegal")
+      else -> throw UnsupportedOperationException("Unknown primitive: $type")
+    }
+  } else {
+    null
+  }
+
+internal val KmType.canonicalName: String
+  get() {
+    return buildString {
+      val classifierString =
+        when (val cl = classifier) {
+          is KmClassifier.Class -> createClassName(cl.name)
+          is TypeAlias -> createClassName(cl.name)
+          is TypeParameter -> arguments[cl.id].type?.canonicalName ?: "*"
+        }
+      append(classifierString)
+
+      val args =
+        arguments.joinToString(", ") {
+          "${it.variance?.name.orEmpty()} ${it.type?.canonicalName ?: "*"}".trim()
+        }
+
+      if (args.isNotBlank()) {
+        append('<')
+        append(args)
+        append('>')
+      }
+    }
+  }
+
+/**
+ * Creates a canonical class name as represented in Metadata's [kotlin.metadata.ClassName], where
+ * package names in this name are separated by '/' and class names are separated by '.'.
+ *
+ * Example ClassName that we want to canonicalize: `"java/util/Map.Entry"`.
+ *
+ * Local classes are prefixed with ".", but for Moshi's use case we don't deal with those.
+ */
+private fun createClassName(kotlinMetadataName: String): String {
+  require(!kotlinMetadataName.isLocalClassName()) {
+    "Local/anonymous classes are not supported: $kotlinMetadataName"
+  }
+  return kotlinMetadataName.replace("/", ".")
+}
+
+internal data class KtParameter(
+  val km: KmValueParameter,
+  val index: Int,
+  val rawType: Class<*>,
+  val annotations: List<Annotation>,
+) {
+  val name
+    get() = km.name
+
+  val declaresDefaultValue
+    get() = km.declaresDefaultValue
+
+  val isNullable
+    get() = km.type.isNullable
+}
+
+internal data class KtConstructor(
+  val type: Class<*>,
+  val km: KmConstructor,
+  val jvm: Constructor<*>,
+  val parameters: List<KtParameter>,
+  val isDefault: Boolean,
+) {
+  init {
+    jvm.isAccessible = true
+  }
+
+  fun <R> callBy(argumentsMap: Map<KtParameter, Any?>): R {
+    val arguments = ArrayList<Any?>(parameters.size)
+    var mask = 0
+    val masks = ArrayList<Int>(1)
+    var index = 0
+
+    for (parameter in parameters) {
+      if (index != 0 && index % Integer.SIZE == 0) {
+        masks += mask
+        mask = 0
+        index = 0
+      }
+
+      val possibleArg = argumentsMap[parameter]
+      val usePossibleArg = possibleArg != null || parameter in argumentsMap
+      when {
+        usePossibleArg -> {
+          arguments += possibleArg
+        }
+        parameter.declaresDefaultValue -> {
+          arguments += defaultPrimitiveValue(parameter.rawType)
+          mask = mask or (1 shl (index % Integer.SIZE))
+        }
+        else -> {
+          throw IllegalArgumentException(
+            "No argument provided for a required parameter: $parameter",
+          )
+        }
+      }
+
+      index++
+    }
+
+    if (!isDefault) {
+      @Suppress("UNCHECKED_CAST")
+      return jvm.newInstance(*arguments.toTypedArray()) as R
+    }
+
+    masks += mask
+    arguments.addAll(masks)
+
+    // DefaultConstructorMarker
+    arguments += null
+
+    @Suppress("UNCHECKED_CAST")
+    return jvm.newInstance(*arguments.toTypedArray()) as R
+  }
+
+  companion object {
+    fun primary(rawType: Class<*>, kmClass: KmClass): KtConstructor? {
+      val kmConstructor = kmClass.constructors.find { !it.isSecondary } ?: return null
+      val kmConstructorSignature = kmConstructor.signature?.toString() ?: return null
+      val constructorsBySignature =
+        rawType.declaredConstructors.associateBy { it.jvmMethodSignature }
+      val jvmConstructor = constructorsBySignature[kmConstructorSignature] ?: return null
+      val parameterAnnotations = jvmConstructor.parameterAnnotations
+      val parameterTypes = jvmConstructor.parameterTypes
+      val parameters =
+        kmConstructor.valueParameters.withIndex().map { (index, kmParam) ->
+          KtParameter(kmParam, index, parameterTypes[index], parameterAnnotations[index].toList())
+        }
+
+      val anyOptional = parameters.any { it.declaresDefaultValue }
+      val actualConstructor =
+        if (anyOptional) {
+          val prefix = jvmConstructor.jvmMethodSignature.removeSuffix(")V")
+          val parameterCount = jvmConstructor.parameterTypes.size
+          val maskParamsToAdd = (parameterCount + 31) / 32
+          val defaultConstructorSignature = buildString {
+            append(prefix)
+            repeat(maskParamsToAdd) { append("I") }
+            append(DEFAULT_CONSTRUCTOR_SIGNATURE)
+            append(")V")
+          }
+          constructorsBySignature[defaultConstructorSignature] ?: return null
+        } else {
+          jvmConstructor
+        }
+
+      return KtConstructor(rawType, kmConstructor, actualConstructor, parameters, anyOptional)
+    }
+  }
+}
+
+internal data class KtProperty(
+  val km: KmProperty,
+  val jvmField: Field?,
+  val jvmGetter: Method?,
+  val jvmSetter: Method?,
+  val jvmAnnotationsMethod: Method?,
+  val parameter: KtParameter?,
+) {
+  init {
+    jvmField?.isAccessible = true
+    jvmGetter?.isAccessible = true
+    jvmSetter?.isAccessible = true
+  }
+
+  val name
+    get() = km.name
+
+  val javaType =
+    jvmField?.genericType
+      ?: jvmGetter?.genericReturnType
+      ?: jvmSetter?.genericReturnType
+      ?: error(
+        "No type information available for property '${km.name}' with type '${km.returnType.canonicalName}'.",
+      )
+
+  val annotations: Set<Annotation> by lazy {
+    val set = LinkedHashSet<Annotation>()
+    jvmField?.annotations?.let { set += it }
+    jvmGetter?.annotations?.let { set += it }
+    jvmSetter?.annotations?.let { set += it }
+    jvmAnnotationsMethod?.annotations?.let { set += it }
+    parameter?.annotations?.let { set += it }
+    set
+  }
+}

--- a/moshi-kotlin/src/main/resources/META-INF/com.android.tools/proguard/moshi-metadata-reflect.pro
+++ b/moshi-kotlin/src/main/resources/META-INF/com.android.tools/proguard/moshi-metadata-reflect.pro
@@ -1,0 +1,16 @@
+# When editing this file, update the following files as well:
+# - META-INF/com.android.tools/r8-from-1.6.0/moshi-metadata-reflect.pro
+# - META-INF/com.android.tools/r8-upto-1.6.0/moshi-metadata-reflect.pro
+# - META-INF/proguard/moshi-metadata-reflect.pro
+# Keep Metadata annotations so they can be parsed at runtime.
+-keep class kotlin.Metadata { *; }
+
+# Keep default constructor marker name for lookup in signatures.
+-keepnames class kotlin.jvm.internal.DefaultConstructorMarker
+
+# Keep implementations of service loaded interfaces
+-keep interface kotlin.metadata.internal.extensions.MetadataExtensions
+-keep class * implements kotlin.metadata.internal.extensions.MetadataExtensions { public protected *; }
+
+# Keep generic signatures and annotations at runtime.
+-keepattributes Signature,RuntimeVisible*Annotations

--- a/moshi-kotlin/src/main/resources/META-INF/com.android.tools/r8-from-1.6.0/moshi-metadata-reflect.pro
+++ b/moshi-kotlin/src/main/resources/META-INF/com.android.tools/r8-from-1.6.0/moshi-metadata-reflect.pro
@@ -1,0 +1,13 @@
+# When editing this file, update the following files as well:
+# - META-INF/com.android.tools/proguard/moshi-kotlin.pro
+# - META-INF/com.android.tools/r8-upto-1.6.0/moshi-kotlin.pro
+# - META-INF/proguard/moshi-kotlin.pro
+# Keep Metadata annotations so they can be parsed at runtime.
+-keep class kotlin.Metadata { *; }
+
+# Keep default constructor marker name for lookup in signatures.
+-keepnames class kotlin.jvm.internal.DefaultConstructorMarker
+
+# Keep generic signatures and annotations at runtime.
+# R8 requires InnerClasses and EnclosingMethod if you keepattributes Signature.
+-keepattributes InnerClasses,Signature,RuntimeVisible*Annotations,EnclosingMethod

--- a/moshi-kotlin/src/main/resources/META-INF/com.android.tools/r8-upto-1.6.0/moshi-metadata-reflect.pro
+++ b/moshi-kotlin/src/main/resources/META-INF/com.android.tools/r8-upto-1.6.0/moshi-metadata-reflect.pro
@@ -1,0 +1,18 @@
+# When editing this file, update the following files as well:
+# - META-INF/com.android.tools/proguard/moshi-kotlin.pro
+# - META-INF/com.android.tools/r8-from-1.6.0/moshi-kotlin.pro
+# - META-INF/proguard/moshi-kotlin.pro
+# Keep Metadata annotations so they can be parsed at runtime.
+-keep class kotlin.Metadata { *; }
+
+# Keep default constructor marker name for lookup in signatures.
+-keepnames class kotlin.jvm.internal.DefaultConstructorMarker
+
+# Keep implementations of service loaded interfaces
+# R8 will automatically handle these these in 1.6+
+-keep interface kotlin.metadata.internal.extensions.MetadataExtensions
+-keep class * implements kotlin.metadata.internal.extensions.MetadataExtensions { public protected *; }
+
+# Keep generic signatures and annotations at runtime.
+# R8 requires InnerClasses and EnclosingMethod if you keepattributes Signature.
+-keepattributes InnerClasses,Signature,RuntimeVisible*Annotations,EnclosingMethod


### PR DESCRIPTION
Mostly a straight port of https://github.com/ZacSweers/MoshiX/tree/main/moshi-metadata-reflect (benchmarks linked there too)