### PR TITLE
Fix nested array default constructor lookup

### DIFF
--- a/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/kotlintypes.kt
+++ b/moshi-kotlin-codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/kotlintypes.kt
@@ -105,12 +105,12 @@ internal fun TypeName.asTypeBlock(): CodeBlock {
       return if (rawType == ARRAY) {
         val componentType = typeArguments[0]
         if (componentType is ParameterizedTypeName) {
-          // "generic" array just uses the component's raw type
-          // java.lang.reflect.Array.newInstance(<raw-type>, 0).javaClass
+          // Render parameterized array components recursively.
+          // java.lang.reflect.Array.newInstance(<component-type>, 0).javaClass
           CodeBlock.of(
             "%T.newInstance(%L, 0).javaClass",
             Array::class.java.asClassName(),
-            componentType.rawType.asTypeBlock(),
+            componentType.asTypeBlock(),
           )
         } else {
           CodeBlock.of("%T::class.java", copy(nullable = false))

--- a/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/DefaultConstructorTest.kt
+++ b/moshi-kotlin-tests/codegen-only/src/test/kotlin/com/squareup/moshi/kotlin/codegen/DefaultConstructorTest.kt
@@ -45,7 +45,16 @@ class DefaultConstructorTest {
     val instance = Moshi.Builder().build().adapter<TestClass>().fromJson(json)
     check(instance == expected) { "No match:\nActual  : $instance\nExpected: $expected" }
   }
+
+  @Test
+  fun nestedArrayWithDefault() {
+    val instance = Moshi.Builder().build().adapter<NestedArrayTestClass>().fromJson("{}")
+    check(instance.nestedArray.isEmpty())
+  }
 }
+
+@JsonClass(generateAdapter = true)
+data class NestedArrayTestClass(val nestedArray: Array<Array<String>> = emptyArray())
 
 @JsonClass(generateAdapter = true)
 data class TestClass(


### PR DESCRIPTION
Fixes #1862.

## Summary

- Preserve nested array component types when generating synthetic default-constructor lookups.
- Add a regression test for an `Array<Array<String>>` property with a default value.

## Validation

- Focused `DefaultConstructorTest.nestedArrayWithDefault` regression
- `./gradlew build`
- `./gradlew build check -PkotlinTestMode=REFLECT`
