### PR TITLE
Hide more symbols from the public API

### DIFF
--- a/moshi/src/main/java/com/squareup/moshi/-JsonUtf8Reader.kt
+++ b/moshi/src/main/java/com/squareup/moshi/-JsonUtf8Reader.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.moshi
 
+import com.squareup.moshi.internal.JsonScope
 import com.squareup.moshi.internal.JsonValueSource
 import com.squareup.moshi.internal.knownNotNull
 import okio.Buffer
@@ -26,7 +27,8 @@ import okio.IOException
 import okio.buffer
 import java.math.BigDecimal
 
-internal class JsonUtf8Reader : JsonReader {
+@Suppress("ktlint:standard:class-naming") // Hide this symbol from Java callers.
+internal class `-JsonUtf8Reader` : JsonReader {
   /** The input JSON. */
   private val source: BufferedSource
   private val buffer: Buffer
@@ -61,7 +63,7 @@ internal class JsonUtf8Reader : JsonReader {
   }
 
   /** Copy-constructor makes a deep copy for peeking. */
-  constructor(copyFrom: JsonUtf8Reader) : super(copyFrom) {
+  constructor(copyFrom: `-JsonUtf8Reader`) : super(copyFrom) {
     val sourcePeek = copyFrom.source.peek()
     source = sourcePeek
     buffer = sourcePeek.buffer
@@ -1081,7 +1083,7 @@ internal class JsonUtf8Reader : JsonReader {
     return found
   }
 
-  override fun peekJson(): JsonReader = JsonUtf8Reader(this)
+  override fun peekJson(): JsonReader = `-JsonUtf8Reader`(this)
 
   override fun toString(): String = "JsonReader($source)"
 
@@ -1195,8 +1197,8 @@ internal class JsonUtf8Reader : JsonReader {
     private const val NUMBER_CHAR_EXP_E = 5
     private const val NUMBER_CHAR_EXP_SIGN = 6
     private const val NUMBER_CHAR_EXP_DIGIT = 7
+
+    @Suppress("NOTHING_TO_INLINE")
+    private inline fun Byte.asChar(): Char = toInt().toChar()
   }
 }
-
-@Suppress("NOTHING_TO_INLINE")
-private inline fun Byte.asChar(): Char = toInt().toChar()

--- a/moshi/src/main/java/com/squareup/moshi/-JsonUtf8Writer.kt
+++ b/moshi/src/main/java/com/squareup/moshi/-JsonUtf8Writer.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.moshi
 
+import com.squareup.moshi.internal.JsonScope
 import okio.Buffer
 import okio.BufferedSink
 import okio.Sink
@@ -35,7 +36,8 @@ import kotlin.check
 import kotlin.code
 import kotlin.require
 
-internal class JsonUtf8Writer(
+@Suppress("ktlint:standard:class-naming") // Hide this symbol from Java callers.
+internal class `-JsonUtf8Writer`(
   /** The output data, containing at most one top-level array or object. */
   private val sink: BufferedSink,
 ) : JsonWriter() {

--- a/moshi/src/main/java/com/squareup/moshi/-JsonValueReader.kt
+++ b/moshi/src/main/java/com/squareup/moshi/-JsonValueReader.kt
@@ -15,14 +15,11 @@
  */
 package com.squareup.moshi
 
-import com.squareup.moshi.JsonValueReader.JsonIterator
+import com.squareup.moshi.internal.JsonScope
 import com.squareup.moshi.internal.knownNotNull
 import okio.Buffer
 import okio.BufferedSource
 import java.math.BigDecimal
-
-/** Sentinel object pushed on [JsonValueReader.stack] when the reader is closed. */
-private val JSON_READER_CLOSED = Any()
 
 /**
  * This class reads a JSON document by traversing a Java object comprising maps, lists, and JSON
@@ -39,7 +36,8 @@ private val JSON_READER_CLOSED = Any()
  *  element of that iterator is pushed.
  *  * If the top of the stack is an exhausted iterator, calling [endArray] or [endObject] will pop it.
  */
-internal class JsonValueReader : JsonReader {
+@Suppress("ktlint:standard:class-naming") // Hide this symbol from Java callers.
+internal class `-JsonValueReader` : JsonReader {
   private var stack: Array<Any?>
 
   constructor(root: Any?) {
@@ -49,7 +47,7 @@ internal class JsonValueReader : JsonReader {
   }
 
   /** Copy-constructor makes a deep copy for peeking. */
-  constructor(copyFrom: JsonValueReader) : super(copyFrom) {
+  constructor(copyFrom: `-JsonValueReader`) : super(copyFrom) {
     stack = copyFrom.stack.clone()
     for (i in 0 until stackSize) {
       val element = stack[i]
@@ -314,7 +312,7 @@ internal class JsonValueReader : JsonReader {
     return result
   }
 
-  override fun peekJson(): JsonReader = JsonValueReader(this)
+  override fun peekJson(): JsonReader = `-JsonValueReader`(this)
 
   override fun promoteNameToValue() {
     if (hasNext()) {
@@ -406,5 +404,10 @@ internal class JsonValueReader : JsonReader {
 
     // No need to copy the array; it's read-only.
     public override fun clone() = JsonIterator(endToken, array, next)
+  }
+
+  private companion object {
+    /** Sentinel object pushed on [JsonValueReader.stack] when the reader is closed. */
+    val JSON_READER_CLOSED = Any()
   }
 }

--- a/moshi/src/main/java/com/squareup/moshi/-JsonValueWriter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/-JsonValueWriter.kt
@@ -15,11 +15,11 @@
  */
 package com.squareup.moshi
 
-import com.squareup.moshi.JsonScope.EMPTY_ARRAY
-import com.squareup.moshi.JsonScope.EMPTY_DOCUMENT
-import com.squareup.moshi.JsonScope.EMPTY_OBJECT
-import com.squareup.moshi.JsonScope.NONEMPTY_DOCUMENT
-import com.squareup.moshi.JsonScope.STREAMING_VALUE
+import com.squareup.moshi.internal.JsonScope.EMPTY_ARRAY
+import com.squareup.moshi.internal.JsonScope.EMPTY_DOCUMENT
+import com.squareup.moshi.internal.JsonScope.EMPTY_OBJECT
+import com.squareup.moshi.internal.JsonScope.NONEMPTY_DOCUMENT
+import com.squareup.moshi.internal.JsonScope.STREAMING_VALUE
 import com.squareup.moshi.internal.LinkedHashTreeMap
 import com.squareup.moshi.internal.knownNotNull
 import okio.Buffer
@@ -30,7 +30,8 @@ import okio.buffer
 import java.math.BigDecimal
 
 /** Writes JSON by building a Java object comprising maps, lists, and JSON primitives. */
-internal class JsonValueWriter : JsonWriter() {
+@Suppress("ktlint:standard:class-naming") // Hide this symbol from Java callers.
+internal class `-JsonValueWriter` : JsonWriter() {
   var stack = arrayOfNulls<Any>(32)
   private var deferredName: String? = null
 
@@ -202,11 +203,11 @@ internal class JsonValueWriter : JsonWriter() {
         stackSize-- // Remove STREAMING_VALUE from the stack.
         val value = JsonReader.of(buffer).readJsonValue()
         val serializeNulls = serializeNulls
-        this@JsonValueWriter.serializeNulls = true
+        this@`-JsonValueWriter`.serializeNulls = true
         try {
           add(value)
         } finally {
-          this@JsonValueWriter.serializeNulls = serializeNulls
+          this@`-JsonValueWriter`.serializeNulls = serializeNulls
         }
         pathIndices[stackSize - 1]++
       }
@@ -225,7 +226,7 @@ internal class JsonValueWriter : JsonWriter() {
     check(stackSize != 0) { "JsonWriter is closed." }
   }
 
-  private fun add(newTop: Any?): JsonValueWriter {
+  private fun add(newTop: Any?): `-JsonValueWriter` {
     val scope = peekScope()
     when {
       stackSize == 1 -> {

--- a/moshi/src/main/java/com/squareup/moshi/JsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/JsonAdapter.kt
@@ -105,7 +105,7 @@ public abstract class JsonAdapter<T> {
    */
   @CheckReturnValue
   public fun toJsonValue(value: T?): Any? {
-    val writer = JsonValueWriter()
+    val writer = `-JsonValueWriter`()
     return try {
       toJson(writer, value)
       writer.root()
@@ -120,7 +120,7 @@ public abstract class JsonAdapter<T> {
    */
   @CheckReturnValue
   public fun fromJsonValue(value: Any?): T? {
-    val reader = JsonValueReader(value)
+    val reader = `-JsonValueReader`(value)
     return try {
       fromJson(reader)
     } catch (e: IOException) {
@@ -278,7 +278,7 @@ public abstract class JsonAdapter<T> {
     }
   }
 
-  public open val isLenient: Boolean
+  internal open val isLenient: Boolean
     get() = false
 
   public fun interface Factory {

--- a/moshi/src/main/java/com/squareup/moshi/JsonReader.kt
+++ b/moshi/src/main/java/com/squareup/moshi/JsonReader.kt
@@ -15,8 +15,8 @@
  */
 package com.squareup.moshi
 
-import com.squareup.moshi.JsonScope.getPath
-import com.squareup.moshi.JsonUtf8Writer.Companion.string
+import com.squareup.moshi.`-JsonUtf8Writer`.Companion.string
+import com.squareup.moshi.internal.JsonScope.getPath
 import okio.Buffer
 import okio.BufferedSource
 import okio.Closeable
@@ -670,7 +670,7 @@ public sealed class JsonReader : Closeable {
     @CheckReturnValue
     @JvmStatic
     public fun of(source: BufferedSource): JsonReader {
-      return JsonUtf8Reader(source)
+      return `-JsonUtf8Reader`(source)
     }
   }
 }

--- a/moshi/src/main/java/com/squareup/moshi/JsonWriter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/JsonWriter.kt
@@ -15,10 +15,11 @@
  */
 package com.squareup.moshi
 
-import com.squareup.moshi.JsonScope.EMPTY_ARRAY
-import com.squareup.moshi.JsonScope.EMPTY_OBJECT
-import com.squareup.moshi.JsonScope.NONEMPTY_ARRAY
-import com.squareup.moshi.JsonScope.NONEMPTY_OBJECT
+import com.squareup.moshi.internal.JsonScope
+import com.squareup.moshi.internal.JsonScope.EMPTY_ARRAY
+import com.squareup.moshi.internal.JsonScope.EMPTY_OBJECT
+import com.squareup.moshi.internal.JsonScope.NONEMPTY_ARRAY
+import com.squareup.moshi.internal.JsonScope.NONEMPTY_OBJECT
 import okio.BufferedSink
 import okio.BufferedSource
 import okio.Closeable
@@ -235,7 +236,7 @@ public sealed class JsonWriter :
     scopes = scopes.copyOf(scopes.size * 2)
     pathNames = pathNames.copyOf(pathNames.size * 2)
     pathIndices = pathIndices.copyOf(pathIndices.size * 2)
-    if (this is JsonValueWriter) {
+    if (this is `-JsonValueWriter`) {
       stack = stack.copyOf(stack.size * 2)
     }
     return true
@@ -538,6 +539,6 @@ public sealed class JsonWriter :
     /** Returns a new instance that writes UTF-8 encoded JSON to `sink`. */
     @JvmStatic
     @CheckReturnValue
-    public fun of(sink: BufferedSink): JsonWriter = JsonUtf8Writer(sink)
+    public fun of(sink: BufferedSink): JsonWriter = `-JsonUtf8Writer`(sink)
   }
 }

--- a/moshi/src/main/java/com/squareup/moshi/Moshi.kt
+++ b/moshi/src/main/java/com/squareup/moshi/Moshi.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.moshi
 
-import com.squareup.moshi.Types.createJsonQualifierImplementation
 import com.squareup.moshi.internal.AdapterMethodsFactory
 import com.squareup.moshi.internal.ArrayJsonAdapter
 import com.squareup.moshi.internal.ClassJsonAdapter
@@ -27,6 +26,7 @@ import com.squareup.moshi.internal.NullSafeJsonAdapter
 import com.squareup.moshi.internal.RecordJsonAdapter
 import com.squareup.moshi.internal.StandardJsonAdapters
 import com.squareup.moshi.internal.canonicalize
+import com.squareup.moshi.internal.createJsonQualifierImplementation
 import com.squareup.moshi.internal.isAnnotationPresent
 import com.squareup.moshi.internal.removeSubtypeWildcard
 import com.squareup.moshi.internal.toStringWithAnnotations
@@ -43,7 +43,7 @@ import kotlin.reflect.typeOf
  * Moshi instances are thread-safe, meaning multiple threads can safely use a single instance
  * concurrently.
  */
-public class Moshi internal constructor(builder: Builder) {
+public class Moshi private constructor(builder: Builder) {
   private val factories = buildList {
     addAll(builder.factories)
     addAll(BUILT_IN_FACTORIES)
@@ -268,7 +268,7 @@ public class Moshi internal constructor(builder: Builder) {
    * successfully been computed. That way we don't pollute the cache with incomplete stubs, or
    * adapters that may transitively depend on incomplete stubs.
    */
-  internal inner class LookupChain {
+  private inner class LookupChain {
     private val callLookups = mutableListOf<Lookup<*>>()
     private val stack = ArrayDeque<Lookup<*>>()
     private var exceptionAnnotated = false
@@ -354,7 +354,7 @@ public class Moshi internal constructor(builder: Builder) {
   }
 
   /** This class implements `JsonAdapter` so it can be used as a stub for re-entrant calls. */
-  internal class Lookup<T>(val type: Type, val fieldName: String?, val cacheKey: Any) : JsonAdapter<T>() {
+  private class Lookup<T>(val type: Type, val fieldName: String?, val cacheKey: Any) : JsonAdapter<T>() {
     var adapter: JsonAdapter<T>? = null
 
     override fun fromJson(reader: JsonReader) = withAdapter { fromJson(reader) }

--- a/moshi/src/main/java/com/squareup/moshi/Types.kt
+++ b/moshi/src/main/java/com/squareup/moshi/Types.kt
@@ -21,16 +21,13 @@ import com.squareup.moshi.internal.EMPTY_TYPE_ARRAY
 import com.squareup.moshi.internal.GenericArrayTypeImpl
 import com.squareup.moshi.internal.ParameterizedTypeImpl
 import com.squareup.moshi.internal.WildcardTypeImpl
-import com.squareup.moshi.internal.getGenericSupertype
-import com.squareup.moshi.internal.resolve
+import com.squareup.moshi.internal.getSupertype
 import java.lang.reflect.GenericArrayType
 import java.lang.reflect.ParameterizedType
-import java.lang.reflect.Proxy
 import java.lang.reflect.Type
 import java.lang.reflect.TypeVariable
 import java.lang.reflect.WildcardType
 import java.util.Collections
-import java.util.Properties
 import javax.annotation.CheckReturnValue
 import java.lang.annotation.Annotation as JavaAnnotation
 
@@ -295,85 +292,6 @@ public object Types {
         "Could not access field $fieldName on class ${clazz.canonicalName}",
         e,
       )
-    }
-  }
-
-  @JvmStatic
-  public fun <T : Annotation?> createJsonQualifierImplementation(annotationType: Class<T>): T {
-    require(annotationType.isAnnotation) {
-      "$annotationType must be an annotation."
-    }
-    require(annotationType.isAnnotationPresent(JsonQualifier::class.java)) {
-      "$annotationType must have @JsonQualifier."
-    }
-    require(annotationType.declaredMethods.isEmpty()) {
-      "$annotationType must not declare methods."
-    }
-    @Suppress("UNCHECKED_CAST")
-    return Proxy.newProxyInstance(
-      annotationType.classLoader,
-      arrayOf<Class<*>>(annotationType),
-    ) { proxy, method, args ->
-      when (method.name) {
-        "annotationType" -> annotationType
-
-        "equals" -> {
-          val o = args[0]
-          annotationType.isInstance(o)
-        }
-
-        "hashCode" -> 0
-
-        "toString" -> "@${annotationType.name}()"
-
-        else -> method.invoke(proxy, *args)
-      }
-    } as T
-  }
-
-  /**
-   * Returns a two element array containing this map's key and value types in positions 0 and 1
-   * respectively.
-   */
-  @JvmStatic
-  public fun mapKeyAndValueTypes(context: Type, contextRawType: Class<*>): Array<Type> {
-    // Work around a problem with the declaration of java.util.Properties. That class should extend
-    // Hashtable<String, String>, but it's declared to extend Hashtable<Object, Object>.
-    if (context === Properties::class.java) return arrayOf(String::class.java, String::class.java)
-    val mapType = getSupertype(context, contextRawType, MutableMap::class.java)
-    if (mapType is ParameterizedType) {
-      return mapType.actualTypeArguments
-    }
-    return arrayOf(Any::class.java, Any::class.java)
-  }
-
-  /**
-   * Returns the generic form of `supertype`. For example, if this is `ArrayList<String>`, this returns `Iterable<String>` given the input `Iterable.class`.
-   *
-   * @param supertype a superclass of, or interface implemented by, this.
-   */
-  @JvmStatic
-  public fun getSupertype(context: Type, contextRawType: Class<*>, supertype: Class<*>): Type {
-    if (!supertype.isAssignableFrom(contextRawType)) throw IllegalArgumentException()
-    return getGenericSupertype(context, contextRawType, supertype).resolve((context), (contextRawType))
-  }
-
-  @JvmStatic
-  public fun getGenericSuperclass(type: Type): Type {
-    val rawType = getRawType(type)
-    return rawType.genericSuperclass.resolve(type, rawType)
-  }
-
-  /**
-   * Returns the element type of `type` if it is an array type, or null if it is not an array
-   * type.
-   */
-  @JvmStatic
-  public fun arrayComponentType(type: Type): Type? {
-    return when (type) {
-      is GenericArrayType -> type.genericComponentType
-      is Class<*> -> type.componentType
-      else -> null
     }
   }
 }

--- a/moshi/src/main/java/com/squareup/moshi/internal/ArrayJsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/internal/ArrayJsonAdapter.kt
@@ -19,7 +19,6 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.Types
 import com.squareup.moshi.rawType
 import java.lang.reflect.Type
 import java.lang.reflect.Array as JavaArray
@@ -111,7 +110,7 @@ internal class ArrayJsonAdapter(
 
   companion object Factory : JsonAdapter.Factory {
     override fun create(type: Type, annotations: Set<Annotation>, moshi: Moshi): JsonAdapter<*>? {
-      val elementType = Types.arrayComponentType(type) ?: return null
+      val elementType = arrayComponentType(type) ?: return null
       if (annotations.isNotEmpty()) return null
       val elementClass = elementType.rawType
       val elementAdapter = moshi.adapter<Any>(elementType)

--- a/moshi/src/main/java/com/squareup/moshi/internal/ClassJsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/internal/ClassJsonAdapter.kt
@@ -20,7 +20,6 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.Types
 import com.squareup.moshi.rawType
 import java.lang.reflect.Field
 import java.lang.reflect.InvocationTargetException
@@ -166,7 +165,7 @@ internal class ClassJsonAdapter<T>(
       var parentType = type
       while (parentType != Any::class.java) {
         createFieldBindings(moshi, parentType, fields)
-        parentType = Types.getGenericSuperclass(parentType)
+        parentType = getGenericSuperclass(parentType)
       }
       return ClassJsonAdapter(classFactory, fields).nullSafe()
     }

--- a/moshi/src/main/java/com/squareup/moshi/internal/JsonScope.kt
+++ b/moshi/src/main/java/com/squareup/moshi/internal/JsonScope.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.squareup.moshi
+package com.squareup.moshi.internal
 
 /** Lexical scoping elements within a JSON reader or writer. */
 internal object JsonScope {

--- a/moshi/src/main/java/com/squareup/moshi/internal/MapJsonAdapter.kt
+++ b/moshi/src/main/java/com/squareup/moshi/internal/MapJsonAdapter.kt
@@ -20,7 +20,6 @@ import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.Types
 import com.squareup.moshi.rawType
 import java.lang.reflect.Type
 
@@ -72,7 +71,7 @@ internal class MapJsonAdapter<K, V>(moshi: Moshi, keyType: Type, valueType: Type
       if (annotations.isNotEmpty()) return null
       val rawType = type.rawType
       if (rawType != Map::class.java) return null
-      val keyAndValue = Types.mapKeyAndValueTypes(type, rawType)
+      val keyAndValue = mapKeyAndValueTypes(type, rawType)
       return MapJsonAdapter<Any, Any>(moshi, keyAndValue[0], keyAndValue[1]).nullSafe()
     }
   }

--- a/moshi/src/test/java/com/squareup/moshi/JsonCodecFactory.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonCodecFactory.java
@@ -15,6 +15,8 @@
  */
 package com.squareup.moshi;
 
+import static com.squareup.moshi.MoshiTesting.jsonValueReader;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -39,7 +41,7 @@ abstract class JsonCodecFactory {
           @Override
           JsonWriter newWriter() {
             buffer = new Buffer();
-            return new JsonUtf8Writer(buffer);
+            return JsonWriter.of(buffer);
           }
 
           @Override
@@ -62,13 +64,13 @@ abstract class JsonCodecFactory {
 
     final JsonCodecFactory value =
         new JsonCodecFactory() {
-          JsonValueWriter writer;
+          JsonWriter writer;
 
           @Override
           public JsonReader newReader(String json) throws IOException {
             Moshi moshi = new Moshi.Builder().build();
             Object object = moshi.adapter(Object.class).lenient().fromJson(json);
-            return new JsonValueReader(object);
+            return jsonValueReader(object);
           }
 
           // TODO(jwilson): fix precision checks and delete his method.
@@ -79,7 +81,7 @@ abstract class JsonCodecFactory {
 
           @Override
           JsonWriter newWriter() {
-            writer = new JsonValueWriter();
+            writer = MoshiTesting.jsonValueWriter();
             return writer;
           }
 
@@ -91,7 +93,7 @@ abstract class JsonCodecFactory {
               JsonWriter bufferedSinkWriter = JsonWriter.of(buffer);
               bufferedSinkWriter.setSerializeNulls(true);
               bufferedSinkWriter.setLenient(true);
-              OBJECT_ADAPTER.toJson(bufferedSinkWriter, writer.root());
+              OBJECT_ADAPTER.toJson(bufferedSinkWriter, MoshiTesting.root(writer));
               return buffer.readUtf8();
             } catch (IOException e) {
               throw new AssertionError();

--- a/moshi/src/test/java/com/squareup/moshi/JsonUtf8WriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonUtf8WriterTest.java
@@ -116,7 +116,7 @@ public final class JsonUtf8WriterTest {
   @Test
   public void valueFromSource() throws IOException {
     Buffer buffer = new Buffer();
-    JsonWriter writer = JsonUtf8Writer.of(buffer);
+    JsonWriter writer = JsonWriter.of(buffer);
     writer.beginObject();
     writer.name("a");
     writer.value(new Buffer().writeUtf8("[\"value\"]"));

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueReaderTest.java
@@ -16,6 +16,7 @@
 package com.squareup.moshi;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.squareup.moshi.MoshiTesting.jsonValueReader;
 import static com.squareup.moshi.TestUtil.MAX_DEPTH;
 import static com.squareup.moshi.TestUtil.repeat;
 import static java.util.Collections.singletonList;
@@ -39,7 +40,7 @@ public final class JsonValueReaderTest {
     root.add(1.5d);
     root.add(true);
     root.add(null);
-    JsonReader reader = new JsonValueReader(root);
+    JsonReader reader = jsonValueReader(root);
 
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.BEGIN_ARRAY);
@@ -75,7 +76,7 @@ public final class JsonValueReaderTest {
     root.put("b", 1.5d);
     root.put("c", true);
     root.put("d", null);
-    JsonReader reader = new JsonValueReader(root);
+    JsonReader reader = jsonValueReader(root);
 
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.BEGIN_OBJECT);
@@ -116,7 +117,7 @@ public final class JsonValueReaderTest {
   public void nesting() throws Exception {
     List<Map<String, List<Map<String, Double>>>> root =
         singletonList(singletonMap("a", singletonList(singletonMap("b", 1.5d))));
-    JsonReader reader = new JsonValueReader(root);
+    JsonReader reader = jsonValueReader(root);
 
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.BEGIN_ARRAY);
@@ -169,7 +170,7 @@ public final class JsonValueReaderTest {
   public void promoteNameToValue() throws Exception {
     Map<String, String> root = singletonMap("a", "b");
 
-    JsonReader reader = new JsonValueReader(root);
+    JsonReader reader = jsonValueReader(root);
     reader.beginObject();
     reader.promoteNameToValue();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.STRING);
@@ -184,7 +185,7 @@ public final class JsonValueReaderTest {
 
   @Test
   public void endArrayTooEarly() throws Exception {
-    JsonReader reader = new JsonValueReader(singletonList("s"));
+    JsonReader reader = jsonValueReader(singletonList("s"));
 
     reader.beginArray();
     try {
@@ -199,7 +200,7 @@ public final class JsonValueReaderTest {
 
   @Test
   public void endObjectTooEarly() throws Exception {
-    JsonReader reader = new JsonValueReader(singletonMap("a", "b"));
+    JsonReader reader = jsonValueReader(singletonMap("a", "b"));
 
     reader.beginObject();
     try {
@@ -212,7 +213,7 @@ public final class JsonValueReaderTest {
 
   @Test
   public void unsupportedType() throws Exception {
-    JsonReader reader = new JsonValueReader(singletonList(new StringBuilder("x")));
+    JsonReader reader = jsonValueReader(singletonList(new StringBuilder("x")));
 
     reader.beginArray();
     try {
@@ -227,7 +228,7 @@ public final class JsonValueReaderTest {
 
   @Test
   public void unsupportedKeyType() throws Exception {
-    JsonReader reader = new JsonValueReader(singletonMap(new StringBuilder("x"), "y"));
+    JsonReader reader = jsonValueReader(singletonMap(new StringBuilder("x"), "y"));
 
     reader.beginObject();
     try {
@@ -242,7 +243,7 @@ public final class JsonValueReaderTest {
 
   @Test
   public void nullKey() throws Exception {
-    JsonReader reader = new JsonValueReader(singletonMap(null, "y"));
+    JsonReader reader = jsonValueReader(singletonMap(null, "y"));
 
     reader.beginObject();
     try {
@@ -255,7 +256,7 @@ public final class JsonValueReaderTest {
 
   @Test
   public void unexpectedIntType() throws Exception {
-    JsonReader reader = new JsonValueReader(singletonList(new StringBuilder("1")));
+    JsonReader reader = jsonValueReader(singletonList(new StringBuilder("1")));
     reader.beginArray();
     try {
       reader.nextInt();
@@ -269,7 +270,7 @@ public final class JsonValueReaderTest {
 
   @Test
   public void unexpectedLongType() throws Exception {
-    JsonReader reader = new JsonValueReader(singletonList(new StringBuilder("1")));
+    JsonReader reader = jsonValueReader(singletonList(new StringBuilder("1")));
     reader.beginArray();
     try {
       reader.nextLong();
@@ -283,7 +284,7 @@ public final class JsonValueReaderTest {
 
   @Test
   public void unexpectedDoubleType() throws Exception {
-    JsonReader reader = new JsonValueReader(singletonList(new StringBuilder("1")));
+    JsonReader reader = jsonValueReader(singletonList(new StringBuilder("1")));
     reader.beginArray();
     try {
       reader.nextDouble();
@@ -297,7 +298,7 @@ public final class JsonValueReaderTest {
 
   @Test
   public void unexpectedStringType() throws Exception {
-    JsonReader reader = new JsonValueReader(singletonList(new StringBuilder("s")));
+    JsonReader reader = jsonValueReader(singletonList(new StringBuilder("s")));
     reader.beginArray();
     try {
       reader.nextString();
@@ -311,7 +312,7 @@ public final class JsonValueReaderTest {
 
   @Test
   public void unexpectedBooleanType() throws Exception {
-    JsonReader reader = new JsonValueReader(singletonList(new StringBuilder("true")));
+    JsonReader reader = jsonValueReader(singletonList(new StringBuilder("true")));
     reader.beginArray();
     try {
       reader.nextBoolean();
@@ -325,7 +326,7 @@ public final class JsonValueReaderTest {
 
   @Test
   public void unexpectedNullType() throws Exception {
-    JsonReader reader = new JsonValueReader(singletonList(new StringBuilder("null")));
+    JsonReader reader = jsonValueReader(singletonList(new StringBuilder("null")));
     reader.beginArray();
     try {
       reader.nextNull();
@@ -339,7 +340,7 @@ public final class JsonValueReaderTest {
 
   @Test
   public void skipRoot() throws Exception {
-    JsonReader reader = new JsonValueReader(singletonList(new StringBuilder("x")));
+    JsonReader reader = jsonValueReader(singletonList(new StringBuilder("x")));
     reader.skipValue();
     assertThat(reader.peek()).isEqualTo(JsonReader.Token.END_DOCUMENT);
   }
@@ -350,7 +351,7 @@ public final class JsonValueReaderTest {
     root.add("a");
     root.add("b");
     root.add("c");
-    JsonReader reader = new JsonValueReader(root);
+    JsonReader reader = jsonValueReader(root);
 
     reader.beginArray();
 
@@ -372,7 +373,7 @@ public final class JsonValueReaderTest {
     root.put("a", "s");
     root.put("b", 1.5d);
     root.put("c", true);
-    JsonReader reader = new JsonValueReader(root);
+    JsonReader reader = jsonValueReader(root);
 
     reader.beginObject();
 
@@ -400,7 +401,7 @@ public final class JsonValueReaderTest {
     root.put("a", "s");
     root.put("b", 1.5d);
     root.put("c", true);
-    JsonReader reader = new JsonValueReader(root);
+    JsonReader reader = jsonValueReader(root);
 
     reader.beginObject();
 
@@ -424,7 +425,7 @@ public final class JsonValueReaderTest {
 
   @Test
   public void failOnUnknown() throws Exception {
-    JsonReader reader = new JsonValueReader(singletonList("a"));
+    JsonReader reader = jsonValueReader(singletonList("a"));
     reader.setFailOnUnknown(true);
 
     reader.beginArray();
@@ -439,7 +440,7 @@ public final class JsonValueReaderTest {
   @Test
   public void close() throws Exception {
     try {
-      JsonReader reader = new JsonValueReader(singletonList("a"));
+      JsonReader reader = jsonValueReader(singletonList("a"));
       reader.beginArray();
       reader.close();
       reader.nextString();
@@ -448,7 +449,7 @@ public final class JsonValueReaderTest {
     }
 
     try {
-      JsonReader reader = new JsonValueReader(singletonList("a"));
+      JsonReader reader = jsonValueReader(singletonList("a"));
       reader.close();
       reader.beginArray();
       fail();
@@ -459,7 +460,7 @@ public final class JsonValueReaderTest {
   @Test
   public void numberToStringCoersion() throws Exception {
     JsonReader reader =
-        new JsonValueReader(Arrays.asList(0, 9223372036854775807L, 2.5d, 3.01f, "a", "5"));
+        jsonValueReader(Arrays.asList(0, 9223372036854775807L, 2.5d, 3.01f, "a", "5"));
     reader.beginArray();
     assertThat(reader.nextString()).isEqualTo("0");
     assertThat(reader.nextString()).isEqualTo("9223372036854775807");
@@ -476,7 +477,7 @@ public final class JsonValueReaderTest {
     for (int i = 0; i < MAX_DEPTH + 1; i++) {
       root = singletonList(root);
     }
-    JsonReader reader = new JsonValueReader(root);
+    JsonReader reader = jsonValueReader(root);
     for (int i = 0; i < MAX_DEPTH; i++) {
       reader.beginArray();
     }
@@ -496,7 +497,7 @@ public final class JsonValueReaderTest {
     for (int i = 0; i < MAX_DEPTH + 1; i++) {
       root = singletonMap("a", root);
     }
-    JsonReader reader = new JsonValueReader(root);
+    JsonReader reader = jsonValueReader(root);
     for (int i = 0; i < MAX_DEPTH; i++) {
       reader.beginObject();
       assertThat(reader.nextName()).isEqualTo("a");

--- a/moshi/src/test/java/com/squareup/moshi/JsonValueWriterTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/JsonValueWriterTest.java
@@ -16,6 +16,8 @@
 package com.squareup.moshi;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.squareup.moshi.MoshiTesting.jsonValueWriter;
+import static com.squareup.moshi.MoshiTesting.root;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.fail;
 
@@ -34,7 +36,7 @@ public final class JsonValueWriterTest {
   @SuppressWarnings("unchecked")
   @Test
   public void array() throws Exception {
-    JsonValueWriter writer = new JsonValueWriter();
+    JsonWriter writer = jsonValueWriter();
 
     writer.beginArray();
     writer.value("s");
@@ -43,12 +45,12 @@ public final class JsonValueWriterTest {
     writer.nullValue();
     writer.endArray();
 
-    assertThat((List<Object>) writer.root()).containsExactly("s", 1.5d, true, null);
+    assertThat((List<Object>) root(writer)).containsExactly("s", 1.5d, true, null);
   }
 
   @Test
   public void object() throws Exception {
-    JsonValueWriter writer = new JsonValueWriter();
+    JsonWriter writer = jsonValueWriter();
     writer.setSerializeNulls(true);
 
     writer.beginObject();
@@ -58,13 +60,13 @@ public final class JsonValueWriterTest {
     writer.name("d").nullValue();
     writer.endObject();
 
-    assertThat((Map<String, Object>) writer.root())
+    assertThat((Map<String, Object>) root(writer))
         .containsExactly("a", "s", "b", 1.5d, "c", true, "d", null);
   }
 
   @Test
   public void repeatedNameThrows() throws IOException {
-    JsonValueWriter writer = new JsonValueWriter();
+    JsonWriter writer = jsonValueWriter();
     writer.beginObject();
     writer.name("a").value(1L);
     try {
@@ -79,7 +81,7 @@ public final class JsonValueWriterTest {
 
   @Test
   public void valueLongEmitsLong() throws Exception {
-    JsonValueWriter writer = new JsonValueWriter();
+    JsonWriter writer = jsonValueWriter();
     writer.beginArray();
     writer.value(Long.MIN_VALUE);
     writer.value(-1L);
@@ -89,12 +91,12 @@ public final class JsonValueWriterTest {
     writer.endArray();
 
     List<Number> numbers = Arrays.<Number>asList(Long.MIN_VALUE, -1L, 0L, 1L, Long.MAX_VALUE);
-    assertThat((List<?>) writer.root()).isEqualTo(numbers);
+    assertThat((List<?>) root(writer)).isEqualTo(numbers);
   }
 
   @Test
   public void valueDoubleEmitsDouble() throws Exception {
-    JsonValueWriter writer = new JsonValueWriter();
+    JsonWriter writer = jsonValueWriter();
     writer.setLenient(true);
     writer.beginArray();
     writer.value(-2147483649.0d);
@@ -145,12 +147,12 @@ public final class JsonValueWriterTest {
             Double.MAX_VALUE,
             Double.POSITIVE_INFINITY,
             Double.NaN);
-    assertThat((List<?>) writer.root()).isEqualTo(numbers);
+    assertThat((List<?>) root(writer)).isEqualTo(numbers);
   }
 
   @Test
   public void primitiveIntegerTypesEmitLong() throws Exception {
-    JsonValueWriter writer = new JsonValueWriter();
+    JsonWriter writer = jsonValueWriter();
     writer.beginArray();
     writer.value(Byte.valueOf(Byte.MIN_VALUE));
     writer.value(Short.valueOf(Short.MIN_VALUE));
@@ -160,24 +162,24 @@ public final class JsonValueWriterTest {
 
     List<Number> numbers =
         Arrays.<Number>asList(-128L, -32768L, -2147483648L, -9223372036854775808L);
-    assertThat((List<?>) writer.root()).isEqualTo(numbers);
+    assertThat((List<?>) root(writer)).isEqualTo(numbers);
   }
 
   @Test
   public void primitiveFloatingPointTypesEmitDouble() throws Exception {
-    JsonValueWriter writer = new JsonValueWriter();
+    JsonWriter writer = jsonValueWriter();
     writer.beginArray();
     writer.value(Float.valueOf(0.5f));
     writer.value(Double.valueOf(0.5d));
     writer.endArray();
 
     List<Number> numbers = Arrays.<Number>asList(0.5d, 0.5d);
-    assertThat((List<?>) writer.root()).isEqualTo(numbers);
+    assertThat((List<?>) root(writer)).isEqualTo(numbers);
   }
 
   @Test
   public void otherNumberTypesEmitBigDecimal() throws Exception {
-    JsonValueWriter writer = new JsonValueWriter();
+    JsonWriter writer = jsonValueWriter();
     writer.beginArray();
     writer.value(new AtomicInteger(-2147483648));
     writer.value(new AtomicLong(-9223372036854775808L));
@@ -221,12 +223,12 @@ public final class JsonValueWriterTest {
             new BigDecimal("0.5"),
             new BigDecimal("100000e15"),
             new BigDecimal("0.0000100e-10"));
-    assertThat((List<?>) writer.root()).isEqualTo(numbers);
+    assertThat((List<?>) root(writer)).isEqualTo(numbers);
   }
 
   @Test
   public void valueCustomNumberTypeEmitsLongOrBigDecimal() throws Exception {
-    JsonValueWriter writer = new JsonValueWriter();
+    JsonWriter writer = jsonValueWriter();
     writer.beginArray();
     writer.value(stringNumber("-9223372036854775809"));
     writer.value(stringNumber("-9223372036854775808"));
@@ -240,12 +242,12 @@ public final class JsonValueWriterTest {
             new BigDecimal("-9223372036854775808"),
             new BigDecimal("0.5"),
             new BigDecimal("1.0"));
-    assertThat((List<?>) writer.root()).isEqualTo(numbers);
+    assertThat((List<?>) root(writer)).isEqualTo(numbers);
   }
 
   @Test
   public void valueFromSource() throws IOException {
-    JsonValueWriter writer = new JsonValueWriter();
+    JsonWriter writer = jsonValueWriter();
     writer.beginObject();
     writer.name("a");
     writer.value(new Buffer().writeUtf8("[\"value\"]"));
@@ -256,7 +258,7 @@ public final class JsonValueWriterTest {
     writer.name("d");
     writer.value(new Buffer().writeUtf8("null"));
     writer.endObject();
-    assertThat((Map<String, Object>) writer.root())
+    assertThat((Map<String, Object>) root(writer))
         .containsExactly("a", singletonList("value"), "b", 2.0d, "c", 3L, "d", null);
   }
 

--- a/moshi/src/test/java/com/squareup/moshi/MoshiTesting.kt
+++ b/moshi/src/test/java/com/squareup/moshi/MoshiTesting.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:JvmName("MoshiTesting")
+
+package com.squareup.moshi
+
+fun jsonValueReader(value: Any?): JsonReader {
+  return `-JsonValueReader`(value)
+}
+
+fun jsonValueWriter(): JsonWriter {
+  return `-JsonValueWriter`()
+}
+
+fun root(writer: JsonWriter): Any? {
+  return (writer as `-JsonValueWriter`).root()
+}

--- a/moshi/src/test/java/com/squareup/moshi/TypesTest.java
+++ b/moshi/src/test/java/com/squareup/moshi/TypesTest.java
@@ -21,6 +21,7 @@ import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.junit.Assert.fail;
 
+import com.squareup.moshi.internal.Util;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -67,7 +68,7 @@ public final class TypesTest {
   @Test
   public void nextAnnotationsDoesNotContainReturnsNull() throws Exception {
     Set<? extends Annotation> annotations =
-        Collections.singleton(Types.createJsonQualifierImplementation(AnotherTestQualifier.class));
+        Collections.singleton(Util.createJsonQualifierImplementation(AnotherTestQualifier.class));
     assertThat(Types.nextAnnotations(annotations, TestQualifier.class)).isNull();
     assertThat(Types.nextAnnotations(Collections.<Annotation>emptySet(), TestQualifier.class))
         .isNull();
@@ -76,10 +77,10 @@ public final class TypesTest {
   @Test
   public void nextAnnotationsReturnsDelegateAnnotations() throws Exception {
     Set<Annotation> annotations = new LinkedHashSet<>(2);
-    annotations.add(Types.createJsonQualifierImplementation(TestQualifier.class));
-    annotations.add(Types.createJsonQualifierImplementation(AnotherTestQualifier.class));
+    annotations.add(Util.createJsonQualifierImplementation(TestQualifier.class));
+    annotations.add(Util.createJsonQualifierImplementation(AnotherTestQualifier.class));
     Set<AnotherTestQualifier> expected =
-        Collections.singleton(Types.createJsonQualifierImplementation(AnotherTestQualifier.class));
+        Collections.singleton(Util.createJsonQualifierImplementation(AnotherTestQualifier.class));
     assertThat(Types.nextAnnotations(Collections.unmodifiableSet(annotations), TestQualifier.class))
         .isEqualTo(expected);
   }
@@ -228,14 +229,14 @@ public final class TypesTest {
 
   @Test
   public void arrayComponentType() throws Exception {
-    assertThat(Types.arrayComponentType(String[][].class)).isEqualTo(String[].class);
-    assertThat(Types.arrayComponentType(String[].class)).isEqualTo(String.class);
+    assertThat(Util.arrayComponentType(String[][].class)).isEqualTo(String[].class);
+    assertThat(Util.arrayComponentType(String[].class)).isEqualTo(String.class);
 
     Type arrayOfMapOfStringIntegerType =
         TypesTest.class.getDeclaredField("arrayOfMapOfStringInteger").getGenericType();
     Type mapOfStringIntegerType =
         TypesTest.class.getDeclaredField("mapOfStringInteger").getGenericType();
-    assertThat(Types.arrayComponentType(arrayOfMapOfStringIntegerType))
+    assertThat(Util.arrayComponentType(arrayOfMapOfStringIntegerType))
         .isEqualTo(mapOfStringIntegerType);
   }
 
@@ -253,7 +254,7 @@ public final class TypesTest {
   public void mapKeyAndValueTypes() throws Exception {
     Type mapOfStringIntegerType =
         TypesTest.class.getDeclaredField("mapOfStringInteger").getGenericType();
-    assertThat(Types.mapKeyAndValueTypes(mapOfStringIntegerType, Map.class))
+    assertThat(Util.mapKeyAndValueTypes(mapOfStringIntegerType, Map.class))
         .asList()
         .containsExactly(String.class, Integer.class)
         .inOrder();
@@ -261,7 +262,7 @@ public final class TypesTest {
 
   @Test
   public void propertiesTypes() throws Exception {
-    assertThat(Types.mapKeyAndValueTypes(Properties.class, Properties.class))
+    assertThat(Util.mapKeyAndValueTypes(Properties.class, Properties.class))
         .asList()
         .containsExactly(String.class, String.class)
         .inOrder();
@@ -269,7 +270,7 @@ public final class TypesTest {
 
   @Test
   public void fixedVariablesTypes() throws Exception {
-    assertThat(Types.mapKeyAndValueTypes(StringIntegerMap.class, StringIntegerMap.class))
+    assertThat(Util.mapKeyAndValueTypes(StringIntegerMap.class, StringIntegerMap.class))
         .asList()
         .containsExactly(String.class, Integer.class)
         .inOrder();
@@ -278,7 +279,7 @@ public final class TypesTest {
   @SuppressWarnings("GetClassOnAnnotation") // Explicitly checking for proxy implementation.
   @Test
   public void createJsonQualifierImplementation() throws Exception {
-    TestQualifier actual = Types.createJsonQualifierImplementation(TestQualifier.class);
+    TestQualifier actual = Util.createJsonQualifierImplementation(TestQualifier.class);
     TestQualifier expected =
         (TestQualifier) TypesTest.class.getDeclaredField("hasTestQualifier").getAnnotations()[0];
     assertThat(actual.annotationType()).isEqualTo(TestQualifier.class);


### PR DESCRIPTION
Hiding implementations of JsonReader and JsonWriter is particularly annoying as we have to either move it out of the com.squareup.moshi package (and not have a sealed class) or give it a mangled name.

I opted to give it a mangled name, though I'm not super happy with this least-worst choice.